### PR TITLE
Support for missing options for runtime v7.10

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -72,10 +72,10 @@ var _ = require('lodash'),
     },
 
     /**
-     *  used for converting string of host names to an array
+     *  used for converting a comma separated string to an array
      *
-     * @param {String} list - The string of host names
-     * @returns {Array} - The array representation of the host names.
+     * @param {String} list - The comma separated string
+     * @returns {Array} - The array representation of the string.
     */
     arrayCollect = function (list) {
         return list.split(',');

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -72,19 +72,13 @@ var _ = require('lodash'),
     },
 
     /**
-     *  used for converting host names to the required object format.
+     *  used for converting string of host names to an array
      *
-     * --block-hosts 192.168.1.1
-     *
-     * @param {Array} hosts - The array of host name to block
-     * @returns {Object} - {host : true} - The object representation of the host names.
+     * @param {String} list - The string of host names
+     * @returns {Array} - The array representation of the host names.
     */
-    hostCollect = function (hosts) {
-        var obj = {};
-        hosts.split(',').forEach(function (host) {
-            obj[host] = true;
-        });
-        return obj;
+    arrayCollect = function (list) {
+        return list.split(',');
     },
 
     /**
@@ -220,7 +214,9 @@ var _ = require('lodash'),
                 'Specify the Client SSL passphrase (optional, needed for passphrase protected keys).')
             .option('--abort-on-error', 'Abruptly halts the run on errors, and directly calls the done callback')
             .option('--delay-iteration [n]', 'Configure delays (in ms) between iterations', Integer, 1000)
-            .option('--block-hosts [hosts]', 'Allows restricting IP/host in requests', hostCollect, {})
+            .option('--restricted-addresses <hosts>', 'Allows restricting IP/host in requests', arrayCollect)
+            .option('--entrypoint-execute <id>', 'Execute a folder/request using id or name')
+            .option('--entrypoint-path <path>', 'Execute a folder/request using a path', arrayCollect)
             .parse(rawArgs);
     },
 

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -72,6 +72,22 @@ var _ = require('lodash'),
     },
 
     /**
+     *  used for converting host names to the required object format.
+     *
+     * --block-hosts 192.168.1.1
+     *
+     * @param {Array} hosts - The array of host name to block
+     * @returns {Object} - {host : true} - The object representation of the host names.
+    */
+    hostCollect = function (hosts) {
+        var obj = {};
+        hosts.split(',').forEach(function (host) {
+            obj[host] = true;
+        });
+        return obj;
+    },
+
+    /**
      *  used for resetting the program instance for consecutive runs.
     */
     resetProgram = function () {
@@ -202,6 +218,9 @@ var _ = require('lodash'),
                 'Specify the path to the Client SSL key (not needed for .pfx files)')
             .option('--ssl-client-passphrase <path>',
                 'Specify the Client SSL passphrase (optional, needed for passphrase protected keys).')
+            .option('--abort-on-error', 'Abruptly halts the run on errors, and directly calls the done callback')
+            .option('--delay-iteration [n]', 'Configure delays (in ms) between iterations', Integer, 1000)
+            .option('--block-hosts [hosts]', 'Allows restricting IP/host in requests', hostCollect, {})
             .parse(rawArgs);
     },
 

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -217,6 +217,7 @@ var _ = require('lodash'),
             .option('--restricted-addresses <hosts>', 'Allows restricting IP/host in requests', arrayCollect)
             .option('--entrypoint-execute <id>', 'Execute a folder/request using id or name')
             .option('--entrypoint-path <path>', 'Execute a folder/request using a path', arrayCollect)
+            .option('--execute-strategy [name]', 'Specify the execution strategy to be followed', 'path')
             .parse(rawArgs);
     },
 

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -84,6 +84,14 @@ module.exports = function (options, callback) {
             return callback(new Error('newman: expecting a collection to run'));
         }
 
+        if (!_.isEmpty(options.restrictedAddresses)) {
+            var obj = {};
+            options.restrictedAddresses.forEach(function (host) {
+                obj[host] = true;
+            });
+            options.restrictedAddresses = obj;
+        }
+
         // store summary object and other relevant information inside the emitter
         emitter.summary = new RunSummary(emitter, options);
 
