### PR TITLE
v3 => console log

### DIFF
--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -3,6 +3,7 @@ var _ = require('lodash'),
     colors = require('colors/safe'),
     Table = require('cli-table2'),
     format = require('util').format,
+    inspect = require('util').inspect,
 
     cliUtils = require('./cli-utils'),
     print = require('./print'),
@@ -11,6 +12,12 @@ var _ = require('lodash'),
     LF = '\n',
     SPC = ' ',
     E = '',
+    LEVEL_COLORS = {
+        gray: 'reset',
+        log: 'reset',
+        warn: 'yellow',
+        error: 'red'
+    },
 
     /**
      * Helper function to get parent of an item
@@ -23,7 +30,10 @@ var _ = require('lodash'),
     };
 
 module.exports = function PostmanCLIReporter (emitter, options) {
-    var currentGroup = options.collection;
+    var currentGroup = options.collection,
+        inspectOptions = { // to add no-color support for console logs
+            colors: !options.noColor
+        };
 
     emitter.on('start', function () {
         // print the collection name and newman infoline
@@ -83,6 +93,20 @@ module.exports = function PostmanCLIReporter (emitter, options) {
         // print each test assertions
         print.lf('%s %s', passed ? colors.green('  ✔ ') : colors.red.bold(pad(this.summary.failures.length, 3, SPC) +
             '⠄'), passed ? colors.gray(o.assertion) : colors.red.bold(o.assertion));
+    });
+
+    // @todo - add option to disable console logging
+    emitter.on('console', function (err, o) {
+        var level = o.level,
+            color = colors[LEVEL_COLORS[level]] || colors.reset,
+            messages = o.messages;
+
+        // buffer allows to draw the boundary of console, but ensure that if two console calls are done close together
+        // they do not print their boundaries... ;-)
+        print.buffer(color('└───────────────∙\n'), color('┌───────────────∙\n'))
+            .nobuffer('%s\n', _.reduce(messages, function (log, message) {
+                return (log += (log ? colors.gray(', ') : '') + inspect(message, inspectOptions));
+            }, E));
     });
 
     emitter.on('done', function () {

--- a/lib/reporters/cli/print.js
+++ b/lib/reporters/cli/print.js
@@ -24,6 +24,7 @@ print = function () {
  */
 print.print = function () {
     print.waiting && print.unwait();
+    print._buffer && print.unbuffer();
     process.stdout.write(format.apply(this, arguments));
     return print;
 };
@@ -36,6 +37,7 @@ print.print = function () {
  */
 print.lf = function () {
     print.waiting && print.unwait();
+    print._buffer && print.unbuffer();
     process.stdout.write(format.apply(this, arguments) + LF);
     return print;
 };
@@ -68,6 +70,7 @@ print.wait = function (color) {
  *
  * @returns {print}
  * @chainable
+ * @see print.wait
  */
 print.unwait = function () {
     if (print.waiting) {
@@ -76,6 +79,58 @@ print.unwait = function () {
         process.stdout.write('\b');
     }
 
+    return print;
+};
+
+print._buffer = undefined;
+
+/**
+ * Prints a message between start and end text. Consequent buffer calls does not print the start text and any other
+ * unbuffered call or a delay of time prints the end text
+ *
+ * @param {string} startText
+ * @param {string} endText
+ *
+ * @returns {print}
+ * @chainable
+ */
+print.buffer = function (startText, endText) {
+    (print._buffer !== endText) && process.stdout.write(startText);
+    print._buffer = endText;
+
+    print._buferring && (print._buferring = clearTimeout(print._buferring));
+    print._buferring = setTimeout(print.unbuffer, 500);
+
+    process.stdout.write(format.apply(this, Array.prototype.splice.call(arguments, 2)));
+    return print;
+};
+
+/**
+ * Prints text without flushing buffer
+ *
+ * @returns {print}
+ * @chainable
+ * @see print.buffer
+ */
+print.nobuffer = function () {
+    print.unwait();
+    process.stdout.write(format.apply(this, arguments));
+    return print;
+};
+
+/**
+ * Flushes buffer
+ *
+ * @returns {print}
+ * @chainable
+ * @see print.buffer
+ */
+print.unbuffer = function () {
+    print._buferring && (print._buferring = clearTimeout(print._buferring));
+    if (print._buffer) {
+        process.stdout.write(print._buffer);
+        print._buffer = undefined;
+    }
     return print;
 };
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -203,10 +203,18 @@ module.exports = function (options, callback) {
             });
 
             // two runtime callbacks do not follow pattern, define them separately
-            callbacks.console = emitter.emit.bind(emitter, 'console');
+            callbacks.console = function (cursor, level) {
+                emitter.emit('console', null, {
+                    cursor: cursor,
+                    level: level,
+                    messages: _.slice(arguments, 2)
+                });
+            };
+
             callbacks.exception = function (cursor, err) {
-                emitter.emit('exception', err, {
-                    cursor: cursor
+                emitter.emit('exception', null, {
+                    cursor: cursor,
+                    error: err
                 });
             };
 


### PR DESCRIPTION
This adds support to log console to terminal. Features

- data type is coloured
- objects are expanded and coloured recursively
- respects no-color flag
- prints neat boundary of console to avoid confusion
- colour coded boundary for log levels

Sample console.warn() with multiple arguments + object
<img width="627" alt="screenshot 2016-07-26 04 30 42" src="https://cloud.githubusercontent.com/assets/232373/17120421/c72606ba-52e9-11e6-837f-9349141f1af7.png">

Three subsequent console logs sharing common boundary
<img width="614" alt="screenshot 2016-07-26 04 33 14" src="https://cloud.githubusercontent.com/assets/232373/17120466/1df2e508-52ea-11e6-811c-1fe67b386296.png">
