### PR TITLE
Added more details to HTML report

### DIFF
--- a/examples/reports/html-reporter-template-data.json
+++ b/examples/reports/html-reporter-template-data.json
@@ -1,14 +1,16 @@
 {
-  "timestamp": "Thu Aug 25 2016 19:52:02 GMT+0530 (IST)",
+  "timestamp": "Wed Nov 23 2016 01:50:51 GMT+0530 (IST)",
+  "version": "3.3.0",
   "aggregations": [
     {
       "item": {
-        "id": "17d87a3b-fdc8-4b18-9815-950a42d87f59",
+        "id": "d63cd324-9f85-4fb1-99b4-fa30290cf3e5",
         "name": "A simple GET request",
         "request": {
           "url": "https://echo.getpostman.com/get?source=newman-sample-github-collection",
           "method": "GET"
         },
+        "response": [],
         "event": [
           {
             "listen": "test",
@@ -27,7 +29,7 @@
         "header": [
           {
             "key": "User-Agent",
-            "value": "PostmanRuntime/2.4.3"
+            "value": "PostmanRuntime/3.0.4"
           },
           {
             "key": "Accept",
@@ -43,7 +45,9 @@
           }
         ],
         "body": {},
-        "description": {}
+        "description": {
+          "type": "text/plain"
+        }
       },
       "response": {
         "status": "OK",
@@ -79,11 +83,11 @@
           },
           {
             "key": "Date",
-            "value": "Thu, 25 Aug 2016 14:22:01 GMT"
+            "value": "Tue, 22 Nov 2016 20:20:50 GMT"
           },
           {
             "key": "ETag",
-            "value": "W/\"137-PVrRGQ6/XWPrd95mL9VLkA\""
+            "value": "W/\"137-q0lxUUvKUot4wiPUo3uKCg\""
           },
           {
             "key": "Server",
@@ -91,7 +95,7 @@
           },
           {
             "key": "set-cookie",
-            "value": "sails.sid=s%3AKWkP8x3Zi5Dw8iEGxf4rtsVeadIVITil.kefDILpoX6Yda98kJa7ksUS8M5y1tUnu4S7yjKZN5Dg; Path=/; HttpOnly"
+            "value": "sails.sid=s%3AW0Ng8epFgCZJpDdMo_odMqH3BbWD38R9.90SxQF2ceaA7UoFSfYDoZnjOhENQDYmyV8Bun6s11OM; Path=/; HttpOnly"
           },
           {
             "key": "Vary",
@@ -99,19 +103,31 @@
           },
           {
             "key": "Content-Length",
-            "value": "203"
+            "value": "204"
           },
           {
             "key": "Connection",
             "value": "keep-alive"
           }
         ],
-        "body": "{\"args\":{\"source\":\"newman-sample-github-collection\"},\"headers\":{\"host\":\"echo.getpostman.com\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"user-agent\":\"PostmanRuntime/2.4.3\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"url\":\"https://echo.getpostman.com/get?source=newman-sample-github-collection\"}",
-        "responseTime": 1965,
-        "responseSize": 311
+        "body": "{\"args\":{\"source\":\"newman-sample-github-collection\"},\"headers\":{\"host\":\"echo.getpostman.com\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"user-agent\":\"PostmanRuntime/3.0.4\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"url\":\"https://echo.getpostman.com/get?source=newman-sample-github-collection\"}",
+        "cookie": [],
+        "responseTime": 1681,
+        "responseSize": 311,
+        "update": {},
+        "reason": {},
+        "text": {},
+        "json": {},
+        "mime": {},
+        "dataURI": {},
+        "size": {},
+        "describe": {},
+        "toObjectResolved": {},
+        "toJSON": {},
+        "meta": {}
       },
       "mean": {
-        "time": "2s",
+        "time": "1681ms",
         "size": "311B"
       },
       "cumulativeTests": {
@@ -128,7 +144,7 @@
     },
     {
       "item": {
-        "id": "45805ccf-86f6-44d1-b1fa-18431f4025e5",
+        "id": "7a2a3985-e3a4-4402-b34d-5a293e17fccf",
         "name": "A simple POST request",
         "request": {
           "url": "https://echo.getpostman.com/post",
@@ -143,7 +159,9 @@
             "mode": "raw",
             "raw": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium..."
           }
-        }
+        },
+        "response": [],
+        "event": []
       },
       "request": {
         "url": "https://echo.getpostman.com/post",
@@ -155,7 +173,7 @@
           },
           {
             "key": "User-Agent",
-            "value": "PostmanRuntime/2.4.3"
+            "value": "PostmanRuntime/3.0.4"
           },
           {
             "key": "Accept",
@@ -167,7 +185,7 @@
           },
           {
             "key": "cookie",
-            "value": "sails.sid=s%3AKWkP8x3Zi5Dw8iEGxf4rtsVeadIVITil.kefDILpoX6Yda98kJa7ksUS8M5y1tUnu4S7yjKZN5Dg"
+            "value": "sails.sid=s%3AW0Ng8epFgCZJpDdMo_odMqH3BbWD38R9.90SxQF2ceaA7UoFSfYDoZnjOhENQDYmyV8Bun6s11OM"
           },
           {
             "key": "accept-encoding",
@@ -182,7 +200,9 @@
           "mode": "raw",
           "raw": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium..."
         },
-        "description": {}
+        "description": {
+          "type": "text/plain"
+        }
       },
       "response": {
         "status": "OK",
@@ -218,15 +238,19 @@
           },
           {
             "key": "Date",
-            "value": "Thu, 25 Aug 2016 14:22:02 GMT"
+            "value": "Tue, 22 Nov 2016 20:20:51 GMT"
           },
           {
             "key": "ETag",
-            "value": "W/\"1ef-XCjjHFaJKcRm3YHSPLLNSQ\""
+            "value": "W/\"1ef-e/0XWpXc9SVbRHcy3qwkPg\""
           },
           {
             "key": "Server",
             "value": "nginx/1.8.1"
+          },
+          {
+            "key": "set-cookie",
+            "value": "sails.sid=s%3A7t5klbchBLFRoRArWtdPF45G9vWLbWGQ.gnfG4KfjJccNvT3nO8W7xe2NiMXwud8ztejaOblFayU; Path=/; HttpOnly"
           },
           {
             "key": "Vary",
@@ -234,19 +258,31 @@
           },
           {
             "key": "Content-Length",
-            "value": "359"
+            "value": "363"
           },
           {
             "key": "Connection",
             "value": "keep-alive"
           }
         ],
