### PR TITLE
Upgrade nodejs version to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "recursive-readdir": "2.2.1"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
Upgrade nodejs version to 6, for removing error Buffer.from
TypeError: this is not a typed array.
    at Function.from (native)
    at /home/shashanktyagi/repo/regression/node_modules/newman/lib/reporters/html/index.js:79:65
    at /home/shashanktyagi/repo/regression/node_modules/newman/node_modules/lodash/lodash.js:13767:16
    at arrayEach (/home/shashanktyagi/repo/regression/node_modules/newman/node_modules/lodash/lodash.js:537:11)
    at Function.transform (/home/shashanktyagi/repo/regression/node_modules/newman/node_modules/lodash/lodash.js:13766:43)
    at EventEmitter.<anonymous> (/home/shashanktyagi/repo/regression/node_modules/newman/lib/reporters/html/index.js:60:28)
    at EventEmitter.emit (/home/shashanktyagi/repo/regression/node_modules/newman/node_modules/eventemitter3/index.js:151:33)
    at _.assignIn.done (/home/shashanktyagi/repo/regression/node_modules/newman/lib/run/index.js:221:29)
    at /home/shashanktyagi/repo/regression/node_modules/newman/node_modules/postman-runtime/lib/backpack/index.js:56:34
    at PostmanCollectionRun._.assign._process (/home/shashanktyagi/repo/regression/node_modules/newman/node_modules/postman-runtime/lib/runner/run.js:133:20)