### PR TITLE
JUnit (XML) detail on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ docs/*
 .idea/*
 ./*.postman_collection
 ./*.globals
+.project
 
 #Custom files - to prevent inclusion in npm package
 .DS_Store

--- a/src/responseHandlers/AbstractResponseHandler.js
+++ b/src/responseHandlers/AbstractResponseHandler.js
@@ -3,7 +3,6 @@ var jsface = require('jsface'),
     Globals = require('../utilities/Globals'),
     path = require('path'),
     fs = require('fs'),
-    _ = require('lodash'),
     ErrorHandler = require('../utilities/ErrorHandler'),
     EventEmitter = require('../utilities/EventEmitter'),
     ResponseExporter = require('../utilities/ResponseExporter');

--- a/src/responseHandlers/AbstractResponseHandler.js
+++ b/src/responseHandlers/AbstractResponseHandler.js
@@ -39,31 +39,7 @@ var AbstractResponseHandler = jsface.Class([EventEmitter], {
     _printResponse: function (error, response, body, request) {
         if (Globals.outputFileVerbose) {
             var filepath = path.resolve(Globals.outputFileVerbose);
-            var requestData;
-
-            try {
-                requestData = JSON.stringify(_.object(_.pluck(request.transformed.data, "key"),
-                    _.pluck(request.transformed.data, "value")), null, 2);
-            }
-            catch (e) {
-                // Not JSON.
-                requestData = request.transformed.data;
-            }
-
-            var requestString = "-------------------------------------------------------------------------------------------\n" +
-                response.statusCode + " " +
-                response.stats.timeTaken + "ms" + " " +
-                request.name + " " + "[" + request.method + "] " +
-                request.transformed.url +
-                "\n------------------------------------------------------------" +
-                "\nRequest headers:\n" +
-                JSON.stringify(response.req._headers, undefined, 1) +
-                "\nRequest data:\n" +
-                requestData +
-                "\n------------------------------------------------------------" +
-                "\nResponse headers:\n" +
-                JSON.stringify(response.headers, undefined, 1) +
-                "\nResponse body:\n" + response.body + "\n";
+            var requestString = ResponseExporter.formatRequestResponseLog(request, response);
 
             fs.appendFileSync(filepath, requestString);
         }

--- a/src/utilities/ResponseExporter.js
+++ b/src/utilities/ResponseExporter.js
@@ -161,7 +161,7 @@ var ResponseExporter = jsface.Class({
 			// fully-qualified name: collection.folder.request
 			"fqName": request.collectionName +
 					(request.folderId && request.folderName ? '.' + request.folderName : '') +
-					'.' + request.name.replace(/\./, '_'),
+					'.' + request.name.replace(/\./g, '_'),
 			"url": request.url,
 			"totalTime": response.stats.timeTaken,
 			"request": request,

--- a/src/utilities/ResponseExporter.js
+++ b/src/utilities/ResponseExporter.js
@@ -5,7 +5,8 @@ var jsface       = require('jsface'),
 	ResultSummary= require('../models/ResultSummaryModel'),
 	path         = require('path'),
 	HtmlExporter = require('./HtmlExporter'),
-	fs           = require('fs');
+	fs           = require('fs'),
+	_            = require('lodash');
 
 /**
  * @class ResponseExporter

--- a/src/utilities/ResponseExporter.js
+++ b/src/utilities/ResponseExporter.js
@@ -158,6 +158,10 @@ var ResponseExporter = jsface.Class({
 		return {
 			"id": request.id,
 			"name": request.name,
+			// fully-qualified name: collection.folder.request
+			"fqName": request.collectionName +
+					(request.folderId && request.folderName ? '.' + request.folderName : '') +
+					'.' + request.name.replace(/\./, '_'),
 			"url": request.url,
 			"totalTime": response.stats.timeTaken,
 			"request": request,
@@ -329,7 +333,7 @@ var ResponseExporter = jsface.Class({
 					var failures = aggregateTestStats[testcaseName].failures;
 					totalFailuresForSuite += failures;
 					totalSuccessesForSuite += successes;
-					testcases += '\t\t<testcase name="' + _und.escape(testcaseName) + '" ' + (failures > 0 ? '' : '/') + '>\n';
+					testcases += '\t\t<testcase classname="' + _und.escape(suite.fqName) + '" name="' + _und.escape(testcaseName) + '" ' + (failures > 0 ? '' : '/') + '>\n';
 					if(failures > 0) {
 						testcases += '\t\t\t<failure>' + _und.escape(testcaseName) +
 									(iterations > 1 ? ' (failed ' + failures + '/' + iterations + ' iterations)' : '') +
@@ -341,7 +345,7 @@ var ResponseExporter = jsface.Class({
 
 				xml += '\t<testsuite name="' + _und.escape(suite.name) + '" id="' +
 					_und.escape(suite.id) + '" timestamp="' + timeStamp.toISOString() +
-					'" time="' + meanTime + ' ms" tests="' + tests + '" failures="'+totalFailuresForSuite+'">\n';
+					'" time="' + (meanTime/1000) + '" tests="' + tests + '" failures="'+totalFailuresForSuite+'">\n';
 
 				xml += testcases;
 

--- a/src/utilities/ResponseExporter.js
+++ b/src/utilities/ResponseExporter.js
@@ -160,6 +160,8 @@ var ResponseExporter = jsface.Class({
 			"name": request.name,
 			"url": request.url,
 			"totalTime": response.stats.timeTaken,
+			"request": request,
+			"response": response,
 			"responseCode": {
 				"code": response.statusCode,
 				"name": "",       // TODO: Fill these guys later on
@@ -329,9 +331,10 @@ var ResponseExporter = jsface.Class({
 					totalSuccessesForSuite += successes;
 					testcases += '\t\t<testcase name="' + _und.escape(testcaseName) + '" ' + (failures > 0 ? '' : '/') + '>\n';
 					if(failures > 0) {
-						testcases += '\t\t\t<failure><![CDATA[' + _und.escape(testcaseName) +
+						testcases += '\t\t\t<failure>' + _und.escape(testcaseName) +
 									(iterations > 1 ? ' (failed ' + failures + '/' + iterations + ' iterations)' : '') +
-									']]></failure>\n' +
+									'\n' + _und.escape(this.formatRequestResponseLog(suite.request, suite.response)) +
+									'\t\t\t</failure>\n' +
 									'\t\t</testcase>\n';
 					}
 				}, this);
@@ -367,6 +370,34 @@ var ResponseExporter = jsface.Class({
 			delay: 0,
 			synced: Globals.requestJSON.synced
 		};
+	},
+
+	formatRequestResponseLog: function(request, response) {
+		var requestData;
+
+		try {
+			requestData = JSON.stringify(_.object(_.pluck(request.transformed.data, "key"),
+				_.pluck(request.transformed.data, "value")), null, 2);
+		}
+		catch (e) {
+			// Not JSON.
+			requestData = request.transformed.data;
+		}
+
+		return "-------------------------------------------------------------------------------------------\n" +
+			response.statusCode + " " +
+			response.stats.timeTaken + "ms" + " " +
+			request.name + " " + "[" + request.method + "] " +
+			request.transformed.url +
+			"\n------------------------------------------------------------" +
+			"\nRequest headers:\n" +
+			JSON.stringify(response.req._headers, undefined, 1) +
+			"\nRequest data:\n" +
+			requestData +
+			"\n------------------------------------------------------------" +
+			"\nResponse headers:\n" +
+			JSON.stringify(response.headers, undefined, 1) +
+			"\nResponse body:\n" + response.body + "\n";
 	}
 });
 


### PR DESCRIPTION
On test failure, this appends the request and response headers + data to the `<failure>` tag of the failed test in the JUnit test report (XML). If viewing this report in Eclipse or Jenkins (with the JUnit plugin), it will show up under the "stack trace" area. The format is the same as in https://github.com/postmanlabs/newman/pull/218.

I've also fixed the `time` property and added the `classname` property in the shape of "collection.folder.request". This is mainly beneficial when viewing in Jenkins, so that it can organize the test links into a hierarchy (really useful when you have thousands of tests).