### PR TITLE
Fixes collection path ordering issue in run

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -472,8 +472,8 @@ var _ = require('lodash'),
      * @returns {*}
      */
     rawOptions = function (procArgv, programName, callback) {
-        var legacyMode = !_.includes(procArgv, 'run') &&
-        !_.includes(['--help', '-h', '--version', '-v', '-V'], procArgv[2]),
+        var versionHelpCheck = _.includes(['--help', '-h', '--version', '-v', '-V'], procArgv[2]),
+            legacyMode = !_.includes(procArgv, 'run') && !versionHelpCheck,
             reporterArgs,
             rawArgs,
             result,
@@ -484,7 +484,7 @@ var _ = require('lodash'),
             validCommands = [];
 
         !legacyMode && !module.parent && (procArgv = procArgv.slice(2));
-        !legacyMode && (procArgv = updateCollectionPosition(procArgv));
+        !versionHelpCheck && !legacyMode && (procArgv = updateCollectionPosition(procArgv));
         rawArgs = separateReporterArgs(procArgv);
         try {
             if (!legacyMode) {

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -448,7 +448,7 @@ var _ = require('lodash'),
             slicedArr = updateBooleanFlags(slicedArr);
             slicedArr.forEach(function (option, index) {
                 // checks for non options path args
-                if (!_.includes(option, '-') && !_.includes(slicedArr[index - 1], '-') &&
+                if (!_.startsWith(option, '-') && !_.startsWith(slicedArr[index - 1], '-') &&
                     fs.lstatSync(option).isFile()) {
                     slicedArr = move(slicedArr, index, 0);
                 }

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -134,6 +134,22 @@ describe('cli parser', function () {
                 });
         });
 
+        it('should handle cases where collection path is not followed directly by run', function (done) {
+            cli('run -e env.json -n 2 --insecure --no-color examples/sample-collection.json'.split(' '), 'newmantests',
+                function (err, config) {
+                    expect(err).to.be(null);
+                    expect(config.command).to.be('run');
+                    expect(config.run).to.be.ok();
+                    expect(config.run.iterationCount).to.be(2);
+                    expect(config.run.collection).to.be('examples/sample-collection.json');
+                    expect(config.run.environment).to.be('env.json');
+                    expect(config.run.insecure).to.be(true);
+                    expect(config.run.color).to.be(false);
+
+                    done();
+                });
+        });
+
         it('should throw an error for invalid --iteration-count values', function (done) {
             cli('run myCollection.json -n -3.14'.split(' '), 'newmantests', function (err) {
                 expect(err.message).to.be('The value must be a positive integer.');


### PR DESCRIPTION
- Fixes #1336 
- Currently newman strictly follows this order `newman run <collection> [options]` for identifying and running collections, that is the collection path has to be followed immediately by `run` to be identified.
- This breaks certain older configs where people could specify options after the `run` keyword and before actually specifying the collection path.
- The proposed implementation identifies collection path no matter where it is specified and moves it after the `run` keyword before parsing the specified options. 
- This includes identifying all boolean options and moving them to the end of options array and then moving the identified collection path to after `run`.
- Therefore, something like `newman run -e env.json --insecure --no-color collection.json` now works by being transformed internally to `newman run collection.json -e env.json --insecure --no-color` 