### PR TITLE
fix: underscore version is too loose

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "request": "2.72.0",
     "sugar": "1.3.9",
     "tv4": "^1.1.9",
-    "underscore": "1.x.x",
+    "underscore": ">=1.6.0 <2",
     "unirest": "^0.4.0",
     "xml2js": "^0.4.5"
   },


### PR DESCRIPTION
`_.now` not supported prior to v1.6

This is generally going to be ok for global installs but if you want newman installed locally in a project, this can lead to problems if an earlier version of underscore is already installed