### PR TITLE
Allowed run options to be specified as objects

### DIFF
--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -47,7 +47,7 @@ var _ = require('lodash'),
                 return cb(err);
             }
             return cb(null, extractModel(data, type));
-        }) : cb(null, location);
+        }) : cb(null, extractModel(location, type));
     },
 
     /**


### PR DESCRIPTION
**Context:** Newman library usage

This ensures that data / environments / globals options specified as objects within `newman.run` are still processed correctly.