### PR TITLE
Support for file uploading

### DIFF
--- a/src/runners/RequestRunner.js
+++ b/src/runners/RequestRunner.js
@@ -6,7 +6,9 @@ var jsface            = require('jsface'),
     EventEmitter      = require('../utilities/EventEmitter'),
     VariableProcessor = require('../utilities/VariableProcessor.js'),
     prScripter        = require('../utilities/PreRequestScriptProcessor.js'),
-    _und              = require('underscore');
+    _und              = require('underscore'),
+    path              = require('path'),
+    fs                = require('fs');
 
 /**
  * @class RequestRunner
@@ -153,6 +155,9 @@ var RequestRunner = jsface.Class([Queue, EventEmitter], {
                 // TODO: @viig99 add other types like File Stream, Blob, Buffer.
                 if (dataObj.type === 'text') {
                     form.append(dataObj.key, dataObj.value);
+                } else if (dataObj.type === 'file') {
+                    var loc = path.resolve(dataObj.value);
+                    form.append(dataObj.key, fs.createReadStream(loc));
                 }
             });
         }

--- a/tests/integ_tests/tc4.json
+++ b/tests/integ_tests/tc4.json
@@ -1,0 +1,35 @@
+{
+	"id": "a143ec0d-38e3-c4d4-7030-091145b9bca0",
+	"name": "newman tests",
+	"requests": [
+		{
+			"id": "ec1016a7-2819-26ca-c3b8-3b887d1aad73",
+			"headers": "",
+			"url": "http://{{envFileUrl}}/post",
+			"pathVariables": {},
+			"preRequestScript": "",
+			"method": "POST",
+			"data": [
+				{
+					"key": "content",
+					"value": "tests/integ_tests/d2.json",
+					"type": "file"
+				}
+			],
+			"dataMode": "params",
+			"name": "POST file",
+			"description": "This Tes fails, dump.getpostman.com doesn't support file uploads",
+			"time": 1408827691742,
+			"version": 2,
+			"responses": [],
+			"tests": "var data = JSON.parse(responseBody);\nvar file = JSON.parse(data.files[\"file-data\"]);\n\ntests[\"File data uploaded\"] = file[0].dataVar === 'value1';\ntests[\"Success\"] = responseCode.code === 200;",
+			"collectionId": "a143ec0d-38e3-c4d4-7030-091145b9bca0",
+			"synced": false
+		}
+	],
+	"order": [
+		"ec1016a7-2819-26ca-c3b8-3b887d1aad73"
+	],
+	"timestamp": 1408827691742,
+	"synced": false
+}


### PR DESCRIPTION
Support for data objects of type `file`:

``` json
{
  "key": "content",
  "value": "tests/integ_tests/d2.json",
  "type": "file"
}
```
## Test

I also created a test file that can be run with: 
`$ bin/newman -c tests/integ_tests/tc4.json -e tests/integ_tests/e2.json`

How ever it currently fails as http://dump.getpostman.com does not support file uploads.  
## File Paths

Currently the `dataObj.value` must be relative to the `cwd` of where you run the newman command.  This isn't as desirable as it being relative to the location of the collection json file, however I was able to locate that resource location. It may make sense to add the location of the json file to the `Globals.requestJSON` object and pull it from there when resolving the path in the `RequestRunner`.
