### PR TITLE
Modified the timestamp generator function to use a special separator …

### DIFF
--- a/lib/run/export-file.js
+++ b/lib/run/export-file.js
@@ -4,17 +4,34 @@ var _ = require('lodash'),
     joinPath = require('path').join,
     mkdirp = require('mkdirp'),
 
-    timestamp = function (date) {
-        // use the iso string to ensure left padding and other stuff is taken care of
-        return (date || new Date()).toISOString().replace(/[^\d]/g, '');
-    },
-
     /**
      * @const
      * @private
      * @type {string}
      */
-    E = '';
+    E = '',
+
+    /**
+     * Default timestamp separator.
+     *
+     * @const
+     * @private
+     * @type {string}
+     */
+    TS_SEP = '-',
+
+    /**
+     * Generate a timestamp from date
+     *
+     * @param {Date=} [date]
+     * @param {String=} [separator]
+     *
+     * @returns {String} yyyy-mm-dd-HH-MM-SS-MS-0
+     */
+    timestamp = function (date, separator) {
+        // use the iso string to ensure left padding and other stuff is taken care of
+        return (date || new Date()).toISOString().replace(/[^\d]+/g, _.isString(separator) ? separator : TS_SEP);
+    };
 
 /**
  * Module whose job is to export a file which is in an export format.
@@ -38,7 +55,7 @@ module.exports = function (options, done) {
         path.dir = 'newman';
 
         // append timestamp
-        path.name = `${path.name}-${timestamp()}-0`; // @todo make -0 become incremental if file name exists
+        path.name = `${path.name}-${timestamp()}0`; // @todo make -0 become incremental if file name exists
         path.base = path.name + path.ext;
     }
     // final check that path is valid


### PR DESCRIPTION
Modified the timestamp generator function to use a special separator argument or use `-` as separator. This ensures that exported filenames are now more readable.

OLD: `newman-run-report-20160823093308656-0.html`
NEW: `newman-run-report-2016-08-23-10-40-03-637-0.html`