### PR TITLE
Fix to export format of globals and environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Newman Changelog
 
+#### Unreleased
+
+- Fixed issue with environment and globals export format was using wrong property names (GH:553)
+
 #### v3.0.1 (Aug 9, 2016)
 
 - Updated Postman Runtime to v2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Unreleased
 
 - Fixed issue with environment and globals export format was using wrong property names (GH:553)
+- Fixed issue where `--export-*` CLI option did not work with no parameters
 
 #### v3.0.1 (Aug 9, 2016)
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -315,15 +315,21 @@ var _ = require('lodash'),
         });
 
         runParser.addArgument(['--export-environment'], {
-            help: 'Exports the environment to a file after completing the run'
+            help: 'Exports the environment to a file after completing the run',
+            nargs: '?',
+            constant: true
         });
 
         runParser.addArgument(['--export-globals'], {
-            help: 'Specify an output file to dump Globals before exiting'
+            help: 'Specify an output file to dump Globals before exiting',
+            nargs: '?',
+            constant: true
         });
 
         runParser.addArgument(['--export-collection'], {
-            help: 'Specify an output file to save the executed collection'
+            help: 'Specify an output file to save the executed collection',
+            nargs: '?',
+            constant: true
         });
 
         runParser.addArgument(['--delay-request'], {

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -161,9 +161,9 @@ module.exports = function (options, callback) {
                         var path = _.get(options, _.camelCase(`export-${item}`));
 
                         // if the options have an export path, then add the item to export queue
-                        _.isString(path) && emitter.exports.push({
+                        path && emitter.exports.push({
                             name: item,
-                            default: `${item}-export.json`,
+                            default: `newman-${item}.json`,
                             path: path,
                             content: _.merge(emitter.summary[item].toJSON(), {
                                 _postman_exported_at: (new Date()).toISOString(),

--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -1,7 +1,44 @@
 var _ = require('lodash'),
     SerialiseError = require('serialised-error'),
 
+    proxyPropertyList,
     RunSummary;
+
+/**
+ * Create an object that mimics the SDK property list
+ * @private
+ *
+ * @param {Object} options - the object that contains the object to proxy
+ * @param {String} name - the name of the object to proxy from a parent object
+ *
+ * @returns {Object}
+ */
+proxyPropertyList = function (options, name) {
+    return {
+        /**
+         * Get an object containing a copy of all variables and their values
+         *
+         * @type {Function}
+         * @returns {Object<String>}
+         */
+        object: function () {
+            return _.get(options, name, {});
+        },
+
+        /**
+         * Transform object in variable-list JSON format
+         *
+         * @returns {[type]} [description]
+         */
+        toJSON: function () {
+            return {
+                values: _.map(_.get(options, name, {}), function (value, key) {
+                    return { key: key, name: key, value: value, type: 'string' };
+                })
+            };
+        }
+    };
+};
 
 /**
  * @constructor
@@ -28,34 +65,7 @@ RunSummary = function RunSummary (emitter, options) {
          * @todo add name and id here. implying, that .run accepts it and uses the format
          * @todo also, once we start using SDK VariableList, this should become simple toJSON
          */
-        environment: {
-            /**
-             * Get an object containing a copy of all environment variables and their values
-             *
-             * @type {Function}
-             * @returns {Object<String>}
-             */
-            object: function () {
-                return _.get(options, 'environment', {});
-            },
-
-            /**
-             * Gets environment variables in JSON format
-             * @returns {Object}
-             */
-            toJSON: function () {
-                return {
-                    values: _.map(options.environment || {}, function (value, key) {
-                        return {
-                            key: key,
-                            name: key,
-                            value: value,
-                            type: 'string'
-                        };
-                    })
-                };
-            }
-        },
+        environment: proxyPropertyList(options, 'environment'),
 
         /**
          * Environment variables being used during the run
@@ -65,34 +75,7 @@ RunSummary = function RunSummary (emitter, options) {
          * @todo add name and id here. implying, that .run accepts it and uses the format
          * @todo also, once we start using SDK VariableList, this should become simple toJSON
          */
-        globals: {
-            /**
-             * Get an object containing a copy of all global variables and their values
-             *
-             * @type {Function}
-             * @returns {Object<String>}
-             */
-            object: function () {
-                return _.get(options, 'globals', {});
-            },
-
-            /**
-             * Gets global variables in JSON format
-             * @returns {Object}
-             */
-            toJSON: function () {
-                return {
-                    values: _.map(options.globals || {}, function (value, key) {
-                        return {
-                            key: key,
-                            name: key,
-                            value: value,
-                            type: 'string'
-                        };
-                    })
-                };
-            }
-        },
+        globals: proxyPropertyList(options, 'globals'),
 
         /**
          * Holds information related to the run.

--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -47,10 +47,10 @@ RunSummary = function RunSummary (emitter, options) {
                 return {
                     values: _.map(options.environment || {}, function (value, key) {
                         return {
-                            id: key,
+                            key: key,
                             name: key,
                             value: value,
-                            type: 'text'
+                            type: 'string'
                         };
                     })
                 };
@@ -84,10 +84,10 @@ RunSummary = function RunSummary (emitter, options) {
                 return {
                     values: _.map(options.globals || {}, function (value, key) {
                         return {
-                            id: key,
+                            key: key,
                             name: key,
                             value: value,
-                            type: 'text'
+                            type: 'string'
                         };
                     })
                 };

--- a/test/cli/export-environment.test.js
+++ b/test/cli/export-environment.test.js
@@ -1,0 +1,51 @@
+/* global describe, it, exec, expect */
+var fs = require('fs');
+
+describe('--export-environment', function () {
+    this.timeout(1000 * 60); // set 60s timeout
+
+    afterEach(function () {
+        try { fs.unlinkSync('out/test-environment.json'); }
+        catch (e) { console.error(e); }
+    });
+
+    it('`newman run` should export environment to a file', function (done) {
+        // eslint-disable-next-line max-len
+        exec('./bin/newman.js run test/cli/single-get-request.json -e test/cli/simple-variables.json --export-environment out/test-environment.json', function (code) {
+            var environment;
+
+            try { environment = JSON.parse(fs.readFileSync('out/test-environment.json').toString()); }
+            catch (e) { console.error(e); }
+
+            expect(code).be(0);
+            expect(environment).be.ok();
+            expect(environment).have.property('_postman_exported_at');
+            expect(environment).have.property('values');
+            expect(environment.values).eql([
+                { key: 'var-1', name: 'var-1', value: 'value-1', type: 'string' },
+                { key: 'var-2', name: 'var-2', value: 'value-2', type: 'string' }
+            ]);
+            done();
+        });
+    });
+
+    it('`newman run` should export environment to a file even if collection is failing', function (done) {
+        // eslint-disable-next-line max-len
+        exec('./bin/newman.js run test/cli/single-request-failing.json -e test/cli/simple-variables.json --export-environment out/test-environment.json', function (code) {
+            var environment;
+
+            try { environment = JSON.parse(fs.readFileSync('out/test-environment.json').toString()); }
+            catch (e) { console.error(e); }
+
+            expect(code).not.be(0);
+            expect(environment).be.ok();
+            expect(environment).have.property('_postman_exported_at');
+            expect(environment).have.property('values');
+            expect(environment.values).eql([
+                { key: 'var-1', name: 'var-1', value: 'value-1', type: 'string' },
+                { key: 'var-2', name: 'var-2', value: 'value-2', type: 'string' }
+            ]);
+            done();
+        });
+    });
+});

--- a/test/cli/export-globals.test.js
+++ b/test/cli/export-globals.test.js
@@ -1,0 +1,51 @@
+/* global describe, it, exec, expect */
+var fs = require('fs');
+
+describe('--export-globals', function () {
+    this.timeout(1000 * 60); // set 60s timeout
+
+    afterEach(function () {
+        try { fs.unlinkSync('out/test-globals.json'); }
+        catch (e) { console.error(e); }
+    });
+
+    it('`newman run` should export globals to a file', function (done) {
+        // eslint-disable-next-line max-len
+        exec('./bin/newman.js run test/cli/single-get-request.json -g test/cli/simple-variables.json --export-globals out/test-globals.json', function (code) {
+            var globals;
+
+            try { globals = JSON.parse(fs.readFileSync('out/test-globals.json').toString()); }
+            catch (e) { console.error(e); }
+
+            expect(code).be(0);
+            expect(globals).be.ok();
+            expect(globals).have.property('_postman_exported_at');
+            expect(globals).have.property('values');
+            expect(globals.values).eql([
+                { key: 'var-1', name: 'var-1', value: 'value-1', type: 'string' },
+                { key: 'var-2', name: 'var-2', value: 'value-2', type: 'string' }
+            ]);
+            done();
+        });
+    });
+
+    it('`newman run` should export globals to a file even if collection is failing', function (done) {
+        // eslint-disable-next-line max-len
+        exec('./bin/newman.js run test/cli/single-request-failing.json -g test/cli/simple-variables.json --export-globals out/test-globals.json', function (code) {
+            var globals;
+
+            try { globals = JSON.parse(fs.readFileSync('out/test-globals.json').toString()); }
+            catch (e) { console.error(e); }
+
+            expect(code).not.be(0);
+            expect(globals).be.ok();
+            expect(globals).have.property('_postman_exported_at');
+            expect(globals).have.property('values');
+            expect(globals.values).eql([
+                { key: 'var-1', name: 'var-1', value: 'value-1', type: 'string' },
+                { key: 'var-2', name: 'var-2', value: 'value-2', type: 'string' }
+            ]);
+            done();
+        });
+    });
+});

--- a/test/cli/simple-variables.json
+++ b/test/cli/simple-variables.json
@@ -1,0 +1,10 @@
+{
+  "name": "globals",
+  "values": [{
+    "key": "var-1",
+    "value": "value-1"
+  }, {
+    "key": "var-2",
+    "value": "value-2"
+  }]
+}


### PR DESCRIPTION
- adds tests for export globals via CLI (need something for unit tests later TODO)
- fixes globals and environment export JSON structure (still missing env name or global name TODO)
- makes CLI accept param less `--export-*` so that default file names are used


Fixes #553 
