### PR TITLE
Added option to force colored output

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ newman.run({
 - `-x`, `--suppress-exit-code`<br />
   Specify whether or not to override the default exit code for the current run.
 
+- `--color`<br />
+  Use this option to force colored CLI output (for use in CLI for CI / non TTY environments).
+
 - `--no-color`<br />
   Newman attempts to automatically turn off color output to terminals when it detects the lack of color support. With
   this property, one can forcibly turn off the usage of color in terminal output for reporters and other parts of Newman
@@ -284,6 +287,7 @@ return of the `newman.run` function is a run instance, which emits run events th
 | options.suppressExitCode  | If present, allows overriding the default exit code from the current collection run, useful for bypassing collection result failures. Takes no arguments.<br /><br />_Optional_<br />Type: `boolean`, Default value: `false` |
 | options.reporters         | Specify one reporter name as `string` or provide more than one reporter name as an `array`.<br /><br />Available reporters: `cli`, `json`, `html` and `junit`.<br /><br />_Optional_<br />Type: `string|array` |
 | options.reporter          | Specify options for the reporter(s) declared in `options.reporters`. <br /> e.g. `reporter : { junit : { export : './xmlResults.xml' } }` <br /> e.g. `reporter : { html : { export : './htmlResults.html', template: './customTemplate.hbs' } }` <br /><br />_Optional_<br />Type: `object` |
+| options.color             | Forces colored CLI output (for use in CI / non TTY environments).<br /><br />_Optional_<br />Type: `boolean` |
 | options.noColor           | Newman attempts to automatically turn off color output to terminals when it detects the lack of color support. With this property, one can forcibly turn off the usage of color in terminal output for reporters and other parts of Newman that output to console.<br /><br />_Optional_<br />Type: `boolean` |
 | options.sslClientCert     | The path to the public client certificate file.<br /><br />_Optional_<br />Type: `string` |
 | options.sslClientKey      | The path to the private client key file.<br /><br />_Optional_<br />Type: `string` |

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -253,6 +253,11 @@ var _ = require('lodash'),
             action: 'storeTrue'
         });
 
+        commonParser.addArgument(['--color'], {
+            help: 'Force colored output (for use in CI environments)',
+            action: 'storeTrue'
+        });
+
         return commonParser;
     },
 

--- a/lib/reporters/cli/cli-utils.js
+++ b/lib/reporters/cli/cli-utils.js
@@ -90,22 +90,23 @@ cliUtils = {
     /**
      * A CLI utility helper method that checks for the non TTY compliance of the current run environment.
      *
+     * @param {Boolean} - A flag to indicate usage of the --color option.
      * @returns {Boolean} - A boolean value depicting the result of the noTTY check.
      */
-    noTTY: function () {
-        return Boolean(process.env.CI) || !process.stdout.isTTY;
+    noTTY: function (color) {
+        return !color && (Boolean(process.env.CI) || !process.stdout.isTTY);
     },
 
     /**
      * A CLI utility helper method that generates a color inspector function for CLI reports.
      *
-     * @param {Boolean} noColor - A boolean value to indicate if the --no-color flag was used.
+     * @param {Object} runOptions - The set of run options acquired via the runner.
      * @return {Function} - A function to perform utils.inspect, given a sample item, under pre-existing options.
      */
-    inspector: function (noColor) {
+    inspector: function (runOptions) {
         var dimension = cliUtils.dimension(),
             options = {
-                colors: !(noColor || cliUtils.noTTY()),
+                colors: !(runOptions.noColor || cliUtils.noTTY(runOptions.color)),
                 // note that similar dimension calculation is in utils.wrapper
                 breakLength: ((dimension.exists && (dimension.width > 20)) ? dimension.width : 60) - 16
             };


### PR DESCRIPTION
- [X] Added `--color` option.
- [X] Modified noTTY detection to work with the `--color` option.
- [X] Added documentation for `--color`, `options.color`.