### PR TITLE
white screen: normal text has black color

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,6 +42,11 @@ module.exports = function(grunt) {
 					'bin/newman -c tests/integ_tests/esc.postman_collection -e tests/integ_tests/esc.postman_environment -s && ' +
 					'bin/newman -c tests/integ_tests/prototypeCheck.json.postman_collection -s && ' +
 					'bin/newman -c tests/integ_tests/redirectTest.json.postman_collection -s -R'
+    		},
+    		whiteScreenTest: {
+      			exec: 'bin/newman -c tests/integ_tests/tc4.json -s -W && ' +
+					'bin/newman -c tests/integ_tests/randomIntC.json -s -W && ' +
+					'bin/newman -c tests/integ_tests/semicolon_tests.json -s -W '
     		}
 		}
 	});
@@ -56,6 +61,7 @@ module.exports = function(grunt) {
 	grunt.registerTask('prepare_release', ['lint', 'mochaTest', 'jsdoc']);
 	grunt.registerTask('default', ['mochaTest', 'jsdoc', 'jshint']);
 	grunt.registerTask('test', ['mochaTest', 'jshint','run:*']);
-	grunt.registerTask('integ_test',['run:*'])
+	grunt.registerTask('integ_test',['run:*']);
 	grunt.registerTask('docs', 'jsdoc');
+	grunt.registerTask('test_white_screen',['run:whiteScreenTest']);
 }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Misc.:
 -k, --insecure              Disable strict ssl
 -l, --tls                   Use TLSv1
 -x, --exitCode              Continue running tests even after a failure, but exit with code=1
+-W, --whiteScreen			Black text for white screen
+
 
 Output:
 -o, --outputFile [file]     Path to file where output should be written. [file]

--- a/bin/newman
+++ b/bin/newman
@@ -48,7 +48,8 @@ function parseArguments() {
 		.option('-t, --testReportFile [file]', 'Path to file where results should be written as JUnit XML [file]', null)
 		.option('-i, --import [file]', 'Import a Postman backup file, and save collections, environments, and globals [file] (Incompatible with any option except pretty)', null)
 		.option('-p, --pretty', 'Enable pretty-print while saving imported collections, environments, and globals', null)
-		.option('-H, --html [file]', 'Export a HTML report to a specified file [file]', null);
+		.option('-H, --html [file]', 'Export a HTML report to a specified file [file]', null)
+		.option('-W, --whiteScreen', 'Black text for white screen', null);
 
 	program.on('--help', function() {
 		console.log('  Newman is a command-line collection runner for Postman. You must specify a collection file or a collection URL to run newman');
@@ -195,6 +196,7 @@ function main() {
 	newmanOptions.strictSSL = !program.insecure;
 	newmanOptions.asLibrary = false;
 	newmanOptions.exitCode = !!program.exitCode;
+	newmanOptions.whiteScreen = !!program.whiteScreen;
 
 	if (program.collection) {
 		var collectionJson;

--- a/src/utilities/Globals.js
+++ b/src/utilities/Globals.js
@@ -35,6 +35,7 @@ var Globals = jsface.Class({
 		this.html = options.html || false;
 		this.responseEncoding = options.responseEncoding;
 		this.avoidRedirects = options.avoidRedirects;
+		this.whiteScreen = options.whiteScreen;
 	}
 });
 

--- a/src/utilities/Logger.js
+++ b/src/utilities/Logger.js
@@ -78,7 +78,12 @@ var Logger = jsface.Class([EventEmitter], {
 	},
 
 	normal: function(log) {
-		this._printMessage(log, color.white);
+		if (Globals.whiteScreen) {
+			this._printMessage(log, color.black);
+		}
+		else{
+			this._printMessage(log, color.white);
+		}
 		return this;
 	},
 


### PR DESCRIPTION
Feature request: #263 

## Colored output for white terminals

-W option to enable black color for normal text. 

![white-screen](https://cloud.githubusercontent.com/assets/6078423/10207954/61b6a54c-67ed-11e5-968a-9ed51986032b.png)