### PR TITLE
The html reporter generate the same block for different iteration.

### DIFF
--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -123,7 +123,7 @@ PostmanHTMLReporter = function (newman, options) {
                     meanSize = _.get(aggregationMean, 'size', 0),
                     parent = execution.item.parent(),
                     previous = _.last(aggregations),
-                    current = _.merge(items[execution.item.id], {
+                    current = _.merge(execution, {
                         assertions: _.values(assertions[execution.item.id]),
                         mean: {
                             time: util.prettyms(meanTime.sum / meanTime.count),


### PR DESCRIPTION
Since we run the newman for testing the APIs,we need to run a collection in difference parameter like:
https://github.com/auth=1
https://github.com/auth=2
Make a CSV file to let it run in a collection,and actually the html report return 
https://github.com/auth=1
https://github.com/auth=1
results in report.
