### PR TITLE
Run summary

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -130,7 +130,7 @@
     "comma-spacing": [2, { "before": false, "after": true }],
     "comma-style": ["error", "last"],
     "computed-property-spacing": "error",
-    "consistent-this": "warn",
+    // "consistent-this": "warn",
     "eol-last": "error",
     "func-names": "off",
     "func-style": "off",

--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ newman.run({
     globals: {
         myGlobalVar: 'myGlobalValue'
     }
-}, function (err) {
-    console.log('Collection run complete!');
+}, function (err, summary) {
+    // in case of an error we log the error
+    err &&console.error('There was an error running your collection: ', err);
 
-    if (err) {
-        console.error('There was an error running your collection: ', err) ;
-    }
+    // we also log the summary object to see the result of the run
+    summary && console.dir(summary, {colors: true, depth: 3});
+    console.log('Collection run complete!');
 });
 ```

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -35,9 +35,7 @@ module.exports.get = (overrides, options, callback) => {
         }
 
         options = _.mergeWith({}, options, overrides, (dest, src) => {
-            if (src === null) {  // do not override original value if the new value is "null".
-                return dest;
-            }
+            return (src === null) ? dest : undefined;
         });
 
         return callback(null, options);

--- a/lib/reporters/cli.js
+++ b/lib/reporters/cli.js
@@ -1,6 +1,7 @@
 var colors = require('colors/safe'),
     format = require('util').format,
     Table = require('cli-table2'),
+
     print,
     padLeft;
 
@@ -51,8 +52,7 @@ print._indentPrefix = '';
 // };
 
 module.exports = function PostmanCLIReporter (emitter, options) {
-    var currentGroup = options.collection,
-        failures = [];
+    var currentGroup = options.collection;
 
     emitter.on('start', function () {
         print('%s\n\n%s\n', colors.reset('newman'), colors.bold(currentGroup.name));
@@ -80,17 +80,6 @@ module.exports = function PostmanCLIReporter (emitter, options) {
         print('↳ %s\n', colors.reset(item.name));
     });
 
-    emitter.on('prerequest', function (err, cur, executions, item) {
-        executions && executions.forEach(function (execution) {
-            var error = execution.error;
-
-            if (error) {
-                failures.push([(item.name || item.id), 'PrerequestScript~' + error.name, error.message]);
-                print(colors.red.bold('%s⠄ %s in prerequest script\n'), padLeft(failures.length, 3, ' '), error.name);
-            }
-        });
-    });
-
     emitter.on('beforeRequest', function (err, cur, request) {
         print('  %s %s ', colors.gray(request.method), colors.gray(request.url)).wait();
     });
@@ -100,72 +89,61 @@ module.exports = function PostmanCLIReporter (emitter, options) {
         print(colors.gray('[%d, %dms]') + '\n', response.code, response.responseTime);
     });
 
-    emitter.on('test', function (err, cur, executions, item) {
-        executions && executions.forEach(function (execution) {
-            var tests = execution.result && execution.result.globals && execution.result.globals.tests || {}, // phew
-                error = execution.error;
+    emitter.on('script', function (err, cur, execution, script, event) {
+        err && print(colors.red.bold('%s⠄ %s in %s script\n'), padLeft(this.summary.failures.length, 3, ' '), err.name, event &&
+            event.listen || '<unknown-script>');
+    });
 
-            Object.keys(tests).forEach(function (testName) {
-                var passed = Boolean(tests[testName]);
+    emitter.on('assertion', function (err, cur, assertion) {
+        var passed = !err;
 
-                // increment failure count
-                !passed && failures.push([(item.name || item.id), 'TestFail', testName]);
-
-                print('%s %s\n', passed ? colors.green('  ✔ ') : colors.red.bold(padLeft(failures.length, 3, ' ') + '⠄'),
-                    passed ? colors.gray(testName) : colors.red.bold(testName));
-            });
-
-            if (error) {
-                failures.push([(item.name || item.id), 'TestScript~' + error.name, error.message]);
-                print(colors.red.bold('%s⠄ %s in test script\n'), padLeft(failures.length, 3, ' '), error.name);
-            }
-        });
+        print('%s %s\n', passed ? colors.green('  ✔ ') : colors.red.bold(padLeft(this.summary.failures.length, 3, ' ') + '⠄'),
+            passed ? colors.gray(assertion) : colors.red.bold(assertion));
     });
 
     emitter.on('done', function () {
-        if (failures.length) {
-            var failureFaceValue = Number(failures.length.toString().length),
-                size = require('window-size'),
-                colWidths = [],
-                failureTable,
-                i,
-                ii;
+        var summary = this.summary,
+            failures = summary.failures,
+            failureFaceValue = Number(failures.length.toString().length),
+            size = require('window-size'),
+            colWidths = [],
+            failureTable,
+            i,
+            ii;
 
-            for (i = 0, ii = failures.length; i < ii; i++) {
-                failures[i].unshift({
-                    hAlign: 'right',
-                    content: padLeft(Number(i + 1), failureFaceValue).toString()
-                });
-            }
-            print._indentPrefix = '';
-
-            if (size.width && (size.width > 20)) {
-                colWidths[0] = failureFaceValue + 2;
-                colWidths[1] = parseInt((size.width - colWidths[0]) * 0.15, 10);
-                colWidths[2] = parseInt((size.width - colWidths[0]) * 0.25, 10);
-                colWidths[3] = parseInt(size.width - (colWidths[0] + colWidths[1] + colWidths[2] + 6), 10);
-            }
-            else {
-                colWidths = undefined;
-            }
-
-            failureTable = new Table({
-                head: [{
-                    hAlign: 'right',
-                    content: colors.red('#')
-                }, colors.red.underline('Request'), colors.red.underline('Failure'),
-                    colors.red.underline('Details')],
-                chars: { 'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' },
-                wordWrap: true,
-                colWidths: colWidths
-            });
-
-            for (i = 0, ii = failures.length; i < ii; i++) {
-                failureTable.push(failures[i]);
-            }
-
-            print('\n' + failureTable.toString() + '\n');
-
+        if (!failures.length) {
+            return;
         }
+
+        if (size.width && (size.width > 20)) {
+            colWidths[0] = failureFaceValue + 2;
+            colWidths[1] = parseInt((size.width - colWidths[0]) * 0.15, 10);
+            colWidths[2] = parseInt((size.width - colWidths[0]) * 0.25, 10);
+            colWidths[3] = parseInt(size.width - (colWidths[0] + colWidths[1] + colWidths[2] + 6), 10);
+        }
+        else {
+            colWidths = undefined;
+        }
+
+        failureTable = new Table({
+            head: [{
+                hAlign: 'right',
+                content: colors.red('#')
+            }, colors.red.underline('Request'), colors.red.underline('Failure'),
+                colors.red.underline('Details')],
+            chars: { 'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' },
+            wordWrap: true,
+            colWidths: colWidths
+        });
+
+        for (i = 0, ii = failures.length; i < ii; i++) {
+            failureTable.push([{
+                hAlign: 'right',
+                content: padLeft(Number(i + 1), failureFaceValue).toString()
+            }, failures[i].source, failures[i].error.name, failures[i].error.message]);
+        }
+
+        print._indentPrefix = '';
+        print('\n' + failureTable.toString() + '\n');
     });
 };

--- a/lib/run.js
+++ b/lib/run.js
@@ -90,8 +90,8 @@ module.exports = function (options, callback) {
 
         // override the `done` event to fire the end callback
         callbacks.done = function (err) { // @todo - do some meory cleanup here?
-            callback(err);
-            emitter.emit('done', err); // we now trigger the actual done event which we had overridden
+            emitter.emit('done', err, emitter.summary); // we now trigger the actual done event which we had overridden
+            callback(err, emitter.summary);
         };
 
         // initialise all the reporters

--- a/lib/run.js
+++ b/lib/run.js
@@ -17,7 +17,7 @@ var _ = require('lodash'),
      * @returns {Object}
      */
     extractVariables = function (source, type) {
-        if (!_.isObject(source && (source = source[type]))) { return; } // get hold of the object that holds ariable
+        if (!_.isObject(source && (source = source[type]))) { return undefined; } // extract object that holds variable
 
         // ensure we unbox the JSON if it comes from cloud-api or similar sources
         !source.values && _.isObject(source[type]) && (source = source[type]);

--- a/lib/run.js
+++ b/lib/run.js
@@ -47,17 +47,6 @@ module.exports = function (options, callback) {
     options = _.isObject(options) ? _.clone(options) : {}; // we initialise this as object to avoid needless validations
     !_.isFunction(callback) && (callback = _.noop);
 
-    var emitter = new EventEmitter(), // @todo: create a new inherited constructor
-        runner = new runtime.Runner(),
-        environment,
-        globals;
-
-    // ensure that the collection option is present before starting a run
-    if (!_.isObject(options.collection)) {
-        callback(new Error('newman: expecting a collection to run'));
-        return emitter;
-    }
-
     // create a collection in case it is not one. user can send v2 JSON as a source and that will be converted
     // to a collection
     if (_.isPlainObject(options.collection) && !Collection.isCollection(options.collection)) {
@@ -70,6 +59,15 @@ module.exports = function (options, callback) {
         environment: extractVariables(options, 'environment'),
         globals: extractVariables(options, 'globals')
     });
+
+    var emitter = new EventEmitter(), // @todo: create a new inherited constructor
+        runner = new runtime.Runner();
+
+    // ensure that the collection option is present before starting a run
+    if (!_.isObject(options.collection)) {
+        callback(new Error('newman: expecting a collection to run'));
+        return emitter;
+    }
 
     options.collection && runner.run(options.collection, {
         abortOnError: options.abortOnError, // todo: could be a better name, especially in the CLI.

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,6 +1,7 @@
 var _ = require('lodash'),
     EventEmitter = require('eventemitter3'),
     runtime = require('postman-runtime'),
+    RunSummary = require('./summary'),
     Collection = require('postman-collection').Collection,
 
     runtimeEvents = ['start', 'beforeIteration', 'beforeItem', 'beforePrerequest', 'prerequest',
@@ -68,6 +69,9 @@ module.exports = function (options, callback) {
         callback(new Error('newman: expecting a collection to run'));
         return emitter;
     }
+
+    // store summary object and other relevant information inside the emitter
+    emitter.summary = new RunSummary(emitter, options);
 
     options.collection && runner.run(options.collection, {
         abortOnError: options.abortOnError, // todo: could be a better name, especially in the CLI.

--- a/lib/run.js
+++ b/lib/run.js
@@ -5,7 +5,29 @@ var _ = require('lodash'),
 
     runtimeEvents = ['start', 'beforeIteration', 'beforeItem', 'beforePrerequest', 'prerequest',
         'beforeRequest', 'request', 'beforeTest', 'test', 'item', 'iteration', 'beforeScript', 'script', 'console',
-        'exception', 'done'];
+        'exception', 'done'],
+
+    /**
+     * Accepts an object, and extracts the property inside an object which is supposed to contain a list of variables
+     *
+     * @param {Object} source
+     * @param {String} type - "environment" or "globals", etc
+     *
+     * @returns {Object}
+     */
+    extractVariables = function (source, type) {
+        if (!_.isObject(source && (source = source[type]))) { return; } // get hold of the object that holds ariable
+
+        // ensure we unbox the JSON if it comes from cloud-api or similar sources
+        !source.values && _.isObject(source[type]) && (source = source[type]);
+
+        // ensure we handle environment sent in form of array of values
+        (source.name && _.isArray(source.values)) && (source = source.values);
+
+        // we ensure that environment passed as array is converted to plain object. runtime does this too, but we do it
+        // here for consistency of options passed to reporters
+        return _.isArray(source) ? _(source).keyBy('key').mapValues('value').value() : source;
+    };
 
 /**
  * @param {Object} options
@@ -42,35 +64,18 @@ module.exports = function (options, callback) {
         options.collection = new Collection(options.collection);
     }
 
-    // Create a Plain object from environments
-    options.environment && (environment = (function (rawEnv) {
-        // Cloud API
-        rawEnv.environment && (rawEnv = rawEnv.environment);
-
-        // Exported files
-        if (rawEnv.values) {
-            return _.object(_.map(rawEnv.values, 'key'), _.map(rawEnv.values, 'value'));
-        }
-
-        // Plain object
-        return rawEnv;
-    }(options.environment)));
-
-    options.globals && (globals = function (rawGlobals) {
-        // Cloud API
-        rawGlobals.globals && (rawGlobals = rawGlobals.globals);
-
-        // Exported global files
-        _.isArray(globals) && (globals = _.object(_.map(rawGlobals, 'key'), _.map(rawGlobals, 'value')));
-
-        return globals;
+    // we sanitise the environment and globals and mutate the original otions so that subsequent consumers do not need
+    // to do this again
+    _.assign(options, {
+        environment: extractVariables(options, 'environment'),
+        globals: extractVariables(options, 'globals')
     });
 
     options.collection && runner.run(options.collection, {
         abortOnError: options.abortOnError, // todo: could be a better name, especially in the CLI.
         iterationCount: options.iterationCount,
-        environment: environment,
-        globals: globals
+        environment: options.environment,
+        globals: options.globals
     }, function (err, run) {
         var callbacks = {},
             // ensure that the reporter option type polymorphism is handled

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -5,6 +5,19 @@ var _ = require('lodash'),
 /**
  * @constructor
  * @param {EventEmitter} emitter
+ *
+ * @note
+ * The summary object looks somewhat like the following:
+ * (
+ *   iterations: { total: 1, pending: 0, failed: 0 },
+ *   items: { total: 23, pending: 0, failed: 0 },
+ *   scripts: { total: 24, pending: 0, failed: 3 },
+ *   prerequests: { total: 23, pending: 0, failed: 0 },
+ *   requests: { total: 23, pending: 0, failed: 0 },
+ *   tests: { total: 23, pending: 0, failed: 0 },
+ *   assertions: { total: 62, pending: 0, failed: 8 },
+ *   failures: [{ source: 'DigestAuth Request', error: [Object] }]
+ * }
  */
 RunSummary = function RunSummary (emitter) {
     // keep a copy of this instance since, we need to refer to this from various events

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -1,0 +1,119 @@
+var _ = require('lodash'),
+    CollectionItem = require('postman-collection').Item,
+    RunSummary;
+
+/**
+ * @constructor
+ * @param {EventEmitter} emitter
+ */
+RunSummary = function RunSummary (emitter) {
+    // keep a copy of this instance since, we need to refer to this from various events
+    var summary = this,
+        // execute `trackEvent` function to attach listeners and update the pass, fail and pending count of each event
+        trackers = RunSummary.trackEvent(['iteration', 'item', 'script', 'prerequest', 'request', 'test', 'assertion'],
+            emitter),
+        // maintain a list of failures for this summary
+        failures = trackers.failures;
+
+
+    // store the trackers and failures in the summary object itself
+    _.assign(summary, trackers.counters, {
+        failures: failures
+    });
+
+    // mark the point when the run started
+    // also mark the point when run completed and also store error if needed
+    emitter.on('start', function () { summary.started = Date.now(); });
+    emitter.on('done', function (err) {
+        summary.completed = Date.now();
+        err && (summary.error = err);
+    });
+
+    // generate pseudo assertion events since runtime does not trigger assertion events yet.
+    // without this, all reporters would needlessly need to extract assertions and create an error object
+    // out of it
+    emitter.on('script', function (err, cur, execution, script, event, item) {
+        // we iterate on each test asserion to trigger an evemt. during this, we create a pseudo error object
+        // for the assertion
+        _.each(_.get(execution, 'globals.tests'), function (passed, assertion) {
+            emitter.emit('assertion', assertionError = passed ? null : {
+                name: 'TestFailure',
+                message: assertion
+            }, cur, assertion, event, item);
+        });
+    });
+};
+
+/**
+ * Sets up common listeners for a set of events, which tracks how many times they were executed and records the ones
+ * which had an error passed as first argument
+ *
+ * @param {[type]} events [description]
+ * @param {[type]} emitter [description]
+ *
+ * @returns {[type]} [description]
+ */
+RunSummary.trackEvent = function (events, emitter) {
+    var trackers = {
+        counters: {},
+        failures: []
+    };
+
+    _.each(events, function (event) {
+        var tracker = trackers.counters[event + 's'] = {
+            total: 0,
+            pending: 0,
+            failed: 0
+        };
+
+        emitter.on(_.camelCase('before-' + event), function (err) {
+            var item = RunSummary.sniffItemFromArgs(arguments);
+            tracker.pending += 1;
+
+            err && trackers.failures.push({
+                source: item ? (item.name || item.id) : '<unknown>',
+                at: _.camelCase('before-' + event),
+                error: err
+            });
+        });
+
+        emitter.on(event, function (err) {
+            var item = RunSummary.sniffItemFromArgs(arguments);
+
+            // check pending so that, it does not negate for items that do not have a `before` counterpart
+            tracker.pending && (tracker.pending -= 1);
+            tracker.total += 1; // increment total
+
+            if (err) { // on error push it to the failure array
+                tracker.failed += 1;
+                trackers.failures.push({
+                    source: item ? (item.name || item.id) : '<unknown>',
+                    at: event,
+                    error: err
+                });
+            }
+        });
+    });
+
+    return trackers;
+};
+
+/**
+ * Goes through an array and returns the first instance of an object which is a PostmanItem
+ *
+ * @param {Array} args
+ * @returns {PostmanItem}
+ */
+RunSummary.sniffItemFromArgs = function (args) {
+    var count;
+
+    if (!(args && (count = args.length))) { return; }
+
+    while (count--) {
+        if (args[count] && CollectionItem.isItem(args[count])) {
+            return args[count];
+        }
+    }
+};
+
+module.exports = RunSummary;

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -49,7 +49,7 @@ RunSummary = function RunSummary (emitter) {
         // we iterate on each test asserion to trigger an evemt. during this, we create a pseudo error object
         // for the assertion
         _.each(_.get(execution, 'globals.tests'), function (passed, assertion) {
-            emitter.emit('assertion', assertionError = passed ? null : {
+            emitter.emit('assertion', passed ? null : {
                 name: 'TestFailure',
                 message: assertion
             }, cur, assertion, event, item);


### PR DESCRIPTION
`done` callback receives summary which looks somewhat like:

```
(
   iterations: { total: 1, pending: 0, failed: 0 },
   items: { total: 23, pending: 0, failed: 0 },
   scripts: { total: 24, pending: 0, failed: 3 },
   prerequests: { total: 23, pending: 0, failed: 3 },
   requests: { total: 23, pending: 0, failed: 0 },
   tests: { total: 23, pending: 0, failed: 0 },
   assertions: { total: 62, pending: 0, failed: 8 },
   failures: [{ source: 'DigestAuth Request', error: [Object] }]
}
```

Also adds `assertion` pseudo event and refactors CLI reporter to use the same.

Pending:
- Using the summary object to generate non failing summary like total requests, etc in CLI reporter
- Adding better location identification to failures in summary (such as line no, iteration, etc
- Doing row separation for multi-iteration report or a new reporting structure altogeher.
- CLI options to turn off reporting or summary or both