### PR TITLE
More Node v4 stuff

### DIFF
--- a/src/Newman.js
+++ b/src/Newman.js
@@ -25,6 +25,8 @@ var Newman = jsface.Class([Options, EventEmitter], {
      * @param {object} Newman options
      */
     execute: function(requestJSON, options, callback) {
+        var checking = false,
+            onChecked = null;
         // var collectionParseError = Validator.validateJSON('c',requestJSON);
         // if(!collectionParseError.status) {
         //     Errors.terminateWithError("Not a valid POSTMAN collection");
@@ -44,13 +46,18 @@ var Newman = jsface.Class([Options, EventEmitter], {
         //     }
         // }
         if(Math.random()<0.3) {
+            checking = true;
             exec("npm show newman version", {timeout:1500}, function(error, stdout, stderr) {
+                checking = false;
                 stdout = stdout.trim();
                 if(stdout!==Globals.newmanVersion && stdout.length>0) {
                     Globals.updateMessage = "\nINFO: Newman v" + stdout+" is available. Use `npm update -g newman` to update.\n";
                 }
                 else {
                     Globals.updateMessage = "";
+                }
+                if(typeof onChecked==='function') {
+                    onChecked();
                 }
             });
         }
@@ -70,15 +77,23 @@ var Newman = jsface.Class([Options, EventEmitter], {
                     log.note("\n\nEnvironment File Exported To: " + options.exportEnvironmentFile + "\n");
                 }
 
-                //if -x is set, return the exit code
-                if(options.exitCode) {
-                    callback(exitCode);
+                function wrapUp() {
+                    //if -x is set, return the exit code
+                    if(options.exitCode) {
+                        callback(exitCode);
+                    }
+                    else if(options.stopOnError && exitCode===1) {
+                        callback(1);
+                    }
+                    else {
+                        callback(0);
+                    }
                 }
-                else if(options.stopOnError && exitCode===1) {
-                    callback(1);
-                }
-                else {
-                    callback(0);
+
+                if(!checking) {
+                    wrapUp();
+                } else {
+                    onChecked = wrapUp;
                 }
             });
         }

--- a/src/responseHandlers/TestResponseHandler.js
+++ b/src/responseHandlers/TestResponseHandler.js
@@ -90,7 +90,7 @@ var TestResponseHandler = jsface.Class(AbstractResponseHandler, {
         sweet += "for(p in sugar.array)  {if(p==='create'){Array.create=sugar.array.create} else{Array.prototype[p]= sugar.array[p];}}";
         sweet += "for(p in sugar.string) String.prototype[p]  = sugar.string[p];";
         sweet += "for(p in sugar.date)  {if(p==='create'){Date.create=sugar.date.create} else{Date.prototype[p]= sugar.date[p];}}";
-        sweet += "for(p in sugar.funcs)  Function.prototype[p]= sugar.funcs[p];";
+        sweet += "for(p in sugar.funcs) Object.defineProperty(Function.prototype, p, Object.getOwnPropertyDescriptor(sugar.funcs, p));";
 
         var setEnvHack = "postman.setEnvironmentVariable = function(key,val) {postman.setEnvironmentVariableReal(key,val);environment[key]=val;};";
         setEnvHack += "postman.setGlobalVariable = function(key,val) {postman.setGlobalVariableReal(key,val);globals[key]=val;};";
@@ -170,7 +170,9 @@ var TestResponseHandler = jsface.Class(AbstractResponseHandler, {
         Object.getOwnPropertyNames(String.prototype).each(function(p) { sugar.string[p] = String.prototype[p];});
         Object.getOwnPropertyNames(Date.prototype).each(function(p) {sugar.date[p] = Date.prototype[p];});
         sugar.date["create"] = Date.create;
-        //Object.getOwnPropertyNames(Function.prototype).each(function(p) { sugar.funcs[p] = Function.prototype[p];});
+        Object.getOwnPropertyNames(Function.prototype).each(function(p) {
+            Object.defineProperty(sugar.funcs, p, Object.getOwnPropertyDescriptor(Function.prototype, p));
+        });
         return {
             sugar: sugar,
             tests: {},

--- a/src/utilities/PreRequestScriptProcessor.js
+++ b/src/utilities/PreRequestScriptProcessor.js
@@ -62,7 +62,7 @@ var PreRequestScriptProcessor = jsface.Class({
         sweet += "for(p in sugar.array)  {if(p==='create'){Array.create=sugar.array.create} else{Array.prototype[p]= sugar.array[p];}}";
         sweet += "for(p in sugar.string) String.prototype[p]  = sugar.string[p];";
         sweet += "for(p in sugar.date)  {if(p==='create'){Date.create=sugar.date.create} else{Date.prototype[p]= sugar.date[p];}}";
-        sweet += "for(p in sugar.funcs)  Function.prototype[p]= sugar.funcs[p];";
+        sweet += "for(p in sugar.funcs) Object.defineProperty(Function.prototype, p, Object.getOwnPropertyDescriptor(sugar.funcs, p));";
 
         var setEnvHack = "postman.setEnvironmentVariable = function(key,val) {postman.setEnvironmentVariableReal(key,val);environment[key]=val;};";
         setEnvHack += "postman.setGlobalVariable = function(key,val) {postman.setGlobalVariableReal(key,val);globals[key]=val;};";
@@ -120,7 +120,9 @@ var PreRequestScriptProcessor = jsface.Class({
             sugar.date[p] = Date.prototype[p];
         });
         sugar.date["create"] = Date.create;
-        //Object.getOwnPropertyNames(Function.prototype).each(function(p) { sugar.funcs[p] = Function.prototype[p];});
+        Object.getOwnPropertyNames(Function.prototype).each(function(p) {
+            Object.defineProperty(sugar.funcs, p, Object.getOwnPropertyDescriptor(Function.prototype, p));
+        });
         return {
             sugar: sugar,
             request: {


### PR DESCRIPTION
Two changes:

### Don't access `arguments` or `caller` properties on `Function.prototype`

ES6 has deprecated these properties, and replaced them with accessors that just throw a `TypeError` if you try to touch them.

My workaround is to simply copy entire file descriptors instead of using direct assignment. This way, you maintain enumerability, setters/getters, etc.

### Fix EPIPE error during version check

Seems like `iterationRunnerOver` was getting called before the `exec` callback, so I just added some flags to make sure we wait for that to finish before invoking the `Newman.execute` callback.