### PR TITLE
Travis: Cache node_modules for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ node_js:
 notifications:
   slack:
     secure: Fdl/sQMTl86jYN1r1CRRRQRgyFoslvrhkkfnM2JSdx4gODPgyg4nCPSKtU5j9wpSbbkq9A+YBeFv+Suh+xYNviegqa0AZbztydfFzVDS7xw43B/uR9Y4LwaP5Kis1WGuIOHawwFISNO3hTUei6aybKiKKlxvfqrARJaO01+Xxrg=
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
`npm install` takes ~24s (out of ~80s build time)

Travis added this feature back [in 2014](https://docs.travis-ci.com/user/caching/).

It will update `node_modules` only when `package.json` is modified.