@@ -98,7 +106,10 @@ module.exports = function (options, callback) {
             iterationCount: options.iterationCount,
             environment: options.environment,
             globals: options.globals,
-            entrypoint: options.folder,
+            entrypoint: {
+                execute: options.entrypointExecute,
+                path: options.entrypointPath || options.folder
+            },
             data: options.iterationData,
             delay: {
                 item: options.delayRequest,
@@ -115,7 +126,7 @@ module.exports = function (options, callback) {
                 followRedirects: _.has(options, 'ignoreRedirects') ? !options.ignoreRedirects : undefined,
                 strictSSL: _.has(options, 'insecure') ? !options.insecure : undefined,
                 network: {
-                    restrictedAddresses: options.blockHosts
+                    restrictedAddresses: options.restrictedAddresses
                 }
             },
             certificates: options.sslClientCert && new sdk.CertificateList({}, [{

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -92,6 +92,7 @@ module.exports = function (options, callback) {
 
         // now start the run!
         runner.run(options.collection, {
+            abortOnError: options.abortOnError,
             stopOnFailure: options.bail, // LOL, you just got trolled ¯\_(ツ)_/¯
             abortOnFailure: options.abortOnFailure, // used in integration tests, to be considered for a future release
             iterationCount: options.iterationCount,
@@ -100,7 +101,8 @@ module.exports = function (options, callback) {
             entrypoint: options.folder,
             data: options.iterationData,
             delay: {
-                item: options.delayRequest
+                item: options.delayRequest,
+                iteration: options.delayIteration
             },
             timeout: {
                 global: options.timeout,
@@ -111,7 +113,10 @@ module.exports = function (options, callback) {
             requester: {
                 cookieJar: request.jar(),
                 followRedirects: _.has(options, 'ignoreRedirects') ? !options.ignoreRedirects : undefined,
-                strictSSL: _.has(options, 'insecure') ? !options.insecure : undefined
+                strictSSL: _.has(options, 'insecure') ? !options.insecure : undefined,
+                network: {
+                    restrictedAddresses: options.blockHosts
+                }
             },
             certificates: options.sslClientCert && new sdk.CertificateList({}, [{
                 name: 'client-cert',

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -108,6 +108,7 @@ module.exports = function (options, callback) {
             globals: options.globals,
             entrypoint: {
                 execute: options.entrypointExecute,
+                lookupStrategy: options.executeStrategy,
                 path: options.entrypointPath || options.folder
             },
             data: options.iterationData,

--- a/test/cli/run-options.test.js
+++ b/test/cli/run-options.test.js
@@ -62,6 +62,14 @@ describe('CLI run options', function () {
         });
     });
 
+    it('should throw an error in case of invalid entrypoint value when --abort-on-error is true', function (done) {
+        // eslint-disable-next-line max-len
+        exec('node ./bin/newman.js run test/fixtures/run/failed-request.json --entrypoint-execute randomName --abort-on-error', function (code) {
+            expect(code).be(1);
+            done();
+        });
+    });
+
     describe('script timeouts', function () {
         it('should be handled correctly when breached', function (done) {
             // eslint-disable-next-line max-len

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -179,6 +179,11 @@ describe('cli parser', function () {
             '--ignore-redirects ' +
             '--bail ' +
             '--suppress-exit-code ' +
+            '--abort-on-error ' +
+            '--delay-iteration 2000 ' +
+            '--restricted-addresses 192.168.1.1,192.168.1.2 ' +
+            '--entrypoint-execute folderName ' +
+            '--entrypoint-path grand_parent_folder_id,parent_folder_id ' +
             '-k').split(' '), 'newmantests', function (err, config) {
                 expect(err).to.be(null);
 
@@ -187,6 +192,7 @@ describe('cli parser', function () {
                 expect(opts.collection).to.be('myCollection.json');
                 expect(opts.environment).to.be('myEnv.json');
                 expect(opts.folder).to.be('myFolder');
+                expect(opts.entrypointExecute).to.be('folderName');
                 expect(opts.exportEnvironment).to.be('exported_env.json');
                 expect(opts.iterationData).to.be('path/to/csv.csv');
                 expect(opts.globals).to.be('myGlobals.json');
@@ -197,6 +203,7 @@ describe('cli parser', function () {
                 expect(opts.timeoutScript).to.be(5000);
                 expect(opts.ignoreRedirects).to.be(true);
                 expect(opts.insecure).to.be(true);
+                expect(opts.delayIteration).to.be(2000);
 
                 expect(opts.color).to.be(false);
 
@@ -208,9 +215,18 @@ describe('cli parser', function () {
                     { key: 'foo', value: 'bar' },
                     { key: 'alpha', value: '=beta=' }
                 ]);
+                expect(opts.restrictedAddresses).to.eql([
+                    '192.168.1.1',
+                    '192.168.1.2'
+                ]);
+                expect(opts.entrypointPath).to.eql([
+                    'grand_parent_folder_id',
+                    'parent_folder_id'
+                ]);
 
                 expect(opts.bail).to.be(true);
                 expect(opts.suppressExitCode).to.be(true);
+                expect(opts.abortOnError).to.be(true);
 
                 done();
             });

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -183,6 +183,7 @@ describe('cli parser', function () {
             '--delay-iteration 2000 ' +
             '--restricted-addresses 192.168.1.1,192.168.1.2 ' +
             '--entrypoint-execute folderName ' +
+            '--execute-strategy idOrName ' +
             '--entrypoint-path grand_parent_folder_id,parent_folder_id ' +
             '-k').split(' '), 'newmantests', function (err, config) {
                 expect(err).to.be(null);
@@ -193,6 +194,7 @@ describe('cli parser', function () {
                 expect(opts.environment).to.be('myEnv.json');
                 expect(opts.folder).to.be('myFolder');
                 expect(opts.entrypointExecute).to.be('folderName');
+                expect(opts.executeStrategy).to.be('idOrName');
                 expect(opts.exportEnvironment).to.be('exported_env.json');
                 expect(opts.iterationData).to.be('path/to/csv.csv');
                 expect(opts.globals).to.be('myGlobals.json');


### PR DESCRIPTION
- Added the following options.
  * `--abort-on-error`
  * `--delay-iteration`
  * `--restricted-addresses`
  * `--entrypoint-execute`
  * `--entrypoint-path`
  * `--execute-strategy`
- Added unit test for checking options.
- Added cli test for `--abort-on-error`
