### PR TITLE
Fixed V1 collection resolution bug

### DIFF
--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -57,35 +57,41 @@ var _ = require('lodash'),
      */
     configLoaders = {
         collection: function (value, callback) {
-            var done = function (err, collection) {
-                if (err) {
-                    return callback(err);
-                }
+            var V2_COLLECTION_PROPERTY = 'info.schema',
+                COLLECTION_TRANSFORMER_OPTION = { inputVersion: '1.0.0', outputVersion: '2.0.0' },
 
-                // ensure that the collection option is present before starting a run
-                if (!_.isObject(collection)) {
-                    return callback(new Error('newman: collection could not be loaded'));
-                }
+                done = function (err, collection) {
+                    if (err) {
+                        return callback(err);
+                    }
 
-                // ensure that the collection reference is an SDK instance
-                // @todo - should this be handled by config loaders?
-                collection = new Collection(Collection.isCollection(collection) ?
-                    // if the option contain an instance of collection, we simply clone it for future use
-                    // create a collection in case it is not one. user can send v2 JSON as a source and that will be
-                    // converted to a collection
-                    collection.toJSON() : collection);
+                    // ensure that the collection option is present before starting a run
+                    if (!_.isObject(collection)) {
+                        return callback(new Error('newman: collection could not be loaded'));
+                    }
 
-                callback(null, collection);
-            };
+                    // ensure that the collection reference is an SDK instance
+                    // @todo - should this be handled by config loaders?
+                    collection = new Collection(Collection.isCollection(collection) ?
+                        // if the option contain an instance of collection, we simply clone it for future use
+                        // create a collection in case it is not one. user can send v2 JSON as a source and that will be
+                        // converted to a collection
+                        collection.toJSON() : collection);
 
-            if (!_.isString(value)) { return done(null, value); }
+                    callback(null, collection);
+                };
+
+            if (_.isObject(value)) {
+                return _.get(value, V2_COLLECTION_PROPERTY) ? done(null, value) : transformer.convert(value,
+                    COLLECTION_TRANSFORMER_OPTION, done);
+            }
 
             externalLoader('collection', value, function (err, data) {
                 if (err) {
                     return done(err);
                 }
-                if (_.isObject(data) && !_.get(data, 'info.schema')) {
-                    return transformer.convert(data, { inputVersion: '1.0.0', outputVersion: '2.0.0' }, done);
+                if (_.isObject(data) && !_.get(data, V2_COLLECTION_PROPERTY)) {
+                    return transformer.convert(data, COLLECTION_TRANSFORMER_OPTION, done);
                 }
                 done(null, data);
             });

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -7,6 +7,9 @@ var _ = require('lodash'),
     util = require('../util'),
     config = require('../config'),
 
+    COLLECTION_LOAD_ERROR_MESSAGE = 'newman: collection could not be loaded',
+    COLLECTION_TRANSFORMER_OPTION = { inputVersion: '1.0.0', outputVersion: '2.0.0' },
+
     /**
      * Accepts an object, and extracts the property inside an object which is supposed to contain the required data.
      * In case of variables, it also extracts them into plain JS objects.
@@ -51,49 +54,57 @@ var _ = require('lodash'),
     },
 
     /**
+     * A helper method to process a collection and convert it to a V2 equivalent if necessary, and return it.
+     * @param {Object} collection The input collection, specified as a JSON object
+     * @param {Function} callback A handler function that consumes an error object and the processed collection
+     * @returns {*|Function}
+     */
+    processCollection = function (collection, callback) {
+        return transformer.isv1(collection) ? transformer.convert(collection, COLLECTION_TRANSFORMER_OPTION, callback) :
+            callback(null, collection);
+    },
+
+    /**
      * Custom configuration loaders for the required configuration keys.
      *
      * @type {Object}
      */
     configLoaders = {
         collection: function (value, callback) {
-            var V2_COLLECTION_PROPERTY = 'info.schema',
-                COLLECTION_TRANSFORMER_OPTION = { inputVersion: '1.0.0', outputVersion: '2.0.0' },
+            var done = function (err, collection) {
+                if (err) {
+                    return callback(err);
+                }
 
-                done = function (err, collection) {
-                    if (err) {
-                        return callback(err);
-                    }
+                // ensure that the collection option is present before starting a run
+                if (!_.isObject(collection)) {
+                    return callback(new Error(COLLECTION_LOAD_ERROR_MESSAGE));
+                }
 
-                    // ensure that the collection option is present before starting a run
-                    if (!_.isObject(collection)) {
-                        return callback(new Error('newman: collection could not be loaded'));
-                    }
+                // ensure that the collection reference is an SDK instance
+                // @todo - should this be handled by config loaders?
+                collection = new Collection(Collection.isCollection(collection) ?
+                    // if the option contain an instance of collection, we simply clone it for future use
+                    // create a collection in case it is not one. user can send v2 JSON as a source and that will be
+                    // converted to a collection
+                    collection.toJSON() : collection);
 
-                    // ensure that the collection reference is an SDK instance
-                    // @todo - should this be handled by config loaders?
-                    collection = new Collection(Collection.isCollection(collection) ?
-                        // if the option contain an instance of collection, we simply clone it for future use
-                        // create a collection in case it is not one. user can send v2 JSON as a source and that will be
-                        // converted to a collection
-                        collection.toJSON() : collection);
+                callback(null, collection);
+            };
 
-                    callback(null, collection);
-                };
-
+            // if the collection has been specified as an object, convert to V2 if necessary and return the result
             if (_.isObject(value)) {
-                return _.get(value, V2_COLLECTION_PROPERTY) ? done(null, value) : transformer.convert(value,
-                    COLLECTION_TRANSFORMER_OPTION, done);
+                return processCollection(value, done);
             }
 
             externalLoader('collection', value, function (err, data) {
                 if (err) {
                     return done(err);
                 }
-                if (_.isObject(data) && !_.get(data, V2_COLLECTION_PROPERTY)) {
-                    return transformer.convert(data, COLLECTION_TRANSFORMER_OPTION, done);
+                if (!_.isObject(data)) {
+                    return done(new Error(COLLECTION_LOAD_ERROR_MESSAGE));
                 }
-                done(null, data);
+                return processCollection(data, done);
             });
         },
 


### PR DESCRIPTION
Takes care of #610 

**Context:** Newman Library usage

This ensures that V1 collections passed as objects are unconditionally converted to their respective V2 equivalents first.