### PR TITLE
emit as single object argument

### DIFF
--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -30,17 +30,17 @@ module.exports = function PostmanCLIReporter (emitter, options) {
         print.lf('%s\n\n%s', colors.reset('newman'), colors.reset(currentGroup.name));
     });
 
-    emitter.on('beforeIteration', function (err, cur) {
-        if (cur.cycles <= 1) {
+    emitter.on('beforeIteration', function (err, o) {
+        if (err || o.cursor.cycles <= 1) {
             return; // do not print iteration banner if it is a single iteration run
         }
 
         // print the iteration infoline
-        print.lf(LF + colors.gray.underline('Iteration %d/%d') + LF, cur.iteration + 1, cur.cycles);
+        print.lf(LF + colors.gray.underline('Iteration %d/%d') + LF, o.cursor.iteration + 1, o.cursor.cycles);
     });
 
-    emitter.on('beforeItem', function (err, cursor, item) {
-        var itemGroup = parentOf(item),
+    emitter.on('beforeItem', function (err, o) {
+        var itemGroup = parentOf(o.item),
             root = !itemGroup || (itemGroup === options.collection);
 
         // in case this item belongs to a separate folder, print that folder name
@@ -56,32 +56,33 @@ module.exports = function PostmanCLIReporter (emitter, options) {
 
         // we print the item name. the symbol prefix denotes if the item is in root or under folder.
         // @todo - when we do indentation, we would not need symbolic representation
-        print.lf('%s %s', (root ? '→' : '↳'), colors.reset(item.name));
+        o.item && print.lf('%s %s', (root ? '→' : '↳'), colors.reset(o.item.name || E));
     });
 
     // print out the request name to be executed and start a spinner
-    emitter.on('beforeRequest', function (err, cur, request) {
-        print('  %s %s ', colors.gray(request.method), colors.gray(request.url)).wait();
+    emitter.on('beforeRequest', function (err, o) {
+        o.request && print('  %s %s ', colors.gray(o.request.method), colors.gray(o.request.url)).wait();
     });
 
     // output the response code, reason and time
-    emitter.on('request', function (err, cur, response) {
+    emitter.on('request', function (err, o) {
         err ? print.lf(colors.red('[errored]')) :
-            print.lf(colors.gray('[%s %d, %s]'), response.reason(), response.code, prettyms(response.responseTime));
+            print.lf(colors.gray('[%s %d, %s]'), o.response.reason(), o.response.code,
+                prettyms(o.response.responseTime));
     });
 
     // realtime print out script errors
-    emitter.on('script', function (err, cur, execution, script, event) {
+    emitter.on('script', function (err, o) {
         err && print.lf(colors.red.bold('%s⠄ %s in %s script'), pad(this.summary.failures.length, 3, SPC), err.name,
-            event && event.listen || '<unknown-script>');
+            o.event && o.event.listen || '<unknown-script>');
     });
 
-    emitter.on('assertion', function (err, cur, assertion) {
+    emitter.on('assertion', function (err, o) {
         var passed = !err;
 
         // print each test assertions
         print.lf('%s %s', passed ? colors.green('  ✔ ') : colors.red.bold(pad(this.summary.failures.length, 3, SPC) +
-            '⠄'), passed ? colors.gray(assertion) : colors.red.bold(assertion));
+            '⠄'), passed ? colors.gray(o.assertion) : colors.red.bold(o.assertion));
     });
 
     emitter.on('done', function () {

--- a/lib/run.js
+++ b/lib/run.js
@@ -6,9 +6,21 @@ var _ = require('lodash'),
     util = require('./util'),
     Collection = require('postman-collection').Collection,
 
-    runtimeEvents = ['start', 'beforeIteration', 'beforeItem', 'beforePrerequest', 'prerequest',
-        'beforeRequest', 'request', 'beforeTest', 'test', 'item', 'iteration', 'beforeScript', 'script', 'console',
-        'exception', 'done'],
+    runtimeEvents = {
+        start: [],
+        beforeIteration: [],
+        beforeItem: ['item'],
+        beforePrerequest: ['events', 'item'],
+        prerequest: ['executions', 'item'],
+        beforeRequest: ['request', 'item'],
+        request: ['response', 'request', 'item'],
+        beforeTest: ['events', 'item'],
+        test: ['executions', 'item'],
+        item: ['item'],
+        iteration: [],
+        beforeScript: ['script', 'event', 'item'],
+        script: ['execution', 'script', 'event', 'item']
+    },
 
     /**
      * Accepts an object, and extracts the property inside an object which is supposed to contain a list of variables
@@ -114,9 +126,31 @@ module.exports = function (options, callback) {
                 reporters = _.isString(options.reporters) ? [options.reporters] : options.reporters;
 
             // emit events for all the callbacks triggered by the runtime
-            runtimeEvents.forEach(function (eventName) {
-                callbacks[eventName] = emitter.emit.bind(emitter, eventName);
+            _.each(runtimeEvents, function (definition, eventName) {
+
+                // intercept each runtime.* callback and expose a global object based event
+                callbacks[eventName] = function (err, cursor) {
+                    var args = arguments,
+                        obj = { cursor: cursor };
+
+                    // convert the arguments into an object by taking the key name reference from the definition
+                    // object
+                    _.each(definition, function (key, index) {
+                        obj[key] = args[index + 2]; // first two are err, cursor
+                    });
+
+                    args = [eventName, err, obj];
+                    emitter.emit.apply(emitter, args); // eslint-disable-line prefer-spread
+                };
             });
+
+            // two runtime callbacks do not follow pattern, define them separately
+            callbacks.console = emitter.emit.bind(emitter, 'console');
+            callbacks.exception = function (cursor, err) {
+                emitter.emit('exception', err, {
+                    cursor: cursor
+                });
+            };
 
             // override the `done` event to fire the end callback
             callbacks.done = function (err) { // @todo - do some meory cleanup here?

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -1,5 +1,4 @@
 var _ = require('lodash'),
-    CollectionItem = require('postman-collection').Item,
     SerialiseError = require('serialised-error'),
     RunSummary;
 
@@ -46,19 +45,24 @@ RunSummary = function RunSummary (emitter) {
     // generate pseudo assertion events since runtime does not trigger assertion events yet.
     // without this, all reporters would needlessly need to extract assertions and create an error object
     // out of it
-    emitter.on('script', function (err, cur, execution, script, event, item) {
+    emitter.on('script', function (err, o) {
         // we iterate on each test asserion to trigger an evemt. during this, we create a pseudo error object
         // for the assertion
         var index = 0;
 
-        _.each(_.get(execution, 'globals.tests'), function (passed, assertion) {
+        _.each(_.get(o.execution, 'globals.tests'), function (passed, assertion) {
             emitter.emit('assertion', passed ? null : (new SerialiseError({
                 name: 'AssertionFailure',
                 message: assertion,
                 stack: 'AssertionFailure: Expected tests["' + assertion + '"] to be truthy\n' +
-                    '   at Object.eval test.js:' + (index + 1) + ':' + (cur.position + 1) + ')',
+                    '   at Object.eval test.js:' + (index + 1) + ':' + (o.cursor.position + 1) + ')',
                 index: index // @todo find better way to notify the same
-            }, true)), cur, assertion, event, item);
+            }, true)), {
+                cursor: o.cursor,
+                assertion: assertion,
+                event: o.event,
+                item: o.item
+            });
             index += 1;
         });
     });
@@ -86,19 +90,21 @@ RunSummary.trackEvent = function (events, emitter) {
             failed: 0
         };
 
-        emitter.on(_.camelCase('before-' + event), function (err) {
-            var item = RunSummary.sniffItemFromArgs(arguments);
+        emitter.on(_.camelCase('before-' + event), function (err, o) {
+            var item = o.item;
             tracker.pending += 1;
 
             err && trackers.failures.push({
                 source: item ? (item.name || item.id) : '<unknown>',
                 at: _.camelCase('before-' + event),
-                error: err
+                error: err,
+                cursor: o.cursor,
+                parent: o.item && item.__parent && item.__parent.__parent
             });
         });
 
-        emitter.on(event, function (err, cur) {
-            var item = RunSummary.sniffItemFromArgs(arguments),
+        emitter.on(event, function (err, o) {
+            var item = o.item,
                 source = event;
 
             // check pending so that, it does not negate for items that do not have a `before` counterpart
@@ -126,7 +132,7 @@ RunSummary.trackEvent = function (events, emitter) {
 
                 tracker.failed += 1;
                 trackers.failures.push({
-                    cursor: cur,
+                    cursor: o.cursor,
                     source: item,
                     parent: item && item.__parent && item.__parent.__parent,
                     at: source,
@@ -137,24 +143,6 @@ RunSummary.trackEvent = function (events, emitter) {
     });
 
     return trackers;
-};
-
-/**
- * Goes through an array and returns the first instance of an object which is a PostmanItem
- *
- * @param {Array} args
- * @returns {PostmanItem}
- */
-RunSummary.sniffItemFromArgs = function (args) {
-    var count;
-
-    if (!(args && (count = args.length))) { return; }
-
-    while (count--) {
-        if (args[count] && CollectionItem.isItem(args[count])) {
-            return args[count];
-        }
-    }
 };
 
 module.exports = RunSummary;


### PR DESCRIPTION
While converting runtime callbacks to events, transform the arguments into a single object.