-        "body": "{\"args\":{},\"data\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\",\"files\":{},\"form\":{},\"headers\":{\"host\":\"echo.getpostman.com\",\"content-length\":\"69\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"content-type\":\"text/plain\",\"cookie\":\"sails.sid=s%3AKWkP8x3Zi5Dw8iEGxf4rtsVeadIVITil.kefDILpoX6Yda98kJa7ksUS8M5y1tUnu4S7yjKZN5Dg\",\"user-agent\":\"PostmanRuntime/2.4.3\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"json\":null,\"url\":\"https://echo.getpostman.com/post\"}",
-        "responseTime": 273,
-        "responseSize": 495
+        "body": "{\"args\":{},\"data\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\",\"files\":{},\"form\":{},\"headers\":{\"host\":\"echo.getpostman.com\",\"content-length\":\"69\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"content-type\":\"text/plain\",\"cookie\":\"sails.sid=s%3AW0Ng8epFgCZJpDdMo_odMqH3BbWD38R9.90SxQF2ceaA7UoFSfYDoZnjOhENQDYmyV8Bun6s11OM\",\"user-agent\":\"PostmanRuntime/3.0.4\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"json\":null,\"url\":\"https://echo.getpostman.com/post\"}",
+        "cookie": [],
+        "responseTime": 362,
+        "responseSize": 495,
+        "update": {},
+        "reason": {},
+        "text": {},
+        "json": {},
+        "mime": {},
+        "dataURI": {},
+        "size": {},
+        "describe": {},
+        "toObjectResolved": {},
+        "toJSON": {},
+        "meta": {}
       },
       "mean": {
-        "time": "273ms",
+        "time": "362ms",
         "size": "495B"
       },
       "cumulativeTests": {
@@ -257,7 +293,7 @@
     },
     {
       "item": {
-        "id": "0d5736de-0cf1-46a9-b057-3997c275af4b",
+        "id": "143bb96b-c727-4858-bca4-cf3caaecd83c",
         "name": "A simple POST request with JSON body",
         "request": {
           "url": "https://echo.getpostman.com/post",
@@ -272,7 +308,9 @@
             "mode": "raw",
             "raw": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}"
           }
-        }
+        },
+        "response": [],
+        "event": []
       },
       "request": {
         "url": "https://echo.getpostman.com/post",
@@ -284,7 +322,7 @@
           },
           {
             "key": "User-Agent",
-            "value": "PostmanRuntime/2.4.3"
+            "value": "PostmanRuntime/3.0.4"
           },
           {
             "key": "Accept",
@@ -296,7 +334,7 @@
           },
           {
             "key": "cookie",
-            "value": "sails.sid=s%3AKWkP8x3Zi5Dw8iEGxf4rtsVeadIVITil.kefDILpoX6Yda98kJa7ksUS8M5y1tUnu4S7yjKZN5Dg"
+            "value": "sails.sid=s%3A7t5klbchBLFRoRArWtdPF45G9vWLbWGQ.gnfG4KfjJccNvT3nO8W7xe2NiMXwud8ztejaOblFayU"
           },
           {
             "key": "accept-encoding",
@@ -311,7 +349,9 @@
           "mode": "raw",
           "raw": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}"
         },
