### PR TITLE
Use error names from error object in the stack for the constructed psuedo error

### DIFF
--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -260,12 +260,12 @@ module.exports = function (options, callback) {
 
             emitter.on('script', function (err, o) {
                 // bubble special script name based events
-                o && o.event && o.event && emitter.emit(o.event.listen + 'Script', err, o);
+                o && o.event && emitter.emit(o.event.listen + 'Script', err, o);
             });
 
             emitter.on('beforeScript', function (err, o) {
                 // bubble special script name based events
-                o && o.event && o.event && emitter.emit(_.camelCase('before-' + o.event.listen + 'Script'), err, o);
+                o && o.event && emitter.emit(_.camelCase('before-' + o.event.listen + 'Script'), err, o);
             });
 
             // initialise all the reporters

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -183,17 +183,19 @@ module.exports = function (options, callback) {
                 assertion: function (cursor, assertions) {
 
                     _.forEach(assertions, function (assertion) {
+                        var errorName = _.get(assertion, 'error.name', 'AssertionError');
+
                         !assertion && (assertion = {});
 
                         // store the legacy assertion index
                         assertion.index && (legacyAssertionIndices[cursor.ref] = assertion.index);
 
                         emitter.emit('assertion', (assertion.passed ? null : {
-                            name: _.get(assertion, 'error.name', 'AssertionFailure'),
+                            name: errorName,
                             index: assertion.index,
                             message: _.get(assertion, 'error.message', assertion.name || ''),
 
-                            stack: 'AssertionFailure: ' + _.get(assertion, 'error.message', '') + '\n' +
+                            stack: errorName + ': ' + _.get(assertion, 'error.message', '') + '\n' +
                                 '   at Object.eval sandbox-script.js:' + (assertion.index + 1) + ':' +
                                 ((cursor && cursor.position || 0) + 1) + ')'
                         }), {


### PR DESCRIPTION
Reusing the same error name from the error object from runtime in the constructed error object stack.