### PR TITLE
Fixed legacy option ordering issue

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -100,6 +100,9 @@ var _ = require('lodash'),
                 }
             }
         }
+        program
+            .version(version)
+            .name('newman');
     },
 
     /**
@@ -113,8 +116,6 @@ var _ = require('lodash'),
     legacy = function (rawArgs) {
         resetProgram();
         program
-            .version(version)
-            .name('newman')
             .usage('[options] <collection>')
             .option('-c, --collection <path>', 'DEPRECATED: Specify a Postman collection as a JSON file')
             .option('-u, --url <path>', 'DEPRECATED: Specify a Postman collection as a URL')
@@ -171,11 +172,6 @@ var _ = require('lodash'),
      */
     run = function (rawArgs) {
         resetProgram();
-        program
-            .version(version);
-
-        program.name = 'newman';
-
         program
             .command('run <collection>')
             .description('URL or path to a Postman Collection.')
@@ -404,8 +400,8 @@ var _ = require('lodash'),
      * @returns {*}
      */
     rawOptions = function (procArgv, programName, callback) {
-        var legacyMode = (procArgv.length && _.startsWith(procArgv[0], '-') &&
-        !_.includes(['--help', '-h', '--version', '-v', '-V'], procArgv[0])),
+        var legacyMode = !_.includes(procArgv, 'run') &&
+        !_.includes(['--help', '-h', '--version', '-v', '-V'], procArgv[2]),
             reporterArgs,
             rawArgs,
             result,
@@ -415,6 +411,7 @@ var _ = require('lodash'),
             vPos,
             validCommands = [];
 
+        !legacyMode && !module.parent && (procArgv = procArgv.slice(2));
         rawArgs = separateReporterArgs(procArgv);
         try {
             if (!legacyMode) {
@@ -523,7 +520,7 @@ module.exports = rawOptions;
 */
 // ensure we run this script exports if this is a direct stdin
 // exported rawOptions above for cases when required as a module for eg tests.
-!module.parent && module.exports(process.argv.slice(2), 'newman', function (err, args) {
+!module.parent && module.exports(process.argv, 'newman', function (err, args) {
     if (err) {
         err.help && console.info(err.help + '\n'); // will print out usage information.
         console.error(err.message || err);


### PR DESCRIPTION
- Fixes the legacy option order issue raised by @shamasis sir. 
- Basically, in case of legacy, the `process.argv.slice(2)` was removing the first two flags provided and they were not being added as options, the collection path was still being identified in case `-c` was the first option because of the fallback that checks for `options.collection` and if absent, takes the collection path from `rawArgs[1]` which was working fine for cases where `-c` was the first option.
- This was leading to any option supplied before `-c` as non-effective since it wasn't being added to the options list at all. 
- The proposed implementation modifies the `legacyMode` check and applies the slice operation only for run command options. 