### PR TITLE
Add response body to CLI reporter

### DIFF
--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -119,8 +119,8 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
         size = size && (size.header || 0) + (size.body || 0) || 0;
 
         err ? print.lf(colors.red('[errored]')) :
-            print.lf(colors.gray('[%d %s, %s, %s]'), o.response.code, o.response.reason(),
-                util.filesize(size), util.prettyms(o.response.responseTime));
+            print.lf(colors.gray('[%d %s, %s, %s]\nResponse body:\n%s'), o.response.code, o.response.reason(),
+                util.filesize(size), util.prettyms(o.response.responseTime), o.response.body);
     });
 
     // Print script errors in real time


### PR DESCRIPTION
When doing automated testing with newman we often encounter the problem, that a test is failing but we don’t know why exactly. So here the response body is very helpful in giving a hint to what really went wrong.
I wanted to include the body only when a test script is failing but unfortunately this information is not passed in the function I changed.   