### PR TITLE
add option to export results as junit xml

### DIFF
--- a/bin/newman
+++ b/bin/newman
@@ -35,6 +35,7 @@ function parseArguments() {
 	  .option('-C, --noColor', 'Disable colored output.', null)
 	  .option('-x, --exitCode', 'Continue running tests even after a failure, but exit with code=1. Incompatible with --stopOnError', null)
 	  .option('-o, --outputFile [file]', 'Path to file where output should be written. [file]', null)
+		.option('-t, --testReportFile [file]', 'Path to file where results should be written as JUnit XML. [file]', null)
 	  .option('-i, --import [file]', 'Import a Postman backup file, and save collections, environments, and globals. [file] (Incompatible with any other option)', null)
 	  .option('-p, --pretty', 'Enable pretty-print while saving imported collections, environments, and globals');
 
@@ -114,6 +115,10 @@ function main() {
 
 	if (program.outputFile) {
 		newmanOptions.outputFile = program.outputFile;
+	}
+
+	if (program.testReportFile) {
+		newmanOptions.testReportFile = program.testReportFile;
 	}
 
     if (program.data) {

--- a/src/utilities/Globals.js
+++ b/src/utilities/Globals.js
@@ -18,6 +18,7 @@ var Globals = jsface.Class({
 		this.envJson = options.envJson || {};
 		this.iterationNumber = 1;
 		this.outputFile = options.outputFile || '';
+		this.testReportFile = options.testReportFile || '';
 		this.globalJson = options.globalJSON || [];
         this.dataJson = [];
 		this.stopOnError = options.stopOnError;

--- a/src/utilities/ResponseExporter.js
+++ b/src/utilities/ResponseExporter.js
@@ -90,6 +90,40 @@ var ResponseExporter = jsface.Class({
 			fs.writeFileSync(filepath , JSON.stringify(exportVariable, null, 4));
 			log.note("\n\n Output Log: " + filepath + "\n");
 		}
+
+		if (Globals.testReportFile) {
+			var outputpath = path.resolve(Globals.testReportFile);
+			fs.writeFileSync(outputpath, this._createJunitXML());
+			log.note("\n\nJunit XML file written to: " + outputpath + "\n");
+		}
+	},
+
+	_createJunitXML: function() {
+			var xml = '<?xml version="1.0" encoding="UTF-8"?>';
+			xml += "<testsuites>";
+
+			_und.each(this._results, function(suite) {
+				var testRequest = _und.find(Globals.requestJSON.requests, function(request) {
+					return suite.id === request.id;
+				});
+
+				var timeStamp = new Date(testRequest.time);
+				var time = testRequest.time;
+				var tests = Object.keys(suite.tests).length;
+
+				xml += "<testsuite name='" + _und.escape(suite.name) + "' id='" +
+					_und.escape(suite.id) + "' timestamp='" + timeStamp.toISOString() +
+					"' time='" + time + "' tests='" + tests + "' >";
+
+				_und.each(suite.testPassFailCounts, function(testcase, testcaseName) {
+					xml += "<testcase name='" + _und.escape(testcaseName) + "' failures='" + testcase.fail + "' />";
+				}, this);
+
+				xml += "</testsuite>";
+			}, this);
+
+			xml += "</testsuites>";
+			return xml;
 	},
 
 	_createExportVariable: function() {


### PR DESCRIPTION
This allows newman to export results as a junit-xml file which is compatible with Jenkins.

This fixes issue #92 
