### PR TITLE
Fixed Global Environment Variable Usage to Use the New Format

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
             integTest: {
                 exec: 'node bin/newman -c tests/integ_tests/tc2.json -d tests/integ_tests/d2.json -e tests/integ_tests/e2.json -s && ' +
                 'node bin/newman -c tests/integ_tests/tc3.json -d tests/integ_tests/d3.json -e tests/integ_tests/e3.json -g tests/integ_tests/g3.json -s && ' +
+                'node bin/newman -c tests/integ_tests/tc3.json -d tests/integ_tests/d3.json -e tests/integ_tests/e3.json -g tests/integ_tests/g4.json -s && ' +
                 'node bin/newman -c tests/integ_tests/tc4.json -s && ' +
                 'node bin/newman -c tests/integ_tests/randomIntC.json -s && ' +
                 'node bin/newman -c tests/integ_tests/semicolon_tests.json -s && ' +

--- a/src/runners/IterationRunner.js
+++ b/src/runners/IterationRunner.js
@@ -119,9 +119,12 @@ var IterationRunner = jsface.Class([Options, EventEmitter], {
             Globals.envJson.values = [];
         }
 
-        //add the globals (globalJSON, overriden by envJson)
-        if (this.globalVars && this.globalVars.length) {
-            Globals.globalJson.values = this.globalVars;//Helpers.augmentDataArrays(this.globalVars,Globals.envJson.values);
+        if (this.globalVars && this.globalVars.values.length) {
+            Globals.globalJson.values = this.globalVars.values; //Helpers.augmentDataArrays(this.globalVars.values, Globals.envJson.values);
+        }
+        // Backwards support for old format
+        else if (this.globalVars && this.globalVars.length) {
+            Globals.globalJson.values = this.globalVars;
         }
         else {
             Globals.globalJson = { values: [] };

--- a/src/runners/IterationRunner.js
+++ b/src/runners/IterationRunner.js
@@ -119,7 +119,7 @@ var IterationRunner = jsface.Class([Options, EventEmitter], {
             Globals.envJson.values = [];
         }
 
-        if (this.globalVars && this.globalVars.values.length) {
+        if (this.globalVars && this.globalVars.values && this.globalVars.values.length) {
             Globals.globalJson.values = this.globalVars.values; //Helpers.augmentDataArrays(this.globalVars.values, Globals.envJson.values);
         }
         // Backwards support for old format

--- a/tests/integ_tests/g4.json
+++ b/tests/integ_tests/g4.json
@@ -1,0 +1,60 @@
+{
+	"id": "b8dc56e7-7612-3f36-2fff-308c845a74c4",
+	"name": "testGlobals",
+	"values": [
+		{
+			"key": "full_global_url",
+			"value": "http://localhost:5000/get",
+			"type": "text",
+			"name": "full_global_url",
+			"enabled": true
+		},
+		{
+			"key": "global_resource_get",
+			"value": "/get",
+			"type": "text",
+			"name": "global_resource_get",
+			"enabled": true
+		},
+		{
+			"key": "Global Foo",
+			"value": "Global Bar",
+			"type": "text",
+			"name": "Global Foo",
+			"enabled": true
+		},
+		{
+			"key": "Global Phew",
+			"value": "Global Works",
+			"type": "text",
+			"name": "Global Phew",
+			"enabled": true
+		},
+		{
+			"key": "global",
+			"value": "global1",
+			"type": "text",
+			"name": "global",
+			"enabled": true
+		},
+		{
+			"key": "env",
+			"value": "global1",
+			"type": "text",
+			"name": "env",
+			"enabled": true
+		},
+		{
+			"key": "data",
+			"value": "global1",
+			"type": "text",
+			"name": "data",
+			"enabled": true
+		}
+	],
+	"timestamp": 1405183029928,
+	"synced": false,
+	"syncedFilename": "",
+	"team": null,
+	"isDeleted": false
+}


### PR DESCRIPTION
The g3.json intergration test is 2 years old so I assume the format is wrong considering the errors that I am getting using the exported global environment variables on the latest version of postman.

I kept support for the old format and added a new test for the new format.