### PR TITLE
Better HTML report folder style

### DIFF
--- a/lib/reporters/html/partials/aggregations.hbs
+++ b/lib/reporters/html/partials/aggregations.hbs
@@ -1,9 +1,9 @@
 {{#if folder}}
     <div class="panel-group" id="collapse-folder-{{@index}}" role="tablist" aria-multiselectable="true">
-        <div class="panel-heading" role="tab" id="folderHead-{{@index}}">
-            <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#folderData-{{@index}}" aria-controls="collapseOne"><strong>{{folder}}</strong></a></h4>
+        <div role="tab" id="folderHead-{{@index}}">
+            <h4 style="font-size: 18px;" class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#folderData-{{@index}}" aria-controls="collapseOne"><strong>{{folder}}</strong></a></h4>
         </div>
-
+        <br/>
         <div id="folderData-{{@index}}" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="folderHead-{{@index}}">
             {{#each contents}}{{> aggregations}}{{/each}}
         </div>


### PR DESCRIPTION
* Folder headings have been made larger and shifted slightly to the left.

Before:
![](https://cloud.githubusercontent.com/assets/7289840/21335134/fe2fa378-c675-11e6-8b65-a40d1e6a1d9d.png)

After:
![better html report folders](https://cloud.githubusercontent.com/assets/7289840/21496560/5ebec1ae-cc45-11e6-8911-0de2478edcc7.png)
