### PR TITLE
Fixed export bug

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -43,9 +43,16 @@ module.exports.get = (overrides, options, callback) => {
             return (src === null) ? dest : undefined;
         });
 
-
         if (_.isEmpty(loaders)) {
             return callback(null, options);
+        }
+        // sanitize environment option
+        if (!options.environment) {
+            options.environment = {};
+        }
+        // sanitize globals option
+        if (!options.globals) {
+            options.globals = {};
         }
 
         async.mapValues(options, (value, name, cb) => {


### PR DESCRIPTION
In case of missing `environment` or `globals` options, a default value of `{}` is used as a fallback. This allows proper handling of variables created during a collection run.

Takes care of #537.