### PR TITLE
Add port and protocol for 'aws4' request inputs.

### DIFF
--- a/src/utilities/HelperProcessor.js
+++ b/src/utilities/HelperProcessor.js
@@ -56,6 +56,8 @@ var HelperProcessor = jsface.Class({
         }
         var signedParams = aws4.sign({
             host: parsedURL.hostname,
+            protocol: parsedURL.protocol,
+            port: parsedURL.port,
             path: parsedURL.path,
             service: properties.serviceName || 'execute-api',
             region: properties.region,


### PR DESCRIPTION
A patch related to this is pending upstream
   - https://github.com/mhart/aws4/pull/21

With this change it would enable `newman` tool to be used
with AWS S3 compatible servers implementing AWS Signature
Version '4'.