-        "description": {}
+        "description": {
+          "type": "text/plain"
+        }
       },
       "response": {
         "status": "OK",
@@ -347,15 +387,19 @@
           },
           {
             "key": "Date",
-            "value": "Thu, 25 Aug 2016 14:22:02 GMT"
+            "value": "Tue, 22 Nov 2016 20:20:51 GMT"
           },
           {
             "key": "ETag",
-            "value": "W/\"24a-RFanBswLWTX2fy8gBq4Fug\""
+            "value": "W/\"24a-hvEkRPhnBgpssYbfJlNGew\""
           },
           {
             "key": "Server",
             "value": "nginx/1.8.1"
+          },
+          {
+            "key": "set-cookie",
+            "value": "sails.sid=s%3AZXbrye0a-V9HGR11zy_KloovYPY_G4Q-.nSJkrTRBZiPhUx6XBZLBIkWbYNO%2FuQcPGV5Xm727r5E; Path=/; HttpOnly"
           },
           {
             "key": "Vary",
@@ -363,19 +407,31 @@
           },
           {
             "key": "Content-Length",
-            "value": "366"
+            "value": "362"
           },
           {
             "key": "Connection",
             "value": "keep-alive"
           }
         ],
-        "body": "{\"args\":{},\"data\":{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"},\"files\":{},\"form\":{},\"headers\":{\"host\":\"echo.getpostman.com\",\"content-length\":\"80\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"content-type\":\"application/json\",\"cookie\":\"sails.sid=s%3AKWkP8x3Zi5Dw8iEGxf4rtsVeadIVITil.kefDILpoX6Yda98kJa7ksUS8M5y1tUnu4S7yjKZN5Dg\",\"user-agent\":\"PostmanRuntime/2.4.3\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"json\":{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"},\"url\":\"https://echo.getpostman.com/post\"}",
-        "responseTime": 309,
-        "responseSize": 586
+        "body": "{\"args\":{},\"data\":{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"},\"files\":{},\"form\":{},\"headers\":{\"host\":\"echo.getpostman.com\",\"content-length\":\"80\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"content-type\":\"application/json\",\"cookie\":\"sails.sid=s%3A7t5klbchBLFRoRArWtdPF45G9vWLbWGQ.gnfG4KfjJccNvT3nO8W7xe2NiMXwud8ztejaOblFayU\",\"user-agent\":\"PostmanRuntime/3.0.4\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"json\":{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"},\"url\":\"https://echo.getpostman.com/post\"}",
+        "cookie": [],
+        "responseTime": 363,
+        "responseSize": 586,
+        "update": {},
+        "reason": {},
+        "text": {},
+        "json": {},
+        "mime": {},
+        "dataURI": {},
+        "size": {},
+        "describe": {},
+        "toObjectResolved": {},
+        "toJSON": {},
+        "meta": {}
       },
       "mean": {
-        "time": "309ms",
+        "time": "363ms",
         "size": "586B"
       },
       "cumulativeTests": {
@@ -435,18 +491,21 @@
     },
     "collection": {
       "info": {
-        "id": "6d031f42-a134-4dba-86c5-ce154f352f33",
+        "id": "c2f7878c-aacf-45f8-8421-2dc0a8c7ec84",
         "name": "Sample Postman Collection",
         "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
       },
+      "event": [],
+      "variable": [],
       "item": [
         {
-          "id": "17d87a3b-fdc8-4b18-9815-950a42d87f59",
+          "id": "d63cd324-9f85-4fb1-99b4-fa30290cf3e5",
           "name": "A simple GET request",
           "request": {
             "url": "https://echo.getpostman.com/get?source=newman-sample-github-collection",
             "method": "GET"
           },
+          "response": [],
           "event": [
             {
               "listen": "test",
@@ -460,7 +519,7 @@
           ]
         },
         {
-          "id": "45805ccf-86f6-44d1-b1fa-18431f4025e5",
+          "id": "7a2a3985-e3a4-4402-b34d-5a293e17fccf",
           "name": "A simple POST request",
           "request": {
             "url": "https://echo.getpostman.com/post",
@@ -475,10 +534,12 @@
               "mode": "raw",
               "raw": "Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium..."
             }
-          }
+          },
+          "response": [],
+          "event": []
         },
         {
-          "id": "0d5736de-0cf1-46a9-b057-3997c275af4b",
+          "id": "143bb96b-c727-4858-bca4-cf3caaecd83c",
           "name": "A simple POST request with JSON body",
           "request": {
             "url": "https://echo.getpostman.com/post",
@@ -493,10 +554,15 @@
               "mode": "raw",
               "raw": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}"
             }
-          }
+          },
+          "response": [],
+          "event": []
         }
       ]
     },
