### PR TITLE
log verbose output file in the end of execution

### DIFF
--- a/src/responseHandlers/AbstractResponseHandler.js
+++ b/src/responseHandlers/AbstractResponseHandler.js
@@ -45,7 +45,7 @@ var AbstractResponseHandler = jsface.Class([EventEmitter], {
                 requestData = _.isArray(request.transformed.data) ? JSON.stringify(_.object(_.pluck(request.transformed.data, "key"),
                     _.pluck(request.transformed.data, "value")), null, 2) : request.transformed.data;
             }
-            catch (e) {
+            catch (err) {
                 // Not JSON.
                 requestData = request.transformed.data;
             }
@@ -65,7 +65,12 @@ var AbstractResponseHandler = jsface.Class([EventEmitter], {
                 JSON.stringify(response.headers, undefined, 1) +
                 "\nResponse body:\n" + response.body + "\n";
 
-            fs.appendFileSync(filepath, requestString);
+            try {
+                fs.appendFileSync(filepath, requestString);
+            }
+            catch (err) {
+                log.error("Error writing to file. Try using sudo. Error: " + (err.stack || err));
+            }
         }
 
         if (response.statusCode >= 200 && response.statusCode < 300) {

--- a/src/utilities/HtmlExporter.js
+++ b/src/utilities/HtmlExporter.js
@@ -1,5 +1,4 @@
 var jsface = require('jsface'),
-    Globals = require('./Globals'),
     log = require('./Logger'),
     fs = require('fs');
 

--- a/src/utilities/HtmlExporter.js
+++ b/src/utilities/HtmlExporter.js
@@ -17,8 +17,8 @@ var HtmlExporter = jsface.Class({
         try {
             fs.writeFileSync(filepath, template(resultObj));
         }
-        catch (e) {
-            log.error("Error writing to file. Try using sudo. Error: " + (e.stack || e));
+        catch (err) {
+            log.error("Error writing to file. Try using sudo. Error: " + (err.stack || err));
         }
     }
 });

--- a/src/utilities/HtmlExporter.js
+++ b/src/utilities/HtmlExporter.js
@@ -10,14 +10,12 @@ var jsface = require('jsface'),
 var HtmlExporter = jsface.Class({
     $singleton: true,
     templates: null,
-    generateHTML: function (resultObj) {
+    generateHTML: function (filepath, resultObj) {
         var template;
         //Always use existing file
         template = require('../templates/htmlResponseTemplate');
-        var htmlPath = Globals.html;
         try {
-            fs.writeFileSync(htmlPath, template(resultObj));
-            log.note("\nHTML Report written to: " + htmlPath + "\n");
+            fs.writeFileSync(filepath, template(resultObj));
         }
         catch (e) {
             log.error("Error writing to file. Try using sudo. Error: " + (e.stack || e));

--- a/src/utilities/ResponseExporter.js
+++ b/src/utilities/ResponseExporter.js
@@ -251,15 +251,25 @@ var ResponseExporter = jsface.Class({
         }
 
         if (Globals.outputFile) {
-            filepath = path.resolve(Globals.outputFile);
-            fs.writeFileSync(filepath, JSON.stringify(exportVariable, null, 4));
-            log.note("\nOutput Log written to: " + filepath + "\n");
+            try {
+                filepath = path.resolve(Globals.outputFile);
+                fs.writeFileSync(filepath, JSON.stringify(exportVariable, null, 4));
+                log.note("\nOutput Log written to: " + filepath + "\n");
+            }
+            catch (err) {
+                log.error("Error writing to file. Try using sudo. Error: " + (err.stack || err));
+            }
         }
 
         if (Globals.testReportFile) {
-            filepath = path.resolve(Globals.testReportFile);
-            fs.writeFileSync(filepath, this._createJunitXML());
-            log.note("\nJunit XML file written to: " + filepath + "\n");
+            try {
+                filepath = path.resolve(Globals.testReportFile);
+                fs.writeFileSync(filepath, this._createJunitXML());
+                log.note("\nJunit XML file written to: " + filepath + "\n");
+            }
+            catch (err) {
+                log.error("Error writing to file. Try using sudo. Error: " + (err.stack || err));
+            }
         }
 
         if (Globals.html) {

--- a/src/utilities/ResponseExporter.js
+++ b/src/utilities/ResponseExporter.js
@@ -244,16 +244,21 @@ var ResponseExporter = jsface.Class({
             result.meanResponseTime = parseInt(result.totalTime, 10) / exportVariable.count;
         });
 
+        if (Globals.outputFileVerbose) {
+            var filepath = path.resolve(Globals.outputFileVerbose);
+            log.note("\nOutput Verbose Log: " + filepath + "\n");
+        }
+
         if (Globals.outputFile) {
             var filepath = path.resolve(Globals.outputFile);
             fs.writeFileSync(filepath, JSON.stringify(exportVariable, null, 4));
-            log.note("\n\nOutput Log: " + filepath + "\n");
+            log.note("\nOutput Log: " + filepath + "\n");
         }
 
         if (Globals.testReportFile) {
             var outputpath = path.resolve(Globals.testReportFile);
             fs.writeFileSync(outputpath, this._createJunitXML());
-            log.note("\n\nJunit XML file written to: " + outputpath + "\n");
+            log.note("\nJunit XML file written to: " + outputpath + "\n");
         }
 
         if (Globals.html) {

--- a/src/utilities/ResponseExporter.js
+++ b/src/utilities/ResponseExporter.js
@@ -237,6 +237,7 @@ var ResponseExporter = jsface.Class({
      * @memberOf ResponseExporter
      */
     exportResults: function () {
+        var filepath;
         var exportVariable = this._createExportVariable();
 
         //calculate mean time
@@ -245,24 +246,26 @@ var ResponseExporter = jsface.Class({
         });
 
         if (Globals.outputFileVerbose) {
-            var filepath = path.resolve(Globals.outputFileVerbose);
-            log.note("\nOutput Verbose Log: " + filepath + "\n");
+            filepath = path.resolve(Globals.outputFileVerbose);
+            log.note("\nOutput Verbose Log written to: " + filepath + "\n");
         }
 
         if (Globals.outputFile) {
-            var filepath = path.resolve(Globals.outputFile);
+            filepath = path.resolve(Globals.outputFile);
             fs.writeFileSync(filepath, JSON.stringify(exportVariable, null, 4));
-            log.note("\nOutput Log: " + filepath + "\n");
+            log.note("\nOutput Log written to: " + filepath + "\n");
         }
 
         if (Globals.testReportFile) {
-            var outputpath = path.resolve(Globals.testReportFile);
-            fs.writeFileSync(outputpath, this._createJunitXML());
-            log.note("\nJunit XML file written to: " + outputpath + "\n");
+            filepath = path.resolve(Globals.testReportFile);
+            fs.writeFileSync(filepath, this._createJunitXML());
+            log.note("\nJunit XML file written to: " + filepath + "\n");
         }
 
         if (Globals.html) {
-            HtmlExporter.generateHTML(exportVariable);
+            filepath = path.resolve(Globals.html);
+            HtmlExporter.generateHTML(filepath, exportVariable);
+            log.note("\nHTML Report written to: " + filepath + "\n");
         }
     },
 


### PR DESCRIPTION
Example log screenshot:
<img width="446" alt="screen shot 2016-06-03 at 13 31 25" src="https://cloud.githubusercontent.com/assets/2770895/15792049/b6f71d70-298f-11e6-96c7-9aa2618f7bba.png">

Closes #414