### PR TITLE
Update index.js

### DIFF
--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -76,7 +76,7 @@ PostmanHTMLReporter = function (newman, options) {
 
                     if (reducedExecution.response && _.isFunction(reducedExecution.response.toJSON)) {
                         reducedExecution.response = reducedExecution.response.toJSON();
-                        reducedExecution.response.body = reducedExecution.response.stream.toString();
+                        reducedExecution.response.body = Buffer.from(reducedExecution.response.stream).toString();
                     }
 
                     // set sample request and response details for the current request


### PR DESCRIPTION
converted response.body to buffer otherwise toString of standard object is called returning [object Object] as a string. Refer to https://github.com/postmanlabs/newman/issues/1037