### PR TITLE
Update package.json to have preferGlobal:true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Arjun Variar & Prakhar Srivastav & Abhijit Kane",
   "main": "Newman",
   "homepage": "https://github.com/a85/Newman",
@@ -27,6 +27,7 @@
   "bin": {
 	"newman": "./bin/newman"
   },
+  "preferGlobal": true,
   "dependencies": {
     "cli-color": "0.2.x",
     "json5": "*",


### PR DESCRIPTION
The docs indicate that this should be installed globally, so this sets the preferGlobal property to true and bumps the build number.
