### PR TITLE
Restore HTML reporter response body

### DIFF
--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -76,6 +76,7 @@ PostmanHTMLReporter = function (newman, options) {
 
                     if (reducedExecution.response && _.isFunction(reducedExecution.response.toJSON)) {
                         reducedExecution.response = reducedExecution.response.toJSON();
+                        reducedExecution.response.body = reducedExecution.response.stream.toString();
                     }
 
                     // set sample request and response details for the current request

--- a/test/library/shallow-html-reporter.test.js
+++ b/test/library/shallow-html-reporter.test.js
@@ -71,4 +71,24 @@ describe('HTML reporter', function () {
             fs.stat(outFile, done);
         });
     });
+
+    describe('backward compatibility', function () {
+        it('should not mutate the run summary', function (done) {
+            newman.run({
+                collection: 'test/fixtures/run/single-get-request.json',
+                reporters: ['html'],
+                reporter: { html: { export: outFile } }
+            }, function (err, summary) {
+                expect(err).to.be(null);
+                expect(summary.run.failures).to.have.length(0);
+
+                summary.run.executions.forEach(function (exec) {
+                    // The body property is only accessible to the HTML reporter
+                    expect(exec.response).to.not.have.property('body');
+                });
+
+                fs.stat(outFile, done);
+            });
+        });
+    });
 });


### PR DESCRIPTION
This does not mutate the original execution summary