### PR TITLE
Add an option (-S, --noTestSymbols) to disable symbols in test output…

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Misc.:
 -s, --stopOnError           Stops the runner when a test case fails
 -j, --noSummary             Doesn't show the summary for each iteration
 -C, --noColor               Disable colored output
+-S, --noTestSymbols         Disable symbols in test output and use PASS|FAIL instead
 -k, --insecure              Disable strict ssl
 -l, --tls                   Use TLSv1
 -x, --exitCode              Continue running tests even after a failure, but exit with code=1

--- a/bin/newman
+++ b/bin/newman
@@ -39,6 +39,7 @@ function parseArguments() {
         .option('-j, --noSummary', "Doesn't show the summary for each iteration", null)
         .option('-n, --number [number]', 'Define the number of iterations to run', null)
         .option('-C, --noColor', 'Disable colored output', null)
+        .option('-S, --noTestSymbols', 'Disable symbols in test output and use PASS|FAIL instead', null)
         .option('-k, --insecure', 'Disable strict ssl', null)
         .option('-l, --tls', 'Use TLSv1', null)
         .option('-N, --encoding [encoding-type]', 'Specify an encoding for the response. Supported values are ascii,utf8,utf16le,ucs2,base64,binary,hex', null)
@@ -203,6 +204,7 @@ function main() {
 
     newmanOptions.stopOnError = !!program.stopOnError;
     newmanOptions.noColor = !!program.noColor;
+    newmanOptions.noTestSymbols = !!program.noTestSymbols;
     newmanOptions.strictSSL = !program.insecure;
     newmanOptions.asLibrary = false;
     newmanOptions.exitCode = !!program.exitCode;

--- a/src/utilities/Globals.js
+++ b/src/utilities/Globals.js
@@ -27,6 +27,7 @@ var Globals = jsface.Class({
         this.dataJson = [];
         this.stopOnError = options.stopOnError;
         this.noColor = options.noColor;
+        this.noTestSymbols = options.noTestSymbols;
         this.asLibrary = options.asLibrary;
         this.strictSSL = options.strictSSL || true;
         this.exitCode = 0;

--- a/src/utilities/Logger.js
+++ b/src/utilities/Logger.js
@@ -98,12 +98,20 @@ var Logger = jsface.Class([EventEmitter], {
     },
 
     testCaseSuccess: function (log) {
-        this.success("    " + Symbols.symbols.ok + log + "\n");
+        var msg = Symbols.symbols.ok;
+        if (Globals.noTestSymbols) {
+            msg = "PASS ";
+        }
+        this.success("    " + msg + log + "\n");
         return this;
     },
 
     testCaseError: function (log) {
-        this.error("    " + Symbols.symbols.err + log + "\n");
+        var msg = Symbols.symbols.err;
+        if (Globals.noTestSymbols) {
+            msg = "FAIL ";
+        }
+        this.error("    " + msg + log + "\n");
         if (Globals.stopOnError) {
             if (Globals.asLibrary) {
                 this.emit('iterationRunnerOver', 1);


### PR DESCRIPTION
… and use PASS and FAIL instead. Fixes #344.