### PR TITLE
HTML report folder designation

### DIFF
--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -47,8 +47,11 @@ var fs = require('fs'),
  */
 PostmanHTMLReporter = function (newman, options) {
     // @todo throw error here or simply don't catch them and it will show up as warning on newman
-    var htmlTemplate = options.template || path.join(__dirname, DEFAULT_TEMPLATE),
+    var aggregationPartial = path.join(__dirname, 'partials', 'aggregations.hbs'),
+        htmlTemplate = options.template || path.join(__dirname, DEFAULT_TEMPLATE),
         compiler = handlebars.compile(fs.readFileSync(htmlTemplate, FILE_READ_OPTIONS));
+
+    handlebars.registerPartial('aggregations', fs.readFileSync(aggregationPartial, FILE_READ_OPTIONS));
 
     newman.on('beforeDone', function () {
         var items = {},

--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -51,7 +51,7 @@ PostmanHTMLReporter = function (newman, options) {
         compiler = handlebars.compile(fs.readFileSync(htmlTemplate, FILE_READ_OPTIONS));
 
     newman.on('beforeDone', function () {
-        var aggregations = [],
+        var items = {},
             executionMeans = {},
             netTestCounts = {},
             traversedRequests = {},
@@ -75,7 +75,7 @@ PostmanHTMLReporter = function (newman, options) {
                     reducedExecution.response = reducedExecution.response.toJSON();
 
                     // set sample request and response details for the current request
-                    aggregations.push(reducedExecution);
+                    items[reducedExecution.item.id] = reducedExecution;
                 }
 
                 executionMeans[executionId].time.sum += _.get(currentExecution, 'response.responseTime', 0);
@@ -100,24 +100,26 @@ PostmanHTMLReporter = function (newman, options) {
                     ++aggregationResult[updateKey];
                     ++netTestCounts[executionId][updateKey];
                 });
-            }, {});
+            }, {}),
 
-        _.forEach(aggregations, function (currentAggregation) {
-            var currentId = currentAggregation.item.id,
-                aggregationMean = _.get(executionMeans, currentId),
-                meanTime = _.get(aggregationMean, 'time'),
-                meanSize = _.get(aggregationMean, 'size');
+            aggregator = function (item) {
+                if (item.items) {
+                    return { folder: item.name, contents: item.items.map(aggregator) };
+                }
 
-            _.merge(currentAggregation, {
-                mean: {
-                    time: util.prettyms(_.get(meanTime, 'sum') / _.get(meanTime, 'count')),
-                    size: util.filesize(_.get(meanSize, 'sum') / _.get(meanSize, 'count'))
-                },
-                cumulativeTests: _.get(netTestCounts, currentId)
-            });
+                var aggregationMean = executionMeans[item.id],
+                    meanTime = aggregationMean.time,
+                    meanSize = aggregationMean.size;
 
-            _.set(currentAggregation, 'assertions', _.values(_.get(assertions, currentId)));
-        });
+                return _.merge(items[item.id], {
+                    assertions: _.values(assertions[item.id]),
+                    mean: {
+                        time: util.prettyms(meanTime.sum / meanTime.count),
+                        size: util.filesize(meanSize.sum / meanSize.count)
+                    },
+                    cumulativeTests: netTestCounts[item.id]
+                });
+            };
 
         this.exports.push({
             name: 'html-reporter',
@@ -126,7 +128,7 @@ PostmanHTMLReporter = function (newman, options) {
             content: compiler({
                 timestamp: Date(),
                 version: util.version,
-                aggregations: aggregations,
+                aggregations: _.map(this.summary.collection.items.members, aggregator),
                 summary: {
                     stats: this.summary.run.stats,
                     collection: this.summary.collection,

--- a/lib/reporters/html/partials/aggregations.hbs
+++ b/lib/reporters/html/partials/aggregations.hbs
@@ -1,0 +1,56 @@
+{{#if folder}}
+    <div class="panel-group" id="collapse-folder-{{@index}}" role="tablist" aria-multiselectable="true">
+        <div class="panel-heading" role="tab" id="folderHead-{{@index}}">
+            <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#folderData-{{@index}}" aria-controls="collapseOne"><strong>{{folder}}</strong></a></h4>
+        </div>
+
+        <div id="folderData-{{@index}}" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="folderHead-{{@index}}">
+            {{#each contents}}{{> aggregations}}{{/each}}
+        </div>
+    </div>
+{{else}}
+    <div class="panel-group" id="collapse-request-{{item.id}}" role="tablist" aria-multiselectable="true">
+        <div class="panel panel-default">
+            <div class="panel-heading" role="tab" id="requestHead-{{item.id}}">
+                <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#requestData-{{item.id}}" aria-controls="collapseOne">{{item.name}}</a></h4>
+            </div>
+
+            <div id="requestData-{{item.id}}" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="requestHead-{{item.id}}">
+                <div class="panel-body">
+                    {{#with request}}
+                        {{#if description.content}}
+                            <div class="col-md-4">Description</div><div class="col-md-8" style="white-space: pre-wrap;">{{description.content}}</div>
+                            <div class="col-md-12">&nbsp;</div>
+                        {{/if}}
+
+                        <div class="col-md-4">Method</div><div class="col-md-8">{{method}}</div>
+                        <div class="col-md-4">URL</div><div class="col-md-8"><a href="{{url}}" target="_blank">{{url}}</a></div>
+                    {{/with}}
+
+                    <div class="col-md-12">&nbsp;</div>
+                    <div class="col-md-4">Mean time per request</div><div class="col-md-8">{{mean.time}}</div><br/>
+                    <div class="col-md-4">Mean size per request</div><div class="col-md-8">{{mean.size}}</div><br/>
+
+                    <div class="col-md-12">&nbsp;</div>
+                    <br/><div class="col-md-4">Total passed tests</div><div class="col-md-8">{{cumulativeTests.passed}}</div>
+                    <div class="col-md-4">Total failed tests</div><div class="col-md-8">{{cumulativeTests.failed}}</div><br/>
+
+                    <div class="col-md-12">&nbsp;</div>
+                    <br/><div class="col-md-4">Status code</div><div class="col-md-8">{{response.code}}</div><br/>
+
+                    {{#if assertions.length}}
+                        <div class="col-md-12">&nbsp;</div>
+                        <div class="col-md-4">Tests</div>
+
+                        <div class="col-md-8">
+                            <table class="table table-responsive table-condensed">
+                                <thead><tr><th>Name</th><th>Pass count</th><th>Fail count</th></tr></thead>
+                                <tbody>{{#each assertions}}<tr><td>{{this.name}}</td><td>{{this.passed}}</td><td>{{this.failed}}</td></tr>{{/each}}</tbody>
+                            </table>
+                        </div>
+                    {{/if}}
+                </div>
+            </div>
+        </div>
+    </div>
+{{/if}}

--- a/lib/reporters/html/template-default.hbs
+++ b/lib/reporters/html/template-default.hbs
@@ -56,52 +56,7 @@
 
     <br/><h4>Requests</h4>
 
-    {{#each aggregations}}
-      <div class="panel-group" id="collapse-request-{{@index}}" role="tablist" aria-multiselectable="true">
-        <div class="panel panel-default">
-          <div class="panel-heading" role="tab" id="requestHead-{{@index}}">
-            <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#requestData-{{@index}}" aria-controls="collapseOne">{{item.name}}</a></h4>
-          </div>
-
-          <div id="requestData-{{@index}}" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="requestHead-{{@index}}">
-            <div class="panel-body">
-              {{#with request}}
-                {{#if description.content}}
-                  <div class="col-md-4">Description</div><div class="col-md-8" style="white-space: pre-wrap;">{{description.content}}</div>
-                  <div class="col-md-12">&nbsp;</div>
-                {{/if}}
-
-                <div class="col-md-4">Method</div><div class="col-md-8">{{method}}</div>
-                <div class="col-md-4">URL</div><div class="col-md-8"><a href="{{url}}" target="_blank">{{url}}</a></div>
-              {{/with}}
-
-              <div class="col-md-12">&nbsp;</div>
-              <div class="col-md-4">Mean time per request</div><div class="col-md-8">{{mean.time}}</div><br/>
-              <div class="col-md-4">Mean size per request</div><div class="col-md-8">{{mean.size}}</div><br/>
-
-              <div class="col-md-12">&nbsp;</div>
-              <br/><div class="col-md-4">Total passed tests</div><div class="col-md-8">{{cumulativeTests.passed}}</div>
-              <div class="col-md-4">Total failed tests</div><div class="col-md-8">{{cumulativeTests.failed}}</div><br/>
-
-              <div class="col-md-12">&nbsp;</div>
-              <br/><div class="col-md-4">Status code</div><div class="col-md-8">{{response.code}}</div><br/>
-
-              {{#if assertions.length}}
-                <div class="col-md-12">&nbsp;</div>
-                <div class="col-md-4">Tests</div>
-
-                <div class="col-md-8">
-                  <table class="table table-responsive table-condensed">
-                    <thead><tr><th>Name</th><th>Pass count</th><th>Fail count</th></tr></thead>
-                    <tbody>{{#each assertions}}<tr><td>{{this.name}}</td><td>{{this.passed}}</td><td>{{this.failed}}</td></tr>{{/each}}</tbody>
-                  </table>
-                </div>
-              {{/if}}
-            </div>
-          </div>
-        </div>
-      </div>
-    {{/each}}
+    {{#each aggregations}}{{> aggregations}}{{/each}}
   </div>
 </body>
 </html>


### PR DESCRIPTION
Inspired by #825 
- [X] Entire folder sections can be collapsed as needed.
- [X] Theoretically, folder mapping will work with infinitely deep folder nesting.
- [X] Works with folder only, singular requests only, and hybrid structured collections as well.

![newman html report folders](https://cloud.githubusercontent.com/assets/7289840/21335134/fe2fa378-c675-11e6-8b65-a40d1e6a1d9d.png)

