### PR TITLE
Use collection v2.1

### DIFF
--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -30,7 +30,7 @@ var _ = require('lodash'),
      * @const
      * @type {Object}
      */
-    COLLECTION_TRANSFORMER_OPTION = { inputVersion: '1.0.0', outputVersion: '2.0.0' },
+    COLLECTION_TRANSFORMER_OPTION = { inputVersion: '1.0.0', outputVersion: '2.1.0' },
 
     /**
      * Accepts an object, and extracts the property inside an object which is supposed to contain the required data.


### PR DESCRIPTION
All transformer calls will now use [v2.1.0](schema.getpostman.com/json/collection/v2.1.0/docs/index.html) as a target format.