### PR TITLE
Feature - Export and Import tests and rawModeData to separate files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Basic setup:
 -e, --environment [file]    Specify a Postman environment as a JSON [file]
 -d, --data [file]           Specify a data file to use either json or csv
 -g, --global [file]         Specify a Postman globals file as JSON [file]
+-J, --exportJSON            Specify an output path to dump tests and rawModeData to [path] To be used with -c
+-K, --importJSON            Specify an input path to import tests and rawModeData from [path] To be used with -c
 -n, --number [number]       Define the number of iterations to run
 -i, --import [file]         Import a Postman backup file, and save collections, environments, and globals. [file]
 -p, --pretty                (Use with -i) Enable pretty-print while saving imported collections, environments, and globals
@@ -149,6 +151,15 @@ Newman can also be used to import a Postman backup file. The collections, enviro
 newman -i /path/to/Backup.json -p
 ```
 
+Newman can also be used to export the JSON data defined in tets and rawModeData to separate source files for ease of local editing. 
+```bash
+newman -J /path/to/outputfolder -c /path/and/mycollection.json
+```
+
+Newman can also be used to import the JSON data defined in tets and rawModeData from separate source files.  Input folder should be same folder as the output folder (used with the -J export JSON option)
+```bash
+newman -K /path/to/inputfolder -c /path/and/mycollection.json
+```
 
 
 **NOTE** Newman allows you to use all [libraries](http://www.getpostman.com/docs/jetpacks_writing_tests) that Postman supports for running tests. For [x2js](https://code.google.com/p/x2js/) however, only  function `xmlToJson` is supported.

--- a/bin/newman
+++ b/bin/newman
@@ -34,7 +34,7 @@ function parseArguments() {
 		.option('-g, --global [file]', 'Specify a Postman globals file [file]', null)
 		.option('-G, --exportGlobals [file]', 'Specify an output file to dump Globals before exiting [file]', null)
 		.option('-J, --exportJSON data to path [path]', 'Specify an output path to dump tests and rawModeData to [path]', null)
-        .option('-K, --importJSON data from path [path]', 'Specify an input path to import tests and rawModeData from [path]', null)        
+		.option('-K, --importJSON data from path [path]', 'Specify an input path to import tests and rawModeData from [path]', null)        
 		.option('-y, --delay [number]', "Specify a delay (in ms) between requests", null)
 		.option('-r, --requestTimeout [number]', "Specify a request timeout (in ms) for requests", null)
 		.option('-R, --avoidRedirects', "Prevents Newman from automatically following redirects", null)
@@ -149,9 +149,9 @@ function main() {
 		newmanOptions.testReportFile = program.testReportFile;
 	}
 
-    if (program.data) {
-        newmanOptions.dataFile = program.data;
-    }
+	if (program.data) {
+		newmanOptions.dataFile = program.data;
+	}
 
 	if (program.delay) {
 		if(isNaN(program.delay) || parseFloat(program.delay)%1 !== 0) {
@@ -160,12 +160,12 @@ function main() {
 		newmanOptions.delay = parseInt(program.delay);
 	}
 
-    if (program.requestTimeout) {
-        if (isNaN(program.requestTimeout) || parseFloat(program.requestTimeout)%1 !== 0) {
-            Errors.terminateWithError("The request Timeout must be an integer");
-        }
+	if (program.requestTimeout) {
+		if (isNaN(program.requestTimeout) || parseFloat(program.requestTimeout)%1 !== 0) {
+			Errors.terminateWithError("The request Timeout must be an integer");
+		}
 		newmanOptions.requestTimeout = parseInt(program.requestTimeout);
-    }
+	}
 
 	if (program.global) {
 		try {
@@ -184,7 +184,7 @@ function main() {
 		newmanOptions.exportEnvironmentFile = program.exportEnvironment;
 	}
 
-    if (program.exportJSON) {
+	if (program.exportJSON) {
 		newmanOptions.exportJSON = program.exportJSON;
 	}
 
@@ -211,8 +211,8 @@ function main() {
 		try {
 			// read collection from the filesystem
 			collectionJson = JSON5.parse(fs.readFileSync(program.collection, 'utf8'));
-            //save the original file name if provided
-            newmanOptions.collectionFileName = program.collection;
+			//save the original file name if provided
+			newmanOptions.collectionFileName = program.collection;
 		}
 		catch (err) {
 			Errors.terminateWithError("The collection file " + program.collection + " could not be parsed.");

--- a/bin/newman
+++ b/bin/newman
@@ -33,6 +33,8 @@ function parseArguments() {
 		.option('-d, --data [file]', 'Specify a data file to use either json or csv', null)
 		.option('-g, --global [file]', 'Specify a Postman globals file [file]', null)
 		.option('-G, --exportGlobals [file]', 'Specify an output file to dump Globals before exiting [file]', null)
+		.option('-J, --exportJSON data to path [path]', 'Specify an output path to dump tests and rawModeData to [path]', null)
+        .option('-K, --importJSON data from path [path]', 'Specify an input path to import tests and rawModeData from [path]', null)        
 		.option('-y, --delay [number]', "Specify a delay (in ms) between requests", null)
 		.option('-r, --requestTimeout [number]', "Specify a request timeout (in ms) for requests", null)
 		.option('-R, --avoidRedirects', "Prevents Newman from automatically following redirects", null)
@@ -182,6 +184,14 @@ function main() {
 		newmanOptions.exportEnvironmentFile = program.exportEnvironment;
 	}
 
+    if (program.exportJSON) {
+		newmanOptions.exportJSON = program.exportJSON;
+	}
+
+	if (program.importJSON) {
+		newmanOptions.importJSON = program.importJSON;
+	}
+
 	if (program.tls) {
 		newmanOptions.secureProtocol = 'TLSv1_method';
 	}
@@ -201,6 +211,8 @@ function main() {
 		try {
 			// read collection from the filesystem
 			collectionJson = JSON5.parse(fs.readFileSync(program.collection, 'utf8'));
+            //save the original file name if provided
+            newmanOptions.collectionFileName = program.collection;
 		}
 		catch (err) {
 			Errors.terminateWithError("The collection file " + program.collection + " could not be parsed.");

--- a/src/Newman.js
+++ b/src/Newman.js
@@ -86,7 +86,168 @@ var Newman = jsface.Class([Options, EventEmitter], {
         // setup the iteration runner with requestJSON passed and options
         this.iterationRunner = new IterationRunner(requestJSON, this.getOptions());
 
-        this.iterationRunner.execute();
+ if (options.exportJSON) {
+
+            var changes = false;
+
+            var collectionName = requestJSON.name.replace(/ /g, '');
+            requestJSON.name = collectionName;
+
+            _und.each(requestJSON.folders, function (folder) {
+
+                var folderItemName = folder.name.replace(/ /g, '')
+                if (folderItemName != folder.name) {
+                    changes = true;
+                    folder.name = folderItemName;
+                }
+            });
+
+            if (changes) {
+                console.log('updated fodler names');
+                this.iterationRunner = new IterationRunner(requestJSON, this.getOptions());
+            }
+
+            //Get a ordered list of all the requests
+            var orderedCollection = this.iterationRunner._getOrderedCollection(requestJSON);
+
+
+            _und.each(orderedCollection, function (postmanRequest) {
+                var fileName
+
+                //Remove spaces from Request Name
+                var requestItem = _und.find(requestJSON.requests, function (request) {
+                    return request.id === postmanRequest.id;
+                });
+
+                requestItem.name = postmanRequest.name.replace(/ /g, '')
+                if (requestItem.name != postmanRequest.name) {
+                    changes = true;
+                }
+
+                //Add folder name to path if it exists
+                if (postmanRequest.folderName) {
+                    console.log('Request:%s.%s with ID:%s', postmanRequest.folderName, requestItem.name, postmanRequest.id);
+                    fileName = postmanRequest.folderName + '.' + requestItem.name;
+
+                } else {
+                    console.log('no folder name');
+                    console.log('Request:%s with ID:%s', postmanRequest.name, postmanRequest.id);
+                    fileName = requestItem.name;
+                }
+
+                //build a base file name for data output
+                baseFileName = path.join(options.exportJSON, fileName);
+
+                if (requestItem.tests) {
+                    //build a file name for the test data output
+                    var testsDatafileName = baseFileName + '.tests.json';
+
+                    var testsJSON = requestItem.tests
+                        //write out the info
+                    fs.writeFileSync(testsDatafileName, testsJSON);
+                    console.log('dump tests to file: %s', testsDatafileName);
+                    requestItem.tests = 'file:' + testsDatafileName;
+                }
+
+
+                if (requestItem.rawModeData) {
+                    var rawModeDatafileName = baseFileName + '.rawModeData.json';
+                    var rawModeData = requestItem.rawModeData
+                        //write out the info
+                    fs.writeFileSync(rawModeDatafileName, rawModeData);
+                    console.log('dump rawModeData to file: %s', rawModeDatafileName);
+                    requestItem.rawModeData = 'file:' + rawModeDatafileName;
+                }
+
+
+            }, this);
+
+            if (changes) {
+                var collectionFileName = path.join(options.exportJSON, collectionName + '.colleciton.json');
+                fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
+                console.log('done something');
+            }
+
+        } 
+        else if (options.importJSON) {
+
+            /*take the path supplied and make a single output file which is a postman collection
+            
+               find the file name of colelction it is in the new options.collectionFileName
+            
+               replace the file: refereces with the actual contents of the file for
+                    tests
+                    rawModeData
+                    
+                write a new output file 
+            */
+            
+            console.log('options.collectionFileName:', options.collectionFileName);
+
+            var changes = false;
+ 
+            //Get a ordered list of all the requests
+            var orderedCollection = this.iterationRunner._getOrderedCollection(requestJSON);
+
+            _und.each(orderedCollection, function (postmanRequest) {
+
+                var fileName
+
+                //get the single request item
+                var requestItem = _und.find(requestJSON.requests, function (request) {
+                    return request.id === postmanRequest.id;
+                });
+
+                console.log('processing request :%s, tests:%s', requestItem.name,requestItem.tests);
+                
+                    
+
+                //take a file reference and convert to postman
+                if (requestItem.tests && requestItem.tests.startsWith('file:')) {
+                    var fileName = requestItem.tests.substring(5);
+                    console.log('Reading in tests from file:%s', fileName);
+
+                    try {
+                        requestItem.tests = fs.readFileSync(fileName, 'utf8');
+                        changes =true;
+                    } catch (e) {
+                        if (e.code === 'ENOENT') {
+                            console.log('File not found!');
+                        } else {
+                            throw e;
+                        }
+                    }
+                } 
+
+                //take a file reference and convert to postman
+                if (requestItem.rawModeData && requestItem.rawModeData.startsWith('file:')) {
+                    var fileName = requestItem.rawModeData.substring(5);
+                    console.log('Reading in rawModeData from file:%s', fileName);
+
+                    try {
+                        requestItem.rawModeData = fs.readFileSync(fileName, 'utf8');
+                        changes =true;
+                    } catch (e) {
+                        if (e.code === 'ENOENT') {
+                            console.log('File not found!');
+                        } else {
+                            throw e;
+                        }
+                    }
+                } 
+
+            }, this);
+
+            if (changes) {
+                var collectionFileName = options.collectionFileName + '.out';
+                fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
+                console.log('done something');
+            }
+
+        } else {
+            this.iterationRunner.execute();
+        }
+        
     }
 });
 

--- a/src/Newman.js
+++ b/src/Newman.js
@@ -27,6 +27,8 @@ var Newman = jsface.Class([Options, EventEmitter], {
      */
     execute: function(requestJSON, options, callback) {
         
+        log.note("this is the new version");
+        
         // var collectionParseError = Validator.validateJSON('c',requestJSON);
         // if(!collectionParseError.status) {
         //     Errors.terminateWithError("Not a valid POSTMAN collection");
@@ -90,7 +92,7 @@ var Newman = jsface.Class([Options, EventEmitter], {
 
         if (options.exportJSON) {
             importer.exportJSON(requestJSON, options);
-        }
+        } 
         else if (options.importJSON) {
             importer.importJSON(requestJSON, options);
         }else {

--- a/src/Newman.js
+++ b/src/Newman.js
@@ -1,14 +1,14 @@
 var jsface          = require("jsface"),
-    //Validator       = require("postman_validator"),
+	//Validator       = require("postman_validator"),
 	//Errors			= require('./utilities/ErrorHandler'),
-    IterationRunner = require("./runners/IterationRunner"),
-    EventEmitter     = require('./utilities/EventEmitter'),
-    Globals          = require('./utilities/Globals'),
-    Options          = require('./utilities/Options'),
-    log              = require('./utilities/Logger'),
-    importer         = require('./utilities/Importer'),
-    fs               = require('fs'),
-    exec             = require('child_process').exec;
+	IterationRunner = require("./runners/IterationRunner"),
+	EventEmitter     = require('./utilities/EventEmitter'),
+	Globals          = require('./utilities/Globals'),
+	Options          = require('./utilities/Options'),
+	log              = require('./utilities/Logger'),
+	importer         = require('./utilities/Importer'),
+	fs               = require('fs'),
+	exec             = require('child_process').exec;
 
 /**
  * @name Newman
@@ -16,90 +16,87 @@ var jsface          = require("jsface"),
  * @namespace
  */
 var Newman = jsface.Class([Options, EventEmitter], {
-    $singleton: true,
+	$singleton: true,
 
-    /**
-     * Executes XHR Requests for the Postman request, and logs the responses
-     * & runs tests on them.
-     * @param  {JSON} requestJSON Takes the Postman Collection JSON from a file or url.
-     * @memberOf Newman
-     * @param {object} Newman options
-     */
-    execute: function(requestJSON, options, callback) {
-        
-        log.note("this is the new version");
-        
-        // var collectionParseError = Validator.validateJSON('c',requestJSON);
-        // if(!collectionParseError.status) {
-        //     Errors.terminateWithError("Not a valid POSTMAN collection");
-        // }
+	/**
+	 * Executes XHR Requests for the Postman request, and logs the responses
+	 * & runs tests on them.
+	 * @param  {JSON} requestJSON Takes the Postman Collection JSON from a file or url.
+	 * @memberOf Newman
+	 * @param {object} Newman options
+	 */
+	execute: function(requestJSON, options, callback) {
+		
+		// var collectionParseError = Validator.validateJSON('c',requestJSON);
+		// if(!collectionParseError.status) {
+		//     Errors.terminateWithError("Not a valid POSTMAN collection");
+		// }
 
-        // if(options.envJson) {
-        //     var envParseError = Validator.validateJSON('e',options.envJson);
-        //     if(!envParseError.status) {
-        //         Errors.terminateWithError("Not a valid POSTMAN environment");
-        //     }
-        // }
+		// if(options.envJson) {
+		//     var envParseError = Validator.validateJSON('e',options.envJson);
+		//     if(!envParseError.status) {
+		//         Errors.terminateWithError("Not a valid POSTMAN environment");
+		//     }
+		// }
 
-        // if(options.globalJSON) {
-        //     var globalParseError = Validator.validateJSON('g',options.globalJSON);
-        //     if(!globalParseError.status) {
-        //         Errors.terminateWithError("Not a valid POSTMAN globals file");
-        //     }
-        // }
-        if(Math.random()<0.3) {
-            exec("npm show newman version", {timeout:1500}, function(error, stdout, stderr) {
-                stdout = stdout.trim();
-                if(stdout!==Globals.newmanVersion && stdout.length>0) {
-                    Globals.updateMessage = "\nINFO: Newman v" + stdout+" is available. Use `npm update -g newman` to update.\n";
-                }
-                else {
-                    Globals.updateMessage = "";
-                }
-            });
-        }
+		// if(options.globalJSON) {
+		//     var globalParseError = Validator.validateJSON('g',options.globalJSON);
+		//     if(!globalParseError.status) {
+		//         Errors.terminateWithError("Not a valid POSTMAN globals file");
+		//     }
+		// }
+		if(Math.random()<0.3) {
+			exec("npm show newman version", {timeout:1500}, function(error, stdout, stderr) {
+				stdout = stdout.trim();
+				if(stdout!==Globals.newmanVersion && stdout.length>0) {
+					Globals.updateMessage = "\nINFO: Newman v" + stdout+" is available. Use `npm update -g newman` to update.\n";
+				}
+				else {
+					Globals.updateMessage = "";
+				}
+			});
+		}
 
-        Globals.addEnvironmentGlobals(requestJSON, options);
-        this.setOptions(options);
+		Globals.addEnvironmentGlobals(requestJSON, options);
+		this.setOptions(options);
 
-        if (typeof callback === "function") {
-            this.addEventListener('iterationRunnerOver', function(exitCode) {
-                if (options.exportGlobalsFile) {
-                    fs.writeFileSync(options.exportGlobalsFile, JSON.stringify(Globals.globalJson.values,null,1));
-                    log.note("\n\nGlobals File Exported To: " + options.exportGlobalsFile + "\n");
-                }
+		if (typeof callback === "function") {
+			this.addEventListener('iterationRunnerOver', function(exitCode) {
+				if (options.exportGlobalsFile) {
+					fs.writeFileSync(options.exportGlobalsFile, JSON.stringify(Globals.globalJson.values,null,1));
+					log.note("\n\nGlobals File Exported To: " + options.exportGlobalsFile + "\n");
+				}
 
-                if (options.exportEnvironmentFile) {
-                    fs.writeFileSync(options.exportEnvironmentFile, JSON.stringify(Globals.envJson,null,1));
-                    log.note("\n\nEnvironment File Exported To: " + options.exportEnvironmentFile + "\n");
-                }
+				if (options.exportEnvironmentFile) {
+					fs.writeFileSync(options.exportEnvironmentFile, JSON.stringify(Globals.envJson,null,1));
+					log.note("\n\nEnvironment File Exported To: " + options.exportEnvironmentFile + "\n");
+				}
 
-                //if -x is set, return the exit code
-                if(options.exitCode) {
-                    callback(exitCode);
-                }
-                else if(options.stopOnError && exitCode===1) {
-                    callback(1);
-                }
-                else {
-                    callback(0);
-                }
-            });
-        }
+				//if -x is set, return the exit code
+				if(options.exitCode) {
+					callback(exitCode);
+				}
+				else if(options.stopOnError && exitCode===1) {
+					callback(1);
+				}
+				else {
+					callback(0);
+				}
+			});
+		}
 
-        // setup the iteration runner with requestJSON passed and options
-        this.iterationRunner = new IterationRunner(requestJSON, this.getOptions());
+		// setup the iteration runner with requestJSON passed and options
+		this.iterationRunner = new IterationRunner(requestJSON, this.getOptions());
 
-        if (options.exportJSON) {
-            importer.exportJSON(requestJSON, options);
-        } 
-        else if (options.importJSON) {
-            importer.importJSON(requestJSON, options);
-        }else {
-            this.iterationRunner.execute();
-        }
-        
-    }
+		if (options.exportJSON) {
+			importer.exportJSON(requestJSON, options);
+		}
+		else if (options.importJSON) {
+			importer.importJSON(requestJSON, options);
+		}else {
+			this.iterationRunner.execute();
+		}
+	}
 });
 
 module.exports = Newman;

--- a/src/Newman.js
+++ b/src/Newman.js
@@ -27,8 +27,6 @@ var Newman = jsface.Class([Options, EventEmitter], {
      */
     execute: function(requestJSON, options, callback) {
         
-        log.note("this is the new version");
-        
         // var collectionParseError = Validator.validateJSON('c',requestJSON);
         // if(!collectionParseError.status) {
         //     Errors.terminateWithError("Not a valid POSTMAN collection");
@@ -92,7 +90,7 @@ var Newman = jsface.Class([Options, EventEmitter], {
 
         if (options.exportJSON) {
             importer.exportJSON(requestJSON, options);
-        } 
+        }
         else if (options.importJSON) {
             importer.importJSON(requestJSON, options);
         }else {

--- a/src/models/RequestModel.js
+++ b/src/models/RequestModel.js
@@ -25,8 +25,10 @@ var RequestModel = jsface.Class(ParentModel, {
 		this.currentHelper = requestJson.currentHelper;
 		this.helperAttributes = requestJson.helperAttributes;
         
+		var fileName;
+		
         if (requestJson.tests && requestJson.tests.startsWith('file:')) {
-            var fileName = requestJson.tests.substring(5);
+            fileName = requestJson.tests.substring(5);
             console.log('Reading in tests from file:%s', fileName);
 
             try {
@@ -66,7 +68,7 @@ var RequestModel = jsface.Class(ParentModel, {
             }
         } else {
             this.rawModeData = requestJson.rawModeData;
-        }  
+        }
 	},
 	toString: function() {
 		return "Request: [" + this.method + "]: " + this.url;

--- a/src/models/RequestModel.js
+++ b/src/models/RequestModel.js
@@ -1,6 +1,6 @@
 var jsface = require('jsface'),
 	ParentModel = require('./ParentModel.js'),
-    fs     = require('fs');
+	fs     = require('fs');
 
 /**
  * @class RequestModel
@@ -24,51 +24,51 @@ var RequestModel = jsface.Class(ParentModel, {
 		this.preRequestScript     = requestJson.preRequestScript;
 		this.currentHelper = requestJson.currentHelper;
 		this.helperAttributes = requestJson.helperAttributes;
-        
+		
 		var fileName;
 		
-        if (requestJson.tests && requestJson.tests.startsWith('file:')) {
-            fileName = requestJson.tests.substring(5);
-            console.log('Reading in tests from file:%s', fileName);
+		if (requestJson.tests && requestJson.tests.startsWith('file:')) {
+			fileName = requestJson.tests.substring(5);
+			console.log('Reading in tests from file:%s', fileName);
 
-            try {
-                this.tests = fs.readFileSync(fileName, 'utf8');
-                //console.log('tests:\n\r', this.tests);
-            } catch (e) {
-                if (e.code === 'ENOENT') {
-                    console.log('File not found!');
-                    //leave tests as they were this will no dobut cause an exception inthe newman process but will be 
-                    //reported back to user
-                    this.tests = requestJson.tests;
-                } else {
-                    throw e;
-                }
-            }
-        } else {
-            this.tests = requestJson.tests;
-        }
+			try {
+				this.tests = fs.readFileSync(fileName, 'utf8');
+				//console.log('tests:\n\r', this.tests);
+			} catch (e) {
+				if (e.code === 'ENOENT') {
+					console.log('File not found!');
+					//leave tests as they were this will no dobut cause an exception inthe newman process but will be 
+					//reported back to user
+					this.tests = requestJson.tests;
+				} else {
+					throw e;
+				}
+			}
+		} else {
+			this.tests = requestJson.tests;
+		}
 
-        
-        if (requestJson.rawModeData && requestJson.rawModeData.startsWith('file:')) {
-            fileName = requestJson.rawModeData.substring(5);
-            console.log('Reading in rawModeData from file:%s', fileName);
+		
+		if (requestJson.rawModeData && requestJson.rawModeData.startsWith('file:')) {
+			fileName = requestJson.rawModeData.substring(5);
+			console.log('Reading in rawModeData from file:%s', fileName);
 
-            try {
-                this.rawModeData = fs.readFileSync(fileName, 'utf8');
-                //console.log('tests:\n\r', this.tests);
-            } catch (e) {
-                if (e.code === 'ENOENT') {
-                    console.log('File not found!');
-                    //leave tests as they were this will no dobut cause an exception inthe newman process but will be 
-                    //reported back to user
-                    this.rawModeData = requestJson.rawModeData;
-                } else {
-                    throw e;
-                }
-            }
-        } else {
-            this.rawModeData = requestJson.rawModeData;
-        }
+			try {
+				this.rawModeData = fs.readFileSync(fileName, 'utf8');
+				//console.log('tests:\n\r', this.tests);
+			} catch (e) {
+				if (e.code === 'ENOENT') {
+					console.log('File not found!');
+					//leave tests as they were this will no dobut cause an exception inthe newman process but will be 
+					//reported back to user
+					this.rawModeData = requestJson.rawModeData;
+				} else {
+					throw e;
+				}
+			}
+		} else {
+			this.rawModeData = requestJson.rawModeData;
+		}
 	},
 	toString: function() {
 		return "Request: [" + this.method + "]: " + this.url;

--- a/src/models/RequestModel.js
+++ b/src/models/RequestModel.js
@@ -23,6 +23,50 @@ var RequestModel = jsface.Class(ParentModel, {
 		this.preRequestScript     = requestJson.preRequestScript;
 		this.currentHelper = requestJson.currentHelper;
 		this.helperAttributes = requestJson.helperAttributes;
+        
+        if (requestJson.tests && requestJson.tests.startsWith('file:')) {
+            var fileName = requestJson.tests.substring(5);
+            console.log('Reading in tests from file:%s', fileName);
+
+            try {
+                this.tests = fs.readFileSync(fileName, 'utf8');
+                //console.log('tests:\n\r', this.tests);
+            } catch (e) {
+                if (e.code === 'ENOENT') {
+                    console.log('File not found!');
+                    //leave tests as they were this will no dobut cause an exception inthe newman process but will be 
+                    //reported back to user
+                    this.tests = requestJson.tests;
+                } else {
+                    throw e;
+                }
+            }
+        } else {
+            this.tests = requestJson.tests;
+        }
+
+        
+        if (requestJson.rawModeData && requestJson.rawModeData.startsWith('file:')) {
+            var fileName = requestJson.rawModeData.substring(5);
+            console.log('Reading in rawModeData from file:%s', fileName);
+
+            try {
+                this.rawModeData = fs.readFileSync(fileName, 'utf8');
+                //console.log('tests:\n\r', this.tests);
+            } catch (e) {
+                if (e.code === 'ENOENT') {
+                    console.log('File not found!');
+                    //leave tests as they were this will no dobut cause an exception inthe newman process but will be 
+                    //reported back to user
+                    this.rawModeData = requestJson.rawModeData;
+                } else {
+                    throw e;
+                }
+            }
+        } else {
+            this.rawModeData = requestJson.rawModeData;
+        }          
+        
 	},
 	toString: function() {
 		return "Request: [" + this.method + "]: " + this.url;

--- a/src/models/RequestModel.js
+++ b/src/models/RequestModel.js
@@ -48,7 +48,7 @@ var RequestModel = jsface.Class(ParentModel, {
 
         
         if (requestJson.rawModeData && requestJson.rawModeData.startsWith('file:')) {
-            var fileName = requestJson.rawModeData.substring(5);
+            fileName = requestJson.rawModeData.substring(5);
             console.log('Reading in rawModeData from file:%s', fileName);
 
             try {
@@ -66,8 +66,7 @@ var RequestModel = jsface.Class(ParentModel, {
             }
         } else {
             this.rawModeData = requestJson.rawModeData;
-        }          
-        
+        }  
 	},
 	toString: function() {
 		return "Request: [" + this.method + "]: " + this.url;

--- a/src/models/RequestModel.js
+++ b/src/models/RequestModel.js
@@ -1,5 +1,6 @@
 var jsface = require('jsface'),
-	ParentModel = require('./ParentModel.js');
+	ParentModel = require('./ParentModel.js'),
+    fs     = require('fs');
 
 /**
  * @class RequestModel

--- a/src/responseHandlers/AbstractResponseHandler.js
+++ b/src/responseHandlers/AbstractResponseHandler.js
@@ -1,8 +1,8 @@
 var jsface = require('jsface'),
-    log = require('../utilities/Logger'),
-    ErrorHandler = require('../utilities/ErrorHandler'),
-    EventEmitter = require('../utilities/EventEmitter'),
-    ResponseExporter = require('../utilities/ResponseExporter');
+	log = require('../utilities/Logger'),
+	ErrorHandler = require('../utilities/ErrorHandler'),
+	EventEmitter = require('../utilities/EventEmitter'),
+	ResponseExporter = require('../utilities/ResponseExporter');
 
 /**
  * @class AbstractResponseHandler
@@ -10,51 +10,51 @@ var jsface = require('jsface'),
  * @mixes EventEmitter
  */
 var AbstractResponseHandler = jsface.Class([EventEmitter], {
-    $singleton: true,
+	$singleton: true,
 
-    /**
-     * Sets up the event listener for the request executed event emitted on each
-     * request execution
-     * @memberOf AbstractResponseHandler
-     */
-    initialize: function () {
-        this._bindedOnRequestExecuted = this._onRequestExecuted.bind(this);
-        this.addEventListener('requestExecuted', this._bindedOnRequestExecuted);
-    },
+	/**
+	 * Sets up the event listener for the request executed event emitted on each
+	 * request execution
+	 * @memberOf AbstractResponseHandler
+	 */
+	initialize: function () {
+		this._bindedOnRequestExecuted = this._onRequestExecuted.bind(this);
+		this.addEventListener('requestExecuted', this._bindedOnRequestExecuted);
+	},
 
-    // method to be over-ridden by the inheriting classes
-    _onRequestExecuted: function (error, response, body, request, tests) {
-        if (error) {
-            ErrorHandler.requestError(request, error);
-        } else {
-            this._printResponse(error, response, body, request);
-        }
-        ResponseExporter.addResult(request, response, tests);
-    },
+	// method to be over-ridden by the inheriting classes
+	_onRequestExecuted: function (error, response, body, request, tests) {
+		if (error) {
+			ErrorHandler.requestError(request, error);
+		} else {
+			this._printResponse(error, response, body, request);
+		}
+		ResponseExporter.addResult(request, response, tests);
+	},
 
-    _printResponse: function (error, response, body, request) {
-        if (response.statusCode >= 200 && response.statusCode < 300) {
-            log.success(response.statusCode);
-        } else {
-            ErrorHandler.responseError(response);
-        }
-        
-        //Include the folder name as part of the request name if present
-        var testName = request.name;
-        if (request.folderName) {
-            testName = request.folderName + '.' + testName;
-        }
+	_printResponse: function (error, response, body, request) {
+		if (response.statusCode >= 200 && response.statusCode < 300) {
+			log.success(response.statusCode);
+		} else {
+			ErrorHandler.responseError(response);
+		}
+		
+		//Include the folder name as part of the request name if present
+		var testName = request.name;
+		if (request.folderName) {
+			testName = request.folderName + '.' + testName;
+		}
 
-        log
-            .notice(" " + response.stats.timeTaken + "ms")
-            .normal(" " + testName + " ")
-            .light(request.transformed.url + "\n");
-    },
+		log
+			.notice(" " + response.stats.timeTaken + "ms")
+			.normal(" " + testName + " ")
+			.light(request.transformed.url + "\n");
+	},
 
-    // clears up the set event
-    clear: function () {
-        this.removeEventListener('requestExecuted', this._bindedOnRequestExecuted);
-    }
+	// clears up the set event
+	clear: function () {
+		this.removeEventListener('requestExecuted', this._bindedOnRequestExecuted);
+	}
 });
 
 module.exports = AbstractResponseHandler;

--- a/src/responseHandlers/AbstractResponseHandler.js
+++ b/src/responseHandlers/AbstractResponseHandler.js
@@ -1,8 +1,8 @@
-var jsface           = require('jsface'),
-	log              = require('../utilities/Logger'),
-	ErrorHandler     = require('../utilities/ErrorHandler'),
-	EventEmitter     = require('../utilities/EventEmitter'),
-	ResponseExporter = require('../utilities/ResponseExporter');
+var jsface = require('jsface'),
+    log = require('../utilities/Logger'),
+    ErrorHandler = require('../utilities/ErrorHandler'),
+    EventEmitter = require('../utilities/EventEmitter'),
+    ResponseExporter = require('../utilities/ResponseExporter');
 
 /**
  * @class AbstractResponseHandler
@@ -10,44 +10,51 @@ var jsface           = require('jsface'),
  * @mixes EventEmitter
  */
 var AbstractResponseHandler = jsface.Class([EventEmitter], {
-	$singleton: true,
+    $singleton: true,
 
-	/**
-	 * Sets up the event listener for the request executed event emitted on each
-	 * request execution
-	 * @memberOf AbstractResponseHandler
-	 */
-	initialize: function() {
-		this._bindedOnRequestExecuted = this._onRequestExecuted.bind(this);
-		this.addEventListener('requestExecuted', this._bindedOnRequestExecuted);
-	},
+    /**
+     * Sets up the event listener for the request executed event emitted on each
+     * request execution
+     * @memberOf AbstractResponseHandler
+     */
+    initialize: function () {
+        this._bindedOnRequestExecuted = this._onRequestExecuted.bind(this);
+        this.addEventListener('requestExecuted', this._bindedOnRequestExecuted);
+    },
 
-	// method to be over-ridden by the inheriting classes
-	_onRequestExecuted: function(error, response, body, request, tests) {
-		if (error) {
-			ErrorHandler.requestError(request, error);
-		} else  {
-			this._printResponse(error, response, body, request);
-		}
-		ResponseExporter.addResult(request, response, tests);
-	},
+    // method to be over-ridden by the inheriting classes
+    _onRequestExecuted: function (error, response, body, request, tests) {
+        if (error) {
+            ErrorHandler.requestError(request, error);
+        } else {
+            this._printResponse(error, response, body, request);
+        }
+        ResponseExporter.addResult(request, response, tests);
+    },
 
-	_printResponse: function(error, response, body, request) {
-		if (response.statusCode >= 200 && response.statusCode < 300) {
-			log.success(response.statusCode);
-		} else {
-			ErrorHandler.responseError(response);
-		}
-		log
-		.notice(" " + response.stats.timeTaken + "ms")
-		.normal(" " + request.name + " ")
-		.light(request.transformed.url + "\n");
-	},
+    _printResponse: function (error, response, body, request) {
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+            log.success(response.statusCode);
+        } else {
+            ErrorHandler.responseError(response);
+        }
+        
+        //Include the folder name as part of the request name if present
+        var testName = request.name;
+        if (request.folderName) {
+            testName = request.folderName + '.' + testName;
+        }
 
-	// clears up the set event
-	clear: function() {
-		this.removeEventListener('requestExecuted', this._bindedOnRequestExecuted);
-	}
+        log
+            .notice(" " + response.stats.timeTaken + "ms")
+            .normal(" " + testName + " ")
+            .light(request.transformed.url + "\n");
+    },
+
+    // clears up the set event
+    clear: function () {
+        this.removeEventListener('requestExecuted', this._bindedOnRequestExecuted);
+    }
 });
 
 module.exports = AbstractResponseHandler;

--- a/src/utilities/Importer.js
+++ b/src/utilities/Importer.js
@@ -1,6 +1,9 @@
 var jsface = require('jsface'),
     fs     = require('fs'),
     Errors = require('./ErrorHandler'),
+    IterationRunner = require('../runners/IterationRunner'),
+    _und = require('underscore'),
+    path = require('path'),
     mkdirp = require('mkdirp');
 
 /**
@@ -99,8 +102,164 @@ var Importer = jsface.Class({
                 console.log('Global ('+globalName+') saved');
             }
         });
-    }
+    },
 
+    exportJSON: function( requestJSON, options ) {
+
+            var changes = false;
+
+            var collectionName = requestJSON.name.replace(/ /g, '');
+            requestJSON.name = collectionName;
+
+            //Remove all the spaces from the folder name to make a decent file name
+            _und.each(requestJSON.folders, function (folder) {
+
+                var folderItemName = folder.name.replace(/ /g, '')
+                if (folderItemName != folder.name) {
+                    changes = true;
+                    folder.name = folderItemName;
+                }
+            });
+
+            var iterationRunner = new IterationRunner(requestJSON, options);
+
+            //Get a ordered list of all the requests
+            var orderedCollection = iterationRunner._getOrderedCollection(requestJSON);
+
+
+            _und.each(orderedCollection, function (postmanRequest) {
+                var fileName
+
+                //Remove spaces from Request Name
+                var requestItem = _und.find(requestJSON.requests, function (request) {
+                    return request.id === postmanRequest.id;
+                });
+
+                requestItem.name = postmanRequest.name.replace(/ /g, '')
+                if (requestItem.name != postmanRequest.name) {
+                    changes = true;
+                }
+
+                //Add folder name to path if it exists
+                if (postmanRequest.folderName) {
+                    console.log('Request:%s.%s with ID:%s', postmanRequest.folderName, requestItem.name, postmanRequest.id);
+                    fileName = postmanRequest.folderName + '.' + requestItem.name;
+
+                } else {
+                    console.log('no folder name');
+                    console.log('Request:%s with ID:%s', postmanRequest.name, postmanRequest.id);
+                    fileName = requestItem.name;
+                }
+
+                //build a base file name for data output
+                baseFileName = path.join(options.exportJSON, fileName);
+
+                if (requestItem.tests) {
+                    //build a file name for the test data output
+                    var testsDatafileName = baseFileName + '.tests.json';
+
+                    var testsJSON = requestItem.tests
+                        //write out the info
+                    fs.writeFileSync(testsDatafileName, testsJSON);
+                    console.log('dump tests to file: %s', testsDatafileName);
+                    requestItem.tests = 'file:' + testsDatafileName;
+                }
+
+
+                if (requestItem.rawModeData) {
+                    var rawModeDatafileName = baseFileName + '.rawModeData.json';
+                    var rawModeData = requestItem.rawModeData
+                        //write out the info
+                    fs.writeFileSync(rawModeDatafileName, rawModeData);
+                    console.log('dump rawModeData to file: %s', rawModeDatafileName);
+                    requestItem.rawModeData = 'file:' + rawModeDatafileName;
+                }
+
+
+            }, this);
+
+            if (changes) {
+                var collectionFileName = path.join(options.exportJSON, collectionName + '.colleciton.json');
+                fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
+                console.log('created output file %s', collectionFileName);
+            }
+
+        },
+    importJSON : function( requestJSON, options ) {
+            
+            /*take the path supplied and make a single output file which is a postman collection
+               find the file name of colelction it is in the new options.collectionFileName
+               replace the file: refereces with the actual contents of the file for
+                    tests
+                    rawModeData
+                write a new output file 
+            */
+            
+            console.log('options.collectionFileName:', options.collectionFileName);
+
+            var changes = false;
+ 
+            //Get a ordered list of all the requests
+            var iterationRunner = new IterationRunner(requestJSON, options);
+            var orderedCollection = iterationRunner._getOrderedCollection(requestJSON);
+
+            _und.each(orderedCollection, function (postmanRequest) {
+
+                var fileName
+
+                //get the single request item
+                var requestItem = _und.find(requestJSON.requests, function (request) {
+                    return request.id === postmanRequest.id;
+                });
+
+                console.log('processing request :%s, tests:%s', requestItem.name,requestItem.tests);
+                
+                    
+
+                //take a file reference and convert to postman
+                if (requestItem.tests && requestItem.tests.startsWith('file:')) {
+                    var fileName = requestItem.tests.substring(5);
+                    console.log('Reading in tests from file:%s', fileName);
+
+                    try {
+                        requestItem.tests = fs.readFileSync(fileName, 'utf8');
+                        changes =true;
+                    } catch (e) {
+                        if (e.code === 'ENOENT') {
+                            console.log('File not found!');
+                        } else {
+                            throw e;
+                        }
+                    }
+                } 
+
+                //take a file reference and convert to postman
+                if (requestItem.rawModeData && requestItem.rawModeData.startsWith('file:')) {
+                    var fileName = requestItem.rawModeData.substring(5);
+                    console.log('Reading in rawModeData from file:%s', fileName);
+
+                    try {
+                        requestItem.rawModeData = fs.readFileSync(fileName, 'utf8');
+                        changes =true;
+                    } catch (e) {
+                        if (e.code === 'ENOENT') {
+                            console.log('File not found!');
+                        } else {
+                            throw e;
+                        }
+                    }
+                } 
+
+            }, this);
+
+            if (changes) {
+                var collectionFileName = options.collectionFileName + '.out';
+                fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
+                console.log('created output file %s', collectionFileName);
+            }
+
+        } 
+    
 
 });
 

--- a/src/utilities/Importer.js
+++ b/src/utilities/Importer.js
@@ -117,8 +117,8 @@ var Importer = jsface.Class({
             //Remove all the spaces from the folder name to make a decent file name
             _und.each(requestJSON.folders, function (folder) {
 
-                var folderItemName = folder.name.replace(/ /g, '')
-                if (folderItemName != folder.name) {
+                var folderItemName = folder.name.replace(/ /g, '');
+                if (folderItemName !== folder.name) {
                     changes = true;
                     folder.name = folderItemName;
                 }
@@ -131,15 +131,15 @@ var Importer = jsface.Class({
 
 
             _und.each(orderedCollection, function (postmanRequest) {
-                var fileName
+                var fileName;
 
                 //Remove spaces from Request Name
                 var requestItem = _und.find(requestJSON.requests, function (request) {
                     return request.id === postmanRequest.id;
                 });
 
-                requestItem.name = postmanRequest.name.replace(/ /g, '')
-                if (requestItem.name != postmanRequest.name) {
+                requestItem.name = postmanRequest.name.replace(/ /g, '');
+                if (requestItem.name !== postmanRequest.name) {
                     changes = true;
                 }
 
@@ -155,13 +155,13 @@ var Importer = jsface.Class({
                 }
 
                 //build a base file name for data output
-                baseFileName = path.join(options.exportJSON, fileName);
+                var baseFileName = path.join(options.exportJSON, fileName);
 
                 if (requestItem.tests) {
                     //build a file name for the test data output
                     var testsDatafileName = baseFileName + '.tests.json';
 
-                    var testsJSON = requestItem.tests
+                    var testsJSON = requestItem.tests;
                         //write out the info
                     fs.writeFileSync(testsDatafileName, testsJSON);
                     console.log('dump tests to file: %s', testsDatafileName);
@@ -171,7 +171,7 @@ var Importer = jsface.Class({
 
                 if (requestItem.rawModeData) {
                     var rawModeDatafileName = baseFileName + '.rawModeData.json';
-                    var rawModeData = requestItem.rawModeData
+                    var rawModeData = requestItem.rawModeData;
                         //write out the info
                     fs.writeFileSync(rawModeDatafileName, rawModeData);
                     console.log('dump rawModeData to file: %s', rawModeDatafileName);
@@ -211,7 +211,7 @@ var Importer = jsface.Class({
 
             _und.each(orderedCollection, function (postmanRequest) {
 
-                var fileName
+                var fileName;
 
                 //get the single request item
                 var requestItem = _und.find(requestJSON.requests, function (request) {
@@ -224,7 +224,7 @@ var Importer = jsface.Class({
 
                 //take a file reference and convert to postman
                 if (requestItem.tests && requestItem.tests.startsWith('file:')) {
-                    var fileName = requestItem.tests.substring(5);
+                    fileName = requestItem.tests.substring(5);
                     console.log('Reading in tests from file:%s', fileName);
 
                     try {
@@ -237,11 +237,11 @@ var Importer = jsface.Class({
                             throw e;
                         }
                     }
-                } 
-
-                //take a file reference and convert to postman
+                }
+				
+				//take a file reference and convert to postman
                 if (requestItem.rawModeData && requestItem.rawModeData.startsWith('file:')) {
-                    var fileName = requestItem.rawModeData.substring(5);
+                    fileName = requestItem.rawModeData.substring(5);
                     console.log('Reading in rawModeData from file:%s', fileName);
 
                     try {
@@ -259,16 +259,12 @@ var Importer = jsface.Class({
             }, this);
 
             if (changes) {
-                
                 var collectionFileName = path.join(options.importJSON, path.basename(options.collectionFileName)+ '.out');
-                
                 fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
                 console.log('created output file %s', collectionFileName);
             }
 
-        } 
-    
-
+        }
 });
 
 module.exports = Importer;

--- a/src/utilities/Importer.js
+++ b/src/utilities/Importer.js
@@ -254,8 +254,7 @@ var Importer = jsface.Class({
                             throw e;
                         }
                     }
-                } 
-
+                }
             }, this);
 
             if (changes) {

--- a/src/utilities/Importer.js
+++ b/src/utilities/Importer.js
@@ -106,6 +106,9 @@ var Importer = jsface.Class({
 
     exportJSON: function( requestJSON, options ) {
 
+            //Make the output folder if required
+            mkdirp.sync(options.exportJSON);
+        
             var changes = false;
 
             var collectionName = requestJSON.name.replace(/ /g, '');
@@ -194,7 +197,10 @@ var Importer = jsface.Class({
                     rawModeData
                 write a new output file 
             */
-            
+        
+            //ensure output path exists
+            mkdirp.sync(options.importJSON);
+        
             console.log('options.collectionFileName:', options.collectionFileName);
 
             var changes = false;
@@ -253,7 +259,9 @@ var Importer = jsface.Class({
             }, this);
 
             if (changes) {
-                var collectionFileName = options.collectionFileName + '.out';
+                
+                var collectionFileName = path.join(options.importJSON, path.basename(options.collectionFileName)+ '.out');
+                
                 fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
                 console.log('created output file %s', collectionFileName);
             }

--- a/src/utilities/Importer.js
+++ b/src/utilities/Importer.js
@@ -1,10 +1,10 @@
 var jsface = require('jsface'),
-    fs     = require('fs'),
-    Errors = require('./ErrorHandler'),
-    IterationRunner = require('../runners/IterationRunner'),
-    _und = require('underscore'),
-    path = require('path'),
-    mkdirp = require('mkdirp');
+	fs     = require('fs'),
+	Errors = require('./ErrorHandler'),
+	IterationRunner = require('../runners/IterationRunner'),
+	_und = require('underscore'),
+	path = require('path'),
+	mkdirp = require('mkdirp');
 
 /**
  * @name Importer
@@ -12,258 +12,257 @@ var jsface = require('jsface'),
  * @classdesc Static class meant to parse and save Postman backup files
  */
 var Importer = jsface.Class({
-    $singleton: true,
+	$singleton: true,
 
-    importFile: function(filePath, pretty) {
-        var jsonObj={};
-        try {
-            jsonObj = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-        } catch(e) {
-            Errors.terminateWithError("Could not find file: "+filePath+"\n"+e);
-        }
+	importFile: function(filePath, pretty) {
+		var jsonObj={};
+		try {
+			jsonObj = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+		} catch(e) {
+			Errors.terminateWithError("Could not find file: "+filePath+"\n"+e);
+		}
 
-        var indentLevel = (pretty)?2:0;
+		var indentLevel = (pretty)?2:0;
 
-        var collections = jsonObj.collections;
-        var environments = jsonObj.environments;
-        var globals = jsonObj.globals;
-        var i;
+		var collections = jsonObj.collections;
+		var environments = jsonObj.environments;
+		var globals = jsonObj.globals;
+		var i;
 
-        if(!collections instanceof Array) {
-            Errors.terminateWithError("Collections must be an array...aborting");
-        }
-        if(!environments instanceof Array) {
-            Errors.terminateWithError("Environments must be an array...aborting");
-        }
-        if(!globals instanceof Array) {
-            Errors.terminateWithError("Globals must be an array...aborting");
-        }
+		if(!collections instanceof Array) {
+			Errors.terminateWithError("Collections must be an array...aborting");
+		}
+		if(!environments instanceof Array) {
+			Errors.terminateWithError("Environments must be an array...aborting");
+		}
+		if(!globals instanceof Array) {
+			Errors.terminateWithError("Globals must be an array...aborting");
+		}
 
-        var numC = collections.length;
-        var numE = environments.length;
+		var numC = collections.length;
+		var numE = environments.length;
 
-        mkdirp.sync('data/collections');
-        mkdirp.sync('data/environments');
-        mkdirp.sync('data/globals');
-
-
-        for(i=0;i<numC;i++) {
-            this._saveCollection(collections[i], indentLevel);
-        }
-
-        for(i=0;i<numE;i++) {
-            this._saveEnvironment(environments[i], indentLevel);
-        }
-
-        this._saveGlobal(globals, indentLevel);
-    },
-
-    _saveCollection: function(thisCollection, indentLevel) {
-        var collectionName = thisCollection.name;
-        if(collectionName===null || collectionName==="") {
-            collectionName = thisCollection.id;
-        }
-        var collectionString = JSON.stringify(thisCollection,undefined,indentLevel)+"\n";
-
-        fs.writeFile('data/collections/'+collectionName+".json", collectionString, function (err) {
-            if (err) {
-                return console.log(err);
-            }
-            else {
-                console.log('Collection ('+collectionName+') saved');
-            }
-        });
-    },
-
-    _saveEnvironment: function(environment, indentLevel) {
-        var envName = environment.name;
-        if(envName===null || envName==="") {
-            envName = environment.id;
-        }
-        var envString = JSON.stringify(environment,undefined,indentLevel)+"\n";
-
-        fs.writeFile('data/environments/'+envName+".json", envString, function (err) {
-            if (err) {
-                return console.log(err);
-            }
-            else {
-                console.log('Environment ('+envName+') saved');
-            }
-        });
-    },
-
-    _saveGlobal: function(globals, indentLevel) {
-        var globalName = "global_"+(new Date().getTime());
-        fs.writeFile('data/globals/'+globalName+".json", JSON.stringify(globals,undefined,indentLevel)+"\n", function (err) {
-            if (err) {
-                return console.log(err);
-            }
-            else {
-                console.log('Global ('+globalName+') saved');
-            }
-        });
-    },
-
-    exportJSON: function( requestJSON, options ) {
-
-            //Make the output folder if required
-            mkdirp.sync(options.exportJSON);
-        
-            var changes = false;
-
-            var collectionName = requestJSON.name.replace(/ /g, '');
-            requestJSON.name = collectionName;
-
-            //Remove all the spaces from the folder name to make a decent file name
-            _und.each(requestJSON.folders, function (folder) {
-
-                var folderItemName = folder.name.replace(/ /g, '');
-                if (folderItemName !== folder.name) {
-                    changes = true;
-                    folder.name = folderItemName;
-                }
-            });
-
-            var iterationRunner = new IterationRunner(requestJSON, options);
-
-            //Get a ordered list of all the requests
-            var orderedCollection = iterationRunner._getOrderedCollection(requestJSON);
+		mkdirp.sync('data/collections');
+		mkdirp.sync('data/environments');
+		mkdirp.sync('data/globals');
 
 
-            _und.each(orderedCollection, function (postmanRequest) {
-                var fileName;
+		for(i=0;i<numC;i++) {
+			this._saveCollection(collections[i], indentLevel);
+		}
 
-                //Remove spaces from Request Name
-                var requestItem = _und.find(requestJSON.requests, function (request) {
-                    return request.id === postmanRequest.id;
-                });
+		for(i=0;i<numE;i++) {
+			this._saveEnvironment(environments[i], indentLevel);
+		}
 
-                requestItem.name = postmanRequest.name.replace(/ /g, '');
-                if (requestItem.name !== postmanRequest.name) {
-                    changes = true;
-                }
+		this._saveGlobal(globals, indentLevel);
+	},
 
-                //Add folder name to path if it exists
-                if (postmanRequest.folderName) {
-                    console.log('Request:%s.%s with ID:%s', postmanRequest.folderName, requestItem.name, postmanRequest.id);
-                    fileName = postmanRequest.folderName + '.' + requestItem.name;
+	_saveCollection: function(thisCollection, indentLevel) {
+		var collectionName = thisCollection.name;
+		if(collectionName===null || collectionName==="") {
+			collectionName = thisCollection.id;
+		}
+		var collectionString = JSON.stringify(thisCollection,undefined,indentLevel)+"\n";
 
-                } else {
-                    console.log('no folder name');
-                    console.log('Request:%s with ID:%s', postmanRequest.name, postmanRequest.id);
-                    fileName = requestItem.name;
-                }
+		fs.writeFile('data/collections/'+collectionName+".json", collectionString, function (err) {
+			if (err) {
+				return console.log(err);
+			}
+			else {
+				console.log('Collection ('+collectionName+') saved');
+			}
+		});
+	},
 
-                //build a base file name for data output
-                var baseFileName = path.join(options.exportJSON, fileName);
+	_saveEnvironment: function(environment, indentLevel) {
+		var envName = environment.name;
+		if(envName===null || envName==="") {
+			envName = environment.id;
+		}
+		var envString = JSON.stringify(environment,undefined,indentLevel)+"\n";
 
-                if (requestItem.tests) {
-                    //build a file name for the test data output
-                    var testsDatafileName = baseFileName + '.tests.json';
+		fs.writeFile('data/environments/'+envName+".json", envString, function (err) {
+			if (err) {
+				return console.log(err);
+			}
+			else {
+				console.log('Environment ('+envName+') saved');
+			}
+		});
+	},
 
-                    var testsJSON = requestItem.tests;
-                        //write out the info
-                    fs.writeFileSync(testsDatafileName, testsJSON);
-                    console.log('dump tests to file: %s', testsDatafileName);
-                    requestItem.tests = 'file:' + testsDatafileName;
-                }
+	_saveGlobal: function(globals, indentLevel) {
+		var globalName = "global_"+(new Date().getTime());
+		fs.writeFile('data/globals/'+globalName+".json", JSON.stringify(globals,undefined,indentLevel)+"\n", function (err) {
+			if (err) {
+				return console.log(err);
+			}
+			else {
+				console.log('Global ('+globalName+') saved');
+			}
+		});
+	},
+
+	exportJSON: function( requestJSON, options ) {
+
+			//Make the output folder if required
+			mkdirp.sync(options.exportJSON);
+		
+			var changes = false;
+
+			var collectionName = requestJSON.name.replace(/ /g, '');
+			requestJSON.name = collectionName;
+
+			//Remove all the spaces from the folder name to make a decent file name
+			_und.each(requestJSON.folders, function (folder) {
+
+				var folderItemName = folder.name.replace(/ /g, '');
+				if (folderItemName !== folder.name) {
+					changes = true;
+					folder.name = folderItemName;
+				}
+			});
+
+			var iterationRunner = new IterationRunner(requestJSON, options);
+
+			//Get a ordered list of all the requests
+			var orderedCollection = iterationRunner._getOrderedCollection(requestJSON);
 
 
-                if (requestItem.rawModeData) {
-                    var rawModeDatafileName = baseFileName + '.rawModeData.json';
-                    var rawModeData = requestItem.rawModeData;
-                        //write out the info
-                    fs.writeFileSync(rawModeDatafileName, rawModeData);
-                    console.log('dump rawModeData to file: %s', rawModeDatafileName);
-                    requestItem.rawModeData = 'file:' + rawModeDatafileName;
-                }
+			_und.each(orderedCollection, function (postmanRequest) {
+				var fileName;
+
+				//Remove spaces from Request Name
+				var requestItem = _und.find(requestJSON.requests, function (request) {
+					return request.id === postmanRequest.id;
+				});
+
+				requestItem.name = postmanRequest.name.replace(/ /g, '');
+				if (requestItem.name !== postmanRequest.name) {
+					changes = true;
+				}
+
+				//Add folder name to path if it exists
+				if (postmanRequest.folderName) {
+					console.log('Request:%s.%s with ID:%s', postmanRequest.folderName, requestItem.name, postmanRequest.id);
+					fileName = postmanRequest.folderName + '.' + requestItem.name;
+
+				} else {
+					console.log('no folder name');
+					console.log('Request:%s with ID:%s', postmanRequest.name, postmanRequest.id);
+					fileName = requestItem.name;
+				}
+
+				//build a base file name for data output
+				var baseFileName = path.join(options.exportJSON, fileName);
+
+				if (requestItem.tests) {
+					//build a file name for the test data output
+					var testsDatafileName = baseFileName + '.tests.json';
+
+					var testsJSON = requestItem.tests;
+						//write out the info
+					fs.writeFileSync(testsDatafileName, testsJSON);
+					console.log('dump tests to file: %s', testsDatafileName);
+					requestItem.tests = 'file:' + testsDatafileName;
+				}
 
 
-            }, this);
+				if (requestItem.rawModeData) {
+					var rawModeDatafileName = baseFileName + '.rawModeData.json';
+					var rawModeData = requestItem.rawModeData;
+						//write out the info
+					fs.writeFileSync(rawModeDatafileName, rawModeData);
+					console.log('dump rawModeData to file: %s', rawModeDatafileName);
+					requestItem.rawModeData = 'file:' + rawModeDatafileName;
+				}
 
-            if (changes) {
-                var collectionFileName = path.join(options.exportJSON, collectionName + '.collection.json');
-                fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
-                console.log('created output file %s', collectionFileName);
-            }
 
-        },
-    importJSON : function( requestJSON, options ) {
-            
-            /*take the path supplied and make a single output file which is a postman collection
-               find the file name of colelction it is in the new options.collectionFileName
-               replace the file: refereces with the actual contents of the file for
-                    tests
-                    rawModeData
-                write a new output file 
-            */
-        
-            //ensure output path exists
-            mkdirp.sync(options.importJSON);
-        
-            console.log('options.collectionFileName:', options.collectionFileName);
+			}, this);
 
-            var changes = false;
+			if (changes) {
+				var collectionFileName = path.join(options.exportJSON, collectionName + '.collection.json');
+				fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
+				console.log('created output file %s', collectionFileName);
+			}
+
+		},
+	importJSON : function( requestJSON, options ) {
+			
+			/*
+			take the path supplied and make a single output file which is a postman collection
+			find the file name of colelction it is in the new options.collectionFileName
+			replace the file: refereces with the actual contents of the file for the tests and rawModeData fields
+			write a new output file 
+			*/
+		
+			//ensure output path exists
+			mkdirp.sync(options.importJSON);
+		
+			console.log('options.collectionFileName:', options.collectionFileName);
+
+			var changes = false;
  
-            //Get a ordered list of all the requests
-            var iterationRunner = new IterationRunner(requestJSON, options);
-            var orderedCollection = iterationRunner._getOrderedCollection(requestJSON);
+			//Get a ordered list of all the requests
+			var iterationRunner = new IterationRunner(requestJSON, options);
+			var orderedCollection = iterationRunner._getOrderedCollection(requestJSON);
 
-            _und.each(orderedCollection, function (postmanRequest) {
+			_und.each(orderedCollection, function (postmanRequest) {
 
-                var fileName;
+				var fileName;
 
-                //get the single request item
-                var requestItem = _und.find(requestJSON.requests, function (request) {
-                    return request.id === postmanRequest.id;
-                });
+				//get the single request item
+				var requestItem = _und.find(requestJSON.requests, function (request) {
+					return request.id === postmanRequest.id;
+				});
 
-                console.log('processing request :%s, tests:%s', requestItem.name,requestItem.tests);
-                
-                    
+				console.log('processing request :%s, tests:%s', requestItem.name,requestItem.tests);
+				
+					
 
-                //take a file reference and convert to postman
-                if (requestItem.tests && requestItem.tests.startsWith('file:')) {
-                    fileName = requestItem.tests.substring(5);
-                    console.log('Reading in tests from file:%s', fileName);
+				//take a file reference and convert to postman
+				if (requestItem.tests && requestItem.tests.startsWith('file:')) {
+					fileName = requestItem.tests.substring(5);
+					console.log('Reading in tests from file:%s', fileName);
 
-                    try {
-                        requestItem.tests = fs.readFileSync(fileName, 'utf8');
-                        changes =true;
-                    } catch (e) {
-                        if (e.code === 'ENOENT') {
-                            console.log('File not found!');
-                        } else {
-                            throw e;
-                        }
-                    }
-                }
+					try {
+						requestItem.tests = fs.readFileSync(fileName, 'utf8');
+						changes =true;
+					} catch (e) {
+						if (e.code === 'ENOENT') {
+							console.log('File not found!');
+						} else {
+							throw e;
+						}
+					}
+				}
 				
 				//take a file reference and convert to postman
-                if (requestItem.rawModeData && requestItem.rawModeData.startsWith('file:')) {
-                    fileName = requestItem.rawModeData.substring(5);
-                    console.log('Reading in rawModeData from file:%s', fileName);
+				if (requestItem.rawModeData && requestItem.rawModeData.startsWith('file:')) {
+					fileName = requestItem.rawModeData.substring(5);
+					console.log('Reading in rawModeData from file:%s', fileName);
 
-                    try {
-                        requestItem.rawModeData = fs.readFileSync(fileName, 'utf8');
-                        changes =true;
-                    } catch (e) {
-                        if (e.code === 'ENOENT') {
-                            console.log('File not found!');
-                        } else {
-                            throw e;
-                        }
-                    }
-                }
-            }, this);
+					try {
+						requestItem.rawModeData = fs.readFileSync(fileName, 'utf8');
+						changes =true;
+					} catch (e) {
+						if (e.code === 'ENOENT') {
+							console.log('File not found!');
+						} else {
+							throw e;
+						}
+					}
+				}
+			}, this);
 
-            if (changes) {
-                var collectionFileName = path.join(options.importJSON, path.basename(options.collectionFileName)+ '.out');
-                fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
-                console.log('created output file %s', collectionFileName);
-            }
+			if (changes) {
+				var collectionFileName = path.join(options.importJSON, path.basename(options.collectionFileName)+ '.out');
+				fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
+				console.log('created output file %s', collectionFileName);
+			}
 
-        }
+		}
 });
 
 module.exports = Importer;

--- a/src/utilities/Importer.js
+++ b/src/utilities/Importer.js
@@ -182,7 +182,7 @@ var Importer = jsface.Class({
             }, this);
 
             if (changes) {
-                var collectionFileName = path.join(options.exportJSON, collectionName + '.colleciton.json');
+                var collectionFileName = path.join(options.exportJSON, collectionName + '.collection.json');
                 fs.writeFileSync(collectionFileName, JSON.stringify(requestJSON, null, 1));
                 console.log('created output file %s', collectionFileName);
             }

--- a/src/utilities/VariableProcessor.js
+++ b/src/utilities/VariableProcessor.js
@@ -95,8 +95,6 @@ var VariableProcessor = jsface.Class({
     // Process variables defined in the tests
     _processEnvVariableForJSONExportedCollections: function (request, envJson) {
         var kvpairs = envJson.values;
-        var oldThis = this;
-
 
         var properties = ["tests","rawModeData"];
 
@@ -113,7 +111,7 @@ var VariableProcessor = jsface.Class({
                     //console.log( 'new value: ', newValue );
                     
                     request[prop] = newValue;
-                } 
+                }
             }
         }, this);
         return true;

--- a/src/utilities/VariableProcessor.js
+++ b/src/utilities/VariableProcessor.js
@@ -26,14 +26,14 @@ var VariableProcessor = jsface.Class({
 		randomInt: _und.random(0, 1000)
 	},
 
-    _resetFunctionVariables: function() {
-        var guid = uuid.v4();
-        var timestamp = _und.now();
-        var randomInt = _und.random(0, 1000);
-        this.getFunctionVariables.guid = guid;
-        this.getFunctionVariables.randomInt = randomInt;
-        this.getFunctionVariables.timestamp= timestamp;
-    },
+	_resetFunctionVariables: function() {
+		var guid = uuid.v4();
+		var timestamp = _und.now();
+		var randomInt = _und.random(0, 1000);
+		this.getFunctionVariables.guid = guid;
+		this.getFunctionVariables.randomInt = randomInt;
+		this.getFunctionVariables.timestamp= timestamp;
+	},
 
 	// updates request url by the replacing it with pathVariables
 	_processPathVariable: function(request) {
@@ -91,33 +91,33 @@ var VariableProcessor = jsface.Class({
 		}
 		return stringSource;
 	},
-    
-    // Process variables defined in the tests
-    _processEnvVariableForJSONExportedCollections: function (request, envJson) {
-        var kvpairs = envJson.values;
+	
+	// Process variables defined in the tests
+	_processEnvVariableForJSONExportedCollections: function (request, envJson) {
+		var kvpairs = envJson.values;
 
-        var properties = ["tests","rawModeData"];
+		var properties = ["tests","rawModeData"];
 
-        var pairObject = Helpers.transformFromKeyValue(kvpairs);
-        _und.each(properties, function (prop) {
-            // check if the prop exists
-            if (request[prop] !== undefined) {
-                if (typeof request[prop] === "string") {
-                    //console.log('_processEnvVariableForTets: processing string prop %s', prop);
+		var pairObject = Helpers.transformFromKeyValue(kvpairs);
+		_und.each(properties, function (prop) {
+			// check if the prop exists
+			if (request[prop] !== undefined) {
+				if (typeof request[prop] === "string") {
+					//console.log('_processEnvVariableForTets: processing string prop %s', prop);
 
-                    // if string, use directly
-                    var newValue = this._findReplace(request[prop], pairObject, this.ENV_REGEX);
-                    
-                    //console.log( 'new value: ', newValue );
-                    
-                    request[prop] = newValue;
-                }
-            }
-        }, this);
-        return true;
-    },
+					// if string, use directly
+					var newValue = this._findReplace(request[prop], pairObject, this.ENV_REGEX);
+					
+					//console.log( 'new value: ', newValue );
+					
+					request[prop] = newValue;
+				}
+			}
+		}, this);
+		return true;
+	},
 
-    
+	
 
 	// transforms the request as per the environment json data passed
 	_processEnvVariable: function(request, envJson) {
@@ -185,11 +185,11 @@ var VariableProcessor = jsface.Class({
 	 * @param {JSON} options passed to Newman runner
 	 */
 	processRequestVariables: function(request, options) {
-        this._resetFunctionVariables();
+		this._resetFunctionVariables();
 		this._processPathVariable(request);
 		this._processFunctionVariable(request);
 		this._processEnvVariable(request, options.envJson);
-        this._processEnvVariableForJSONExportedCollections(request, options.envJson);
+		this._processEnvVariableForJSONExportedCollections(request, options.envJson);
 	}
 });
 

--- a/src/utilities/VariableProcessor.js
+++ b/src/utilities/VariableProcessor.js
@@ -91,6 +91,35 @@ var VariableProcessor = jsface.Class({
 		}
 		return stringSource;
 	},
+    
+    // Process variables defined in the tests
+    _processEnvVariableForJSONExportedCollections: function (request, envJson) {
+        var kvpairs = envJson.values;
+        var oldThis = this;
+
+
+        var properties = ["tests","rawModeData"];
+
+        var pairObject = Helpers.transformFromKeyValue(kvpairs);
+        _und.each(properties, function (prop) {
+            // check if the prop exists
+            if (request[prop] !== undefined) {
+                if (typeof request[prop] === "string") {
+                    //console.log('_processEnvVariableForTets: processing string prop %s', prop);
+
+                    // if string, use directly
+                    var newValue = this._findReplace(request[prop], pairObject, this.ENV_REGEX);
+                    
+                    //console.log( 'new value: ', newValue );
+                    
+                    request[prop] = newValue;
+                } 
+            }
+        }, this);
+        return true;
+    },
+
+    
 
 	// transforms the request as per the environment json data passed
 	_processEnvVariable: function(request, envJson) {
@@ -162,6 +191,7 @@ var VariableProcessor = jsface.Class({
 		this._processPathVariable(request);
 		this._processFunctionVariable(request);
 		this._processEnvVariable(request, options.envJson);
+        this._processEnvVariableForJSONExportedCollections(request, options.envJson);
 	}
 });
 


### PR DESCRIPTION
Hi new to github pull requests so go easy!.

This is a new feature that allows Newman to 
-J export to JSON the requets tests and rawMode fields to separate files, I found this handy when I need to edit the tests or data locally in an editor, bulk search and replace etc.  The import also creates a new collection file, it uses a convention of "file:XXXXX".

So after the export has been done, in the new collection file all the tests and rawModeData fields will be set to e.g for tests:   tests:"file:/somefolder/folderName.requestName.tests.json"

-K import

The reverse of the -J option, recombines the external separate tests and rawModeData back into the original postman format.  Also creates a new collection as output preserving original

Show folder name (if present) as test name in output,  The tests I made had several folders with the same name tests existing under different folders.  The test output was not including the folder name as part of the test name.


