### PR TITLE
Objectified iteration data

### DIFF
--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -186,11 +186,14 @@ var _ = require('lodash'),
         /**
          * The iterationData loader module, with support for JSON or CSV data files.
          *
-         * @param {String} location - The path to the iteration data file for the current collectio run.
+         * @param {String|Object[]} location - The path to the iteration data file for the current collectio run, or
+         * the array of iteration data objects.
          * @param {Function} callback - The function invoked to indicate the end of the iteration data loading routine.
          * @returns {*}
          */
         iterationData: function (location, callback) {
+            if (_.isArray(location)) { return callback(null, location); }
+
             util.fetch(location, function (err, data) {
                 if (err) {
                     return callback(err);

--- a/test/library/run-options.test.js
+++ b/test/library/run-options.test.js
@@ -25,4 +25,15 @@ describe('Newman run options', function () {
             done();
         });
     });
+
+    it('should accept iterationData as an array of objects', function (done) {
+        newman.run({
+            collection: 'test/integration/steph/steph.postman_collection.json',
+            iterationData: require('../integration/steph/steph.postman_data.json')
+        }, function (err, summary) {
+            expect(err).to.not.be.ok();
+            expect(summary.run.failures).to.be.empty();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Inspired by #895

Context: Newman programmatic usage.

* With this pull request, `options.iterationData` can be specified as an array of objects as well.