### PR TITLE
Extending newman to have alternative response handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Options:
 -n, --number [number]     Define the number of iterations to run.
 -o, --outputFile [file]   Path to file where output should be written. [file]
 -C, --noColor             Disable colored output.
+-r, --responseHandler     Name of response handler to use [file]
 ```
 
 Use the `-n` option to set the number of iterations you want to run the collection for.

--- a/bin/newman
+++ b/bin/newman
@@ -29,7 +29,7 @@ function parseArguments() {
 	  .option('-n, --number [number]', 'Define the number of iterations to run.', null)
 	  .option('-C, --noColor', 'Disable colored output.', null)
 	  .option('-o, --outputFile [file]', 'Path to file where output should be written. [file]', null)
-	  .option('-r, --responseHandler [file]', 'Path to response handler to use. [file]', null);
+	  .option('-r, --responseHandler [file]', 'Name of response handler to use. [file]', null);
 
 	program.on('--help', function() {
 	  console.log('  Newman is a command-line collection runner for Postman.');
@@ -70,10 +70,10 @@ function main() {
 	}
 
 	newmanOptions.responseHandler = 'TestResponseHandler';
-	
-    if (program.responseHandler) {
-        newmanOptions.responseHandler = program.responseHandler;
-    }
+
+	if (program.responseHandler) {
+		newmanOptions.responseHandler = program.responseHandler;
+	}
 
 	if (program.number) {
 		newmanOptions.iterationCount = program.number;

--- a/bin/newman
+++ b/bin/newman
@@ -28,7 +28,8 @@ function parseArguments() {
 	  .option('-s, --stopOnError', "Stops the runner when a test case fails", null)
 	  .option('-n, --number [number]', 'Define the number of iterations to run.', null)
 	  .option('-C, --noColor', 'Disable colored output.', null)
-	  .option('-o, --outputFile [file]', 'Path to file where output should be written. [file]', null);
+	  .option('-o, --outputFile [file]', 'Path to file where output should be written. [file]', null)
+	  .option('-r, --responseHandler [file]', 'Path to response handler to use. [file]', null);
 
 	program.on('--help', function() {
 	  console.log('  Newman is a command-line collection runner for Postman.');
@@ -69,6 +70,10 @@ function main() {
 	}
 
 	newmanOptions.responseHandler = 'TestResponseHandler';
+	
+    if (program.responseHandler) {
+        newmanOptions.responseHandler = program.responseHandler;
+    }
 
 	if (program.number) {
 		newmanOptions.iterationCount = program.number;


### PR DESCRIPTION
I have extended the newman binary to receive the filename of a response handler. The response handler must be in the same folder as the supplied ones. this provides consumers the ability to override how tests are reported.