### PR TITLE
awsSignv4: Collection properties should be 'service' not 'serviceName'

### DIFF
--- a/src/utilities/HelperProcessor.js
+++ b/src/utilities/HelperProcessor.js
@@ -57,7 +57,7 @@ var HelperProcessor = jsface.Class({
         var signedParams = aws4.sign({
             host: parsedURL.hostname,
             path: parsedURL.path,
-            service: properties.serviceName || 'execute-api',
+            service: properties.service || 'execute-api',
             region: properties.region,
             method: request.method,
             body: body,


### PR DESCRIPTION
Collection properties for helper attributes lists 'service' not 'serviceName'.
```
"helperAttributes": {
	"id": "awsSigV4",
...
...
	"service": "s3",
	"auto": true,
	"saveHelper": true
},
```

This fixes a bug where 'execute-api' is used as part of Signature calculation
and failing.