### PR TITLE
Converting JUnit Reporter responseTime

### DIFF
--- a/lib/reporters/junit/index.js
+++ b/lib/reporters/junit/index.js
@@ -90,7 +90,7 @@ JunitReporter = function (newman, reporterOptions) {
             });
 
             suite.att('time', _.mean(_.map(executions, function (execution) {
-                return _.get(execution, 'response.responseTime') || 0;
+                return _.get(execution, 'response.responseTime') / 1000 || 0;
             })));
             errorMessages && suite.ele('error').dat(errorMessages);
 


### PR DESCRIPTION
Resolves issue #862 Converting JUnit reporter responseTime from milliseconds to seconds