### PR TITLE
Add help text for current default request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Basic setup:
 
 Request options:
 -y, --delay [number]            Specify a delay (in ms) between requests [number]
--r, --requestTimeout [number]   Specify a request timeout (in ms) for a request
+-r, --requestTimeout [number]   Specify a request timeout (in ms) for a request (Defaults to 15000 if not set)
 
 Misc.:
 -s, --stopOnError           Stops the runner when a test case fails

--- a/bin/newman
+++ b/bin/newman
@@ -33,7 +33,7 @@ function parseArguments() {
         .option('-g, --global [file]', 'Specify a Postman globals file [file]', null)
         .option('-G, --exportGlobals [file]', 'Specify an output file to dump Globals before exiting [file]', null)
         .option('-y, --delay [number]', "Specify a delay (in ms) between requests", null)
-        .option('-r, --requestTimeout [number]', "Specify a request timeout (in ms) for requests", null)
+        .option('-r, --requestTimeout [number]', "Specify a request timeout (in ms) for requests (Defaults to 15000 if not set)", null)
         .option('-R, --avoidRedirects', "Prevents Newman from automatically following redirects", null)
         .option('-s, --stopOnError', "Stops the runner with code=1 when a test case fails", null)
         .option('-j, --noSummary', "Doesn't show the summary for each iteration", null)


### PR DESCRIPTION
Just an idea, as a recent experience in our test environment bamboozled us by not realizing the difference in the request timeout between postman and newman (programatically set in CollectionRunner execute() towards the bottom). This value hasn't changed since April 13th of last year (0d6cf54dae831fd9ce3ce829ee282d0f7ecfd1ac), maybe documentation matching it may be helpful to some?