### PR TITLE
Fixed an issue with console log wrap width calculation

### DIFF
--- a/lib/reporters/cli/cli-utils.js
+++ b/lib/reporters/cli/cli-utils.js
@@ -1,10 +1,18 @@
 var prettyms = require('pretty-ms'),
     filesize = require('filesize'),
+    inspect = require('util').inspect,
+    wrap = require('word-wrap'),
 
-    FILESIZE_OPTIONS = { spacer: '' };
+    FILESIZE_OPTIONS = { spacer: '' },
+
+    cliUtils;
+
+// set styling for inspect options
+inspect.styles.string = 'grey';
+inspect.styles.name = 'white';
 
 // @todo - document the cliUtils function
-module.exports = {
+cliUtils = {
     cliTableTemplate_Blank: {
         'top': '',
         'top-mid': '',
@@ -45,6 +53,33 @@ module.exports = {
         return filesize(bytes, FILESIZE_OPTIONS);
     },
 
+    inspector: function (noColor) {
+        var dimension = cliUtils.dimension(),
+            options = {
+                colors: !(noColor || cliUtils.noTTY()),
+                // note that similar dimension calculation is in utils.wrapper
+                breakLength: ((dimension.exists && (dimension.width > 20)) ? dimension.width : 60) - 16
+            };
+
+        return function (item) {
+            return inspect(item, options);
+        };
+    },
+
+    wrapper: function () {
+        var dimension = cliUtils.dimension(),
+            // note that similar dimension calculation is in utils.wrapper
+            width = ((dimension.exists && (dimension.width > 20)) ? dimension.width : 60) - 6;
+
+        return function (text, indent) {
+            return wrap(text, {
+                indent: indent,
+                width: width,
+                cut: true
+            });
+        };
+    },
+
     dimension: function () {
         var tty,
             width,
@@ -75,3 +110,5 @@ module.exports = {
         };
     }
 };
+
+module.exports = cliUtils;

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -13,7 +13,7 @@ var _ = require('lodash'),
     SPC = ' ',
     E = '',
     LOG_WRAP_WIDTH = (function (size) {
-        return (size.exists && (size.width > 20)) ? (size.width - 2) : 78;
+        return ((size.exists && (size.width > 20)) ? size.width : 60) - 6;
     }(cliUtils.dimension())),
 
     /**
@@ -166,7 +166,8 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
             return (log += (log ? colors.white(', ') : '') + inspect(message, inspectOptions));
         }, E), { // wrap the whole message to the window size
             indent: `  ${color('│')} `, // add an indentation line at the beginning
-            width: LOG_WRAP_WIDTH
+            width: LOG_WRAP_WIDTH,
+            cut: true
         });
 
         print.buffer(color('  ┌\n'), color('  └\n'))

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -2,8 +2,6 @@ var _ = require('lodash'),
     colors = require('colors/safe'),
     Table = require('cli-table2'),
     format = require('util').format,
-    inspect = require('util').inspect,
-    wrap = require('word-wrap'),
 
     cliUtils = require('./cli-utils'),
     print = require('./print'),
@@ -12,9 +10,6 @@ var _ = require('lodash'),
     LF = '\n',
     SPC = ' ',
     E = '',
-    LOG_WRAP_WIDTH = (function (size) {
-        return ((size.exists && (size.width > 20)) ? size.width : 60) - 6;
-    }(cliUtils.dimension())),
 
     /**
      * Helper function to get parent of an item
@@ -37,11 +32,6 @@ colors.setTheme({
     error: 'red'
 });
 
-_.assign(inspect.styles, {
-    string: 'grey',
-    name: 'white'
-});
-
 /**
  * CLI reporter
  *
@@ -56,10 +46,8 @@ _.assign(inspect.styles, {
  */
 PostmanCLIReporter = function (emitter, reporterOptions, options) {
     var currentGroup = options.collection,
-        inspectOptions = { // to add no-color support for console logs since we are using util.inspect to colour logs
-            colors: !(options.noColor || cliUtils.noTTY()),
-            breakLength: LOG_WRAP_WIDTH - 10 // @todo - recompute dimensions here
-        };
+        inspect = cliUtils.inspector(options.noColor),
+        wrap = cliUtils.wrapper();
 
     // respect silent option to not report anything
     if (reporterOptions.silent || options.silent) {
@@ -162,13 +150,9 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 
         // we first merge all messages to a string. while merging we run the values to util.inspect to colour code the
         // messages based on data type
-        message = wrap(_.reduce(o.messages, function (log, message) {
-            return (log += (log ? colors.white(', ') : '') + inspect(message, inspectOptions));
-        }, E), { // wrap the whole message to the window size
-            indent: `  ${color('│')} `, // add an indentation line at the beginning
-            width: LOG_WRAP_WIDTH,
-            cut: true
-        });
+        message = wrap(_.reduce(o.messages, function (log, message) { // wrap the whole message to the window size
+            return (log += (log ? colors.white(', ') : '') + inspect(message));
+        }, E), `  ${color('│')} `); // add an indentation line at the beginning
 
         print.buffer(color('  ┌\n'), color('  └\n'))
             // tweak the message to ensure that its surrounding is not brightly coloured.


### PR DESCRIPTION
- `The LOG_WRAP_WIDTH` constant was off by 2 characters. Fixed it
- configured the `wrap` library to even break between words if needed.