-    "failures": 0
+    "failures": 0,
+    "responseTotal": "929B",
+    "responseAverage": "802ms",
+    "duration": "2.9s"
   }
 }

--- a/examples/reports/html-reporter-template-data.json
+++ b/examples/reports/html-reporter-template-data.json
@@ -113,18 +113,7 @@
         "body": "{\"args\":{\"source\":\"newman-sample-github-collection\"},\"headers\":{\"host\":\"echo.getpostman.com\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"user-agent\":\"PostmanRuntime/3.0.4\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"url\":\"https://echo.getpostman.com/get?source=newman-sample-github-collection\"}",
         "cookie": [],
         "responseTime": 1681,
-        "responseSize": 311,
-        "update": {},
-        "reason": {},
-        "text": {},
-        "json": {},
-        "mime": {},
-        "dataURI": {},
-        "size": {},
-        "describe": {},
-        "toObjectResolved": {},
-        "toJSON": {},
-        "meta": {}
+        "responseSize": 311
       },
       "mean": {
         "time": "1681ms",
@@ -268,18 +257,7 @@
         "body": "{\"args\":{},\"data\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\",\"files\":{},\"form\":{},\"headers\":{\"host\":\"echo.getpostman.com\",\"content-length\":\"69\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"content-type\":\"text/plain\",\"cookie\":\"sails.sid=s%3AW0Ng8epFgCZJpDdMo_odMqH3BbWD38R9.90SxQF2ceaA7UoFSfYDoZnjOhENQDYmyV8Bun6s11OM\",\"user-agent\":\"PostmanRuntime/3.0.4\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"json\":null,\"url\":\"https://echo.getpostman.com/post\"}",
         "cookie": [],
         "responseTime": 362,
-        "responseSize": 495,
-        "update": {},
-        "reason": {},
-        "text": {},
-        "json": {},
-        "mime": {},
-        "dataURI": {},
-        "size": {},
-        "describe": {},
-        "toObjectResolved": {},
-        "toJSON": {},
-        "meta": {}
+        "responseSize": 495
       },
       "mean": {
         "time": "362ms",
@@ -417,18 +395,7 @@
         "body": "{\"args\":{},\"data\":{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"},\"files\":{},\"form\":{},\"headers\":{\"host\":\"echo.getpostman.com\",\"content-length\":\"80\",\"accept\":\"*/*\",\"accept-encoding\":\"gzip, deflate\",\"content-type\":\"application/json\",\"cookie\":\"sails.sid=s%3A7t5klbchBLFRoRArWtdPF45G9vWLbWGQ.gnfG4KfjJccNvT3nO8W7xe2NiMXwud8ztejaOblFayU\",\"user-agent\":\"PostmanRuntime/3.0.4\",\"x-forwarded-port\":\"443\",\"x-forwarded-proto\":\"https\"},\"json\":{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"},\"url\":\"https://echo.getpostman.com/post\"}",
         "cookie": [],
         "responseTime": 363,
