### PR TITLE
Bumped recursive-readdir to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "packity": "0.3.2",
     "parse-gitignore": "0.4.0",
     "postman-jsdoc-theme": "0.0.2",
-    "recursive-readdir": "2.2.0"
+    "recursive-readdir": "2.2.1"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
`v.2.2.0` was withdrawn from npmjs.org