### PR TITLE
v3 => Added check in Newman CLI for node version check.

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+require('../lib/node-version-check');
+
 var _ = require('lodash'),
 
     cli = require('../lib/cli'),

--- a/lib/node-version-check/index.js
+++ b/lib/node-version-check/index.js
@@ -1,0 +1,29 @@
+var semver = require('semver'),
+    colors = require('colors/safe'),
+    pkg = require('../../package.json'),
+
+    /**
+     * the required node version from package.json
+     * @type {String}
+     * @readOnly
+     */
+    requiredNodeVersion = pkg && pkg.engines && pkg.engines.node,
+
+    /**
+     * the current node version as detected from running process
+     *
+     * @type {String}
+     * @readOnly
+     */
+    currentNodeVersion = process && process.version;
+
+// if either current or required version is not detected, we bail out
+if (!(requiredNodeVersion && currentNodeVersion)) {
+    return;
+}
+
+// we check semver satisfaction and throw error on mismatch
+if (!semver.satisfies(currentNodeVersion, requiredNodeVersion)) {
+    console.error([colors.red('newman:'), 'required node version', requiredNodeVersion].join(' '));
+    process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "postman-runtime": "2.2.2",
     "pretty-ms": "2.1.0",
     "request": "2.74.0",
+    "semver": "5.3.0",
     "serialised-error": "1.1.2",
     "shelljs": "0.7.0",
     "word-wrap": "1.1.0"


### PR DESCRIPTION
Did not put any check in preinstall. As we do not have any C++ bindings that cannot recompile if underlying node version is changed.

So, installation can follow on any version. but during usage, it errors out gracefully with appropriate console message. This allows easy usage with `n` or `nvm`.