-        "responseSize": 586,
-        "update": {},
-        "reason": {},
-        "text": {},
-        "json": {},
-        "mime": {},
-        "dataURI": {},
-        "size": {},
-        "describe": {},
-        "toObjectResolved": {},
-        "toJSON": {},
-        "meta": {}
+        "responseSize": 586
       },
       "mean": {
         "time": "363ms",

--- a/examples/reports/sample-collection-report.html
+++ b/examples/reports/sample-collection-report.html
@@ -27,9 +27,9 @@
     <h3>Newman Report</h3>
     <div class="row">
         <div class="col-md-3">Collection</div><div class="col-md-9">Sample Postman Collection</div>
-        <div class="col-md-3">Description</div><div class="col-md-9">A sample collection to demonstrate collections as a set of related requests</div>
-
-        <div class="col-md-3">Time</div><div class="col-md-9">Thu Aug 25 2016 19:52:02 GMT+0530 (IST)</div>
+        <div class="col-md-3">Description</div><div class="col-md-9">A sample collection to demonstrate collections as a set of related requests&nbsp;</div>
+        <div class="col-md-3">Time</div><div class="col-md-9">Wed Nov 23 2016 01:54:46 GMT+0530 (IST)</div>
+        <div class="col-md-3">Exported with</div><div class="col-md-9">Newman v3.3.0</div>
         <div class="col-md-12">&nbsp;</div>
         <div class="col-md-4">&nbsp;</div><div class="col-md-4"><strong>Total</strong></div><div class="col-md-4"><strong>Failed</strong></div>
 
@@ -38,6 +38,11 @@
           <div class="col-md-4">Prerequest Scripts</div><div class="col-md-4">0</div><div class="col-md-4">0</div>
           <div class="col-md-4">Test Scripts</div><div class="col-md-4">1</div><div class="col-md-4">0</div>
           <div class="col-md-4">Assertions</div><div class="col-md-4">1</div><div class="col-md-4">0</div>
+
+        <div class="col-md-12">&nbsp;</div>
+        <div class="col-md-6">Total run duration</div><div class="col-md-6">2.8s</div>
+        <div class="col-md-6">Total data received</div><div class="col-md-6">928B (approx)</div>
+        <div class="col-md-6">Average response time</div><div class="col-md-6">777ms</div>
 
         <div class="col-md-12">&nbsp;</div>
         <div class="col-md-3"><strong>Total Failures</strong></div><div class="col-md-6"><strong>0</strong></div>
@@ -58,12 +63,12 @@
                 <div class="col-md-4">URL</div><div class="col-md-8"><a href="https://echo.getpostman.com/get?source&#x3D;newman-sample-github-collection" target="_blank">https://echo.getpostman.com/get?source&#x3D;newman-sample-github-collection</a></div>
 
               <div class="col-md-12">&nbsp;</div>
-              <div class="col-md-4">Mean time per request</div><div class="col-md-8">2s</div><br/>
+              <div class="col-md-4">Mean time per request</div><div class="col-md-8">1604ms</div><br/>
               <div class="col-md-4">Mean size per request</div><div class="col-md-8">311B</div><br/>
 
               <div class="col-md-12">&nbsp;</div>
               <br/><div class="col-md-4">Total passed tests</div><div class="col-md-8">1</div>
-              <div class="col-md-4">Total failed tests</div><div class="col-md-8"></div><br/>
+              <div class="col-md-4">Total failed tests</div><div class="col-md-8">0</div><br/>
 
               <div class="col-md-12">&nbsp;</div>
               <br/><div class="col-md-4">Status code</div><div class="col-md-8">200</div><br/>
@@ -94,12 +99,12 @@
                 <div class="col-md-4">URL</div><div class="col-md-8"><a href="https://echo.getpostman.com/post" target="_blank">https://echo.getpostman.com/post</a></div>
 
               <div class="col-md-12">&nbsp;</div>
-              <div class="col-md-4">Mean time per request</div><div class="col-md-8">273ms</div><br/>
+              <div class="col-md-4">Mean time per request</div><div class="col-md-8">365ms</div><br/>
               <div class="col-md-4">Mean size per request</div><div class="col-md-8">495B</div><br/>
 
               <div class="col-md-12">&nbsp;</div>
               <br/><div class="col-md-4">Total passed tests</div><div class="col-md-8">0</div>
-              <div class="col-md-4">Total failed tests</div><div class="col-md-8"></div><br/>
+              <div class="col-md-4">Total failed tests</div><div class="col-md-8">0</div><br/>
 
               <div class="col-md-12">&nbsp;</div>
               <br/><div class="col-md-4">Status code</div><div class="col-md-8">200</div><br/>
@@ -121,12 +126,12 @@
                 <div class="col-md-4">URL</div><div class="col-md-8"><a href="https://echo.getpostman.com/post" target="_blank">https://echo.getpostman.com/post</a></div>
 
               <div class="col-md-12">&nbsp;</div>
-              <div class="col-md-4">Mean time per request</div><div class="col-md-8">309ms</div><br/>
-              <div class="col-md-4">Mean size per request</div><div class="col-md-8">586B</div><br/>
+              <div class="col-md-4">Mean time per request</div><div class="col-md-8">362ms</div><br/>
+              <div class="col-md-4">Mean size per request</div><div class="col-md-8">588B</div><br/>
 
               <div class="col-md-12">&nbsp;</div>
               <br/><div class="col-md-4">Total passed tests</div><div class="col-md-8">0</div>
-              <div class="col-md-4">Total failed tests</div><div class="col-md-8"></div><br/>
+              <div class="col-md-4">Total failed tests</div><div class="col-md-8">0</div><br/>
 
               <div class="col-md-12">&nbsp;</div>
               <br/><div class="col-md-4">Status code</div><div class="col-md-8">200</div><br/>

--- a/lib/reporters/cli/cli-utils.js
+++ b/lib/reporters/cli/cli-utils.js
@@ -1,15 +1,6 @@
-var prettyms = require('pretty-ms'),
-    filesize = require('filesize'),
-    inspect = require('util').inspect,
+var inspect = require('util').inspect,
     wrap = require('word-wrap'),
     symbols = require('./cli-utils-symbols'),
-
-    /**
-     * The auxilliary character used to prettify file sizes from raw byte counts.
-     *
-     * @type {Object}
-     */
-    FILESIZE_OPTIONS = { spacer: '' },
 
     cliUtils;
 
@@ -103,26 +94,6 @@ cliUtils = {
      */
     noTTY: function () {
         return Boolean(process.env.CI) || !process.stdout.isTTY;
-    },
-
-    /**
-     * A CLI utlity helper method that prettifies and returns raw millisecond counts.
-     *
-     * @param {Number} ms - The raw millisecond count, usually from response times.
-     * @returns {String} - The pretified time, scaled to units of time, depending on the input value.
-     */
-    prettyms: function (ms) {
-        return (ms < 1998) ? `${parseInt(ms, 10)}ms` : prettyms(ms);
-    },
-
-    /**
-     * A CLI utility helper method to prettify byte counts into human readable strings.
-     *
-     * @param {Number} bytes - The raw byte count, usually from computed response sizes.
-     * @returns {String} - The prettified size, suffixed with scaled units, depending on the actual value provided.
-     */
-    filesize: function (bytes) {
-        return filesize(bytes, FILESIZE_OPTIONS);
     },
 
     /**

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -3,6 +3,7 @@ var _ = require('lodash'),
     Table = require('cli-table2'),
     format = require('util').format,
 
+    util = require('../../util'),
     cliUtils = require('./cli-utils'),
     print = require('../../print'),
     pad = cliUtils.padLeft,
@@ -132,7 +133,7 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 
         err ? print.lf(colors.red('[errored]')) :
             print.lf(colors.gray('[%d %s, %s, %s]'), o.response.code, o.response.reason(),
-                cliUtils.filesize(size), cliUtils.prettyms(o.response.responseTime));
+                util.filesize(size), util.prettyms(o.response.responseTime));
     });
 
     // Print script errors in real time
@@ -253,21 +254,21 @@ _.assignIn(PostmanCLIReporter, {
         // add the total execution time to summary
         timings && summaryTable.push([{
             colSpan: 3,
-            content: format('total run duration: %s', cliUtils.prettyms((timings.completed - timings.started) || 0)),
+            content: format('total run duration: %s', util.prettyms(timings.completed - timings.started)),
             hAlign: 'left' // since main style was set to right
         }]);
 
         // add row to show total data received
         transfers && summaryTable.push([{
             colSpan: 3,
-            content: format('total data received: %s (approx)', cliUtils.filesize(transfers.responseTotal)),
+            content: format('total data received: %s (approx)', util.filesize(transfers.responseTotal)),
             hAlign: 'left'
         }]);
 
         // add row to show average response time
         summaryTable.push([{
             colSpan: 3,
-            content: format('average response time: %s', cliUtils.prettyms(timings.responseAverage)),
+            content: format('average response time: %s', util.prettyms(timings.responseAverage)),
             hAlign: 'left'
         }]);
 

--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -1,9 +1,10 @@
 var fs = require('fs'),
-    _ = require('lodash'),
     path = require('path'),
-    fileSize = require('filesize'),
-    prettyMs = require('pretty-ms'),
+
+    _ = require('lodash'),
     handlebars = require('handlebars'),
+
+    util = require('../../util'),
 
     /**
      * An object of the default file read preferences.
@@ -98,8 +99,8 @@ PostmanHTMLReporter = function (newman, options) {
 
             _.merge(currentAggregation, {
                 mean: {
-                    time: prettyMs(_.get(meanTime, 'sum', 0) / _.get(meanTime, 'count', 1)),
-                    size: fileSize(_.get(meanSize, 'sum', 0) / _.get(meanSize, 'count', 1), { spacer: '' })
+                    time: util.prettyms(_.get(meanTime, 'sum') / _.get(meanTime, 'count')),
+                    size: util.filesize(_.get(meanSize, 'sum') / _.get(meanSize, 'count'))
                 },
                 cumulativeTests: _.get(netTestCounts, currentId)
             });
@@ -113,11 +114,15 @@ PostmanHTMLReporter = function (newman, options) {
             path: options.export,
             content: compiler({
                 timestamp: Date(),
+                version: util.version,
                 aggregations: aggregations,
                 summary: {
                     stats: this.summary.run.stats,
                     collection: this.summary.collection,
-                    failures: this.summary.run.failures.length
+                    failures: this.summary.run.failures.length,
+                    responseTotal: util.filesize(this.summary.run.transfers.responseTotal),
+                    responseAverage: util.prettyms(this.summary.run.timings.responseAverage),
+                    duration: util.prettyms(this.summary.run.timings.completed - this.summary.run.timings.started)
                 }
             })
         });

--- a/lib/reporters/html/template-default.hbs
+++ b/lib/reporters/html/template-default.hbs
@@ -30,8 +30,8 @@
         <div class="col-md-3">Collection</div><div class="col-md-9">{{collection.name}}</div>
         {{#if collection.description}}<div class="col-md-3">Description</div><div class="col-md-9">{{collection.description}}&nbsp;</div>{{/if}}
       {{/with}}
-
         <div class="col-md-3">Time</div><div class="col-md-9">{{timestamp}}</div>
+        <div class="col-md-3">Exported with</div><div class="col-md-9">Newman v{{version}}</div>
         <div class="col-md-12">&nbsp;</div>
         <div class="col-md-4">&nbsp;</div><div class="col-md-4"><strong>Total</strong></div><div class="col-md-4"><strong>Failed</strong></div>
 
@@ -43,6 +43,11 @@
           <div class="col-md-4">Test Scripts</div><div class="col-md-4">{{testScripts.total}}</div><div class="col-md-4">{{testScripts.failed}}</div>
           <div class="col-md-4">Assertions</div><div class="col-md-4">{{assertions.total}}</div><div class="col-md-4">{{assertions.failed}}</div>
         {{/with}}
+
+        <div class="col-md-12">&nbsp;</div>
+        <div class="col-md-6">Total run duration</div><div class="col-md-6">{{duration}}</div>
+        <div class="col-md-6">Total data received</div><div class="col-md-6">{{responseTotal}} (approx)</div>
+        <div class="col-md-6">Average response time</div><div class="col-md-6">{{responseAverage}}</div>
 
         <div class="col-md-12">&nbsp;</div>
         <div class="col-md-3"><strong>Total Failures</strong></div><div class="col-md-6"><strong>{{failures}}</strong></div>

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,12 +1,30 @@
-var _ = require('lodash'),
+var fs = require('fs'),
+
+    _ = require('lodash'),
+    prettyms = require('pretty-ms'),
+    filesize = require('filesize'),
     request = require('postman-request'),
     parseJson = require('parse-json'),
-    fs = require('fs'),
+
     version = require('../package.json').version,
+
+    /**
+     * The auxilliary character used to prettify file sizes from raw byte counts.
+     *
+     * @type {Object}
+     */
+    FILESIZE_OPTIONS = { spacer: '' },
 
     USER_AGENT_VALUE = 'Newman/' + version;
 
 module.exports = {
+
+    /**
+     * The raw newman version, taken from package.json in the root directory
+     *
+     * @type {String}
+     */
+    version: version,
 
     /**
      * The user agent that this newman identifies as.
@@ -14,6 +32,26 @@ module.exports = {
      * @type {String}
      */
     userAgent: USER_AGENT_VALUE,
+
+    /**
+     * A utility helper method that prettifies and returns raw millisecond counts.
+     *
+     * @param {Number} ms - The raw millisecond count, usually from response times.
+     * @returns {String} - The pretified time, scaled to units of time, depending on the input value.
+     */
+    prettyms: function (ms) {
+        return (ms < 1998) ? `${parseInt(ms, 10)}ms` : prettyms(ms || 0);
+    },
+
+    /**
+     * A utility helper method to prettify byte counts into human readable strings.
+     *
+     * @param {Number} bytes - The raw byte count, usually from computed response sizes.
+     * @returns {String} - The prettified size, suffixed with scaled units, depending on the actual value provided.
+     */
+    filesize: function (bytes) {
+        return filesize(bytes || 0, FILESIZE_OPTIONS);
+    },
 
     /**
      * Loads JSON data from the given location.


### PR DESCRIPTION
Partly inspired by #763 

* Shifted `prettyms` and `filesize` methods to `lib/util.js`
* Updated CLI and HTML reporters to use new util helpers.
* Added average and response times, total data transferred, and overall run duration to HTML report.
* Updated sample data in examples/reports

![newman html report](https://cloud.githubusercontent.com/assets/7289840/20541526/a6ae6d62-b123-11e6-8644-d8fc32f79cfe.png)
