### PR TITLE
Added fallback CLI table for non unicode environments

### DIFF
--- a/lib/reporters/cli/cli-utils.js
+++ b/lib/reporters/cli/cli-utils.js
@@ -39,6 +39,30 @@ cliUtils = {
         'right-right': ''
     },
 
+    cliTableTemplateFallback: {
+        'top': '-',
+        'top-mid': '-',
+        'top-left': '-',
+        'top-right': '-',
+        'bottom': '-',
+        'bottom-mid': '-',
+        'bottom-left': '-',
+        'bottom-right': '-',
+        'middle': '|',
+        'mid': '-',
+        'mid-mid': '+',
+        'mid-left': '-',
+        'mid-right': '-',
+        'left': '|',
+        'left-mid': '-',
+        'left-left': '-',
+        'left-right': '-',
+        'right': '|',
+        'right-mid': '-',
+        'right-left': '-',
+        'right-right': '-'
+    },
+
     padLeft: function (nr, n, str) {
         return Array(n - String(nr).length + 1).join(str || '0') + nr;
     },

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -64,7 +64,8 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 
         // show the summary table (provided option does not say it is not to be shown)
         if (!reporterOptions.noSummary) {
-            print(LF + PostmanCLIReporter.parseStatistics(run.stats, run.timings, run.transfers) + LF);
+            // @todo: possible missing .toString() call on parseStatistics below? (see parseFailures call below)
+            print(LF + PostmanCLIReporter.parseStatistics(run.stats, run.timings, run.transfers, options) + LF);
         }
 
         // show the failures table (provided option does not say it is not to be shown)
@@ -167,11 +168,13 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 };
 
 _.assignIn(PostmanCLIReporter, {
-    parseStatistics: function (stats, timings, transfers) {
+    // @todo: change function signature to accept run object and options, thereby reducing parameters
+    parseStatistics: function (stats, timings, transfers, options) {
         var summaryTable;
 
         // create the summary table
         summaryTable = new Table({
+            chars: options.disableUnicode && cliUtils.cliTableTemplateFallback,
             style: { head: [] },
             head: [E, 'executed', '  failed'],
             colAligns: ['right', 'right', 'right'],


### PR DESCRIPTION
Related to #556 

A few points of interest:
* A table without borders is displayed for errors from a collection run, not sure if this is intended or was forgotten.
* There is a subtle difference in the way table output from `parseFailures` and `parseStatistics` is currently being handled in [lib/reporters/cli/index.js](https://github.com/postmanlabs/newman/blob/develop/lib/reporters/cli/index.js#L67#L72), as `.toString()` is not being called on `parseStatistics`
* The function signature for [parseStatistics](https://github.com/postmanlabs/newman/blob/develop/lib/reporters/cli/index.js#L170) should be compressed to one run object, and another for options.
* The [default cliTableTemplate](https://github.com/postmanlabs/newman/blob/develop/lib/reporters/cli/cli-utils.js#L18) has a non-standard name, should be changed.

ASCII table:
![ascii](https://cloud.githubusercontent.com/assets/7289840/18313624/3689b032-752d-11e6-98e3-a59683619531.png)

Unicode table:
![unicode](https://cloud.githubusercontent.com/assets/7289840/18313629/3b342338-752d-11e6-95a4-283c8ee958d3.png)
