### PR TITLE
Commander cleanup

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -161,6 +161,8 @@ var _ = require('lodash'),
         program
             .version(version);
 
+        program.name = 'newman';
+
         program
             .command('run <collection>')
             .description('URL or path to a Postman Collection.')
@@ -420,9 +422,8 @@ var _ = require('lodash'),
         // This hack has been added from //https://github.com/mochajs/mocha/blob/961c5392480a6e9ca730e43a4e86fde0d4420fc9/bin/_mocha#L20//2-L211
         // @todo remove when https://github.com/tj/commander.js/issues/691 is fixed.
         checkForColor = _.includes(rawArgs.argv, '--no-color') || _.includes(rawArgs.argv, '--noColor');
-        vPos = rawArgs.argv.indexOf('-v');
-        if (vPos > -1) {
-            rawArgs.argv[vPos] = '-V';
+        if ((vPos = rawArgs.argv.indexOf('-v')) > -1) {
+            rawArgs[vPos] = '-V';
         }
         if (checkForColor) {
             result.color = false;

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -99,7 +99,7 @@ var _ = require('lodash'),
      * @private
      */
     legacy = function (rawArgs) {
-        resetProgram(program);
+        resetProgram();
         program
             .version(version)
             .option('-c, --collection <path>', 'DEPRECATED: Specify a Postman collection as a JSON file')
@@ -157,13 +157,14 @@ var _ = require('lodash'),
      */
 
     run = function (rawArgs) {
-        resetProgram(program);
+        resetProgram();
         program
             .version(version);
 
         program
             .command('run <collection>')
             .description('URL or path to a Postman Collection.')
+            .usage('<collection> [options]')
             .option('-e, --environment <path>', 'Specify a URL or Path to a Postman Environment.')
             .option('-g, --globals <path>', 'Specify a URL or Path to a file containing Postman Globals.')
             .option('--folder <path>', 'Run a single folder from a collection.')
@@ -373,7 +374,8 @@ var _ = require('lodash'),
             reporterArgs,
             rawArgs,
             result,
-            checkForColor;
+            checkForColor,
+            vPos;
 
         rawArgs = separateReporterArgs(procArgv);
         try {
@@ -418,6 +420,10 @@ var _ = require('lodash'),
         // This hack has been added from //https://github.com/mochajs/mocha/blob/961c5392480a6e9ca730e43a4e86fde0d4420fc9/bin/_mocha#L20//2-L211
         // @todo remove when https://github.com/tj/commander.js/issues/691 is fixed.
         checkForColor = _.includes(rawArgs.argv, '--no-color') || _.includes(rawArgs.argv, '--noColor');
+        vPos = rawArgs.argv.indexOf('-v');
+        if (vPos > -1) {
+            rawArgs.argv[vPos] = '-V';
+        }
         if (checkForColor) {
             result.color = false;
             result.noColor = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman",
-  "version": "3.9.0-beta.1",
+  "version": "3.9.0-beta.2",
   "description": "Command-line companion utility for Postman",
   "homepage": "https://github.com/postmanlabs/newman",
   "bugs": "https://github.com/postmanlabs/newman/issues",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "author": "Postman Labs <help@getpostman.com> (=)",
   "license": "Apache-2.0",
   "dependencies": {
-    "argparse": "1.0.9",
     "async": "2.6.0",
     "cli-progress": "1.6.0",
     "cli-table2": "0.2.0",


### PR DESCRIPTION
- Added support for `-v` for version display.
- Modified help usage to correct the order of `<collection>` and `[options]` in help.
- Removed `argparse` from package.json