### PR TITLE
Log Request and Response Bodies

### DIFF
--- a/bin/newman
+++ b/bin/newman
@@ -44,6 +44,7 @@ function parseArguments() {
 		.option('-N, --encoding [encoding-type]', 'Specify an encoding for the response. Supported values are ascii,utf8,utf16le,ucs2,base64,binary,hex', null)
 		.option('-x, --exitCode', 'Continue running tests even after a failure, but exit with code=1. Incompatible with --stopOnError', null)
 		.option('-o, --outputFile [file]', 'Path to file where output should be written [file]', null)
+		.option('-O, --outputFileVerbose [file]', 'Path to file where full request and responses should be logged [file]', null)
 		.option('-t, --testReportFile [file]', 'Path to file where results should be written as JUnit XML [file]', null)
 		.option('-i, --import [file]', 'Import a Postman backup file, and save collections, environments, and globals [file] (Incompatible with any option except pretty)', null)
 		.option('-p, --pretty', 'Enable pretty-print while saving imported collections, environments, and globals', null)
@@ -138,6 +139,10 @@ function main() {
 
 	if (program.outputFile) {
 		newmanOptions.outputFile = program.outputFile;
+	}
+
+	if (program.outputFileVerbose) {
+		newmanOptions.outputFileVerbose = program.outputFileVerbose;
 	}
 
 	if (program.testReportFile) {

--- a/src/models/RequestModel.js
+++ b/src/models/RequestModel.js
@@ -27,6 +27,7 @@ var RequestModel = jsface.Class(ParentModel, {
 	toString: function() {
 		return "Request: [" + this.method + "]: " + this.url;
 	},
+
 	/**
 	 * Function that returns a boolean to indicate if the url has template
 	 * @memberOf RequestModel

--- a/src/models/RequestModel.js
+++ b/src/models/RequestModel.js
@@ -27,7 +27,6 @@ var RequestModel = jsface.Class(ParentModel, {
 	toString: function() {
 		return "Request: [" + this.method + "]: " + this.url;
 	},
-
 	/**
 	 * Function that returns a boolean to indicate if the url has template
 	 * @memberOf RequestModel

--- a/src/responseHandlers/AbstractResponseHandler.js
+++ b/src/responseHandlers/AbstractResponseHandler.js
@@ -1,5 +1,8 @@
 var jsface           = require('jsface'),
 	log              = require('../utilities/Logger'),
+	Globals           = require('../utilities/Globals'),
+	path              = require('path'),
+	fs                = require('fs'),
 	ErrorHandler     = require('../utilities/ErrorHandler'),
 	EventEmitter     = require('../utilities/EventEmitter'),
 	ResponseExporter = require('../utilities/ResponseExporter');
@@ -33,6 +36,27 @@ var AbstractResponseHandler = jsface.Class([EventEmitter], {
 	},
 
 	_printResponse: function(error, response, body, request) {
+        if (Globals.outputFileVerbose) {
+            var filepath = path.resolve(Globals.outputFileVerbose);
+
+            var requestString = "-------------------------------------------------------------------------------------------\n" +
+                    response.statusCode + " " +
+                    response.stats.timeTaken + "ms" + " " +
+                    request.name + " " +  "[" + request.method + "] " +
+                    request.transformed.url +
+                    "\n------------------------------------------------------------" +
+                    "\nRequest headers:\n" +
+                    JSON.stringify(response.req._headers, undefined, 1) +
+                    "\nRequest body:\n" +
+                    request.body +
+                    "\n------------------------------------------------------------" +
+                    "\nResponse headers:" +
+                    JSON.stringify(response.headers, undefined, 1) +
+                    "\nResponse body:\n" + response.body + "\n";
+
+            fs.appendFileSync(filepath , requestString);
+        }
+
 		if (response.statusCode >= 200 && response.statusCode < 300) {
 			log.success(response.statusCode);
 		} else {
@@ -41,7 +65,8 @@ var AbstractResponseHandler = jsface.Class([EventEmitter], {
 		log
 		.notice(" " + response.stats.timeTaken + "ms")
 		.normal(" " + request.name + " ")
-		.light(request.transformed.url + "\n");
+		.notice("[" + request.method + "] ")
+		.light( request.transformed.url + "\n");
 	},
 
 	// clears up the set event

--- a/src/responseHandlers/AbstractResponseHandler.js
+++ b/src/responseHandlers/AbstractResponseHandler.js
@@ -50,7 +50,7 @@ var AbstractResponseHandler = jsface.Class([EventEmitter], {
                     "\nRequest body:\n" +
                     request.body +
                     "\n------------------------------------------------------------" +
-                    "\nResponse headers:" +
+                    "\nResponse headers:\n" +
                     JSON.stringify(response.headers, undefined, 1) +
                     "\nResponse body:\n" + response.body + "\n";
 

--- a/src/responseHandlers/AbstractResponseHandler.js
+++ b/src/responseHandlers/AbstractResponseHandler.js
@@ -48,7 +48,7 @@ var AbstractResponseHandler = jsface.Class([EventEmitter], {
                     "\nRequest headers:\n" +
                     JSON.stringify(response.req._headers, undefined, 1) +
                     "\nRequest body:\n" +
-                    request.body +
+                    request.transformed.data +
                     "\n------------------------------------------------------------" +
                     "\nResponse headers:\n" +
                     JSON.stringify(response.headers, undefined, 1) +

--- a/src/utilities/Globals.js
+++ b/src/utilities/Globals.js
@@ -21,6 +21,7 @@ var Globals = jsface.Class({
 		this.envJson = options.envJson || {};
 		this.iterationNumber = 1;
 		this.outputFile = options.outputFile || '';
+		this.outputFileVerbose = options.outputFileVerbose || '';
 		this.testReportFile = options.testReportFile || '';
 		this.globalJson = options.globalJSON || [];
         this.dataJson = [];


### PR DESCRIPTION
This adds an optional feature to log (via appending) the full request and response bodies in to a text file.  
It also adds the method to the normal console logging.
Here's some sample output from the text file:

```
-------------------------------------------------------------------------------------------
200 3272ms Get status of server. [GET] http://localhost:8080/status
------------------------------------------------------------
Request headers:
{
 "host": "localhost:8080"
}
Request body:
undefined
------------------------------------------------------------
Response headers:
{
 "date": "Tue, 23 Jun 2015 19:11:14 GMT",
 "x-request-id": "12345",
 "x-request-size": "-1",
 "x--server-id": "10.1.1.14",
 "content-type": "application/json",
 "connection": "close"
}
Response body:
{"Status":"OK" }

```


