### PR TITLE
enhanced junit report with information about assertions of test scripts

### DIFF
--- a/lib/reporters/junit/index.js
+++ b/lib/reporters/junit/index.js
@@ -108,6 +108,14 @@ JunitReporter = function (newman, reporterOptions) {
                     failure = testcase.ele('failure');
                     failure.att('type', 'AssertionFailure');
                     failure.dat('Failed ' + failures.length + ' times.');
+                    failure.dat('Collection JSON ID: ' + collection.id + '.');
+                    failure.dat('Collection name: ' + collection.name + '.');
+                    failure.dat('Request name: ' + util.getFullName(currentItem) + '.');
+                    failure.dat('Test description: ' + name + '.');
+                    if (failures.length !== 0) {
+                        failure.dat('Error message: ' + failures[0].message + '.');
+                        failure.dat('Stacktrace: ' + failures[0].stack + '.');
+                    }
                 }
             });
         });

--- a/test/fixtures/run/newman-report-test.json
+++ b/test/fixtures/run/newman-report-test.json
@@ -15,8 +15,12 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-              "tests[\"Status code is 200\"] = responseCode.code === 200;",\
+              "tests[\"Status code is 200\"] = responseCode.code === 200;",
               "",
+              "// deliberate AssertionError to test proper JUnit report generation",
+              "pm.test(\"Status code is 400\", function () {",
+              "    pm.response.to.have.status(400);",
+              "});",
 							"// deliberate TypeError to test proper HTML report generation",
 							"tests[\"Body contains status\"] = undefined.alpha;",
 							""

--- a/test/fixtures/run/newman-report-test.json
+++ b/test/fixtures/run/newman-report-test.json
@@ -15,8 +15,8 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"tests[\"Status code is 200\"] = responseCode.code === 200;",
-							"",
+              "tests[\"Status code is 200\"] = responseCode.code === 200;",\
+              "",
 							"// deliberate TypeError to test proper HTML report generation",
 							"tests[\"Body contains status\"] = undefined.alpha;",
 							""

--- a/test/library/shallow-html-reporter.test.js
+++ b/test/library/shallow-html-reporter.test.js
@@ -48,14 +48,14 @@ describe('HTML reporter', function () {
         });
     });
 
-    it('should correctly produce the html report for a run with TypeError', function (done) {
+    it('should correctly produce the html report for a run with AssertionError/TypeError', function (done) {
         newman.run({
             collection: 'test/fixtures/run/newman-report-test.json',
             reporters: ['html'],
             reporter: { html: { export: outFile } }
         }, function (err, summary) {
             expect(err).to.be(null);
-            expect(summary.run.failures).to.have.length(1);
+            expect(summary.run.failures).to.have.length(2);
             fs.stat(outFile, done);
         });
     });

--- a/test/library/shallow-junit-reporter.test.js
+++ b/test/library/shallow-junit-reporter.test.js
@@ -48,14 +48,14 @@ describe('JUnit reporter', function () {
         });
     });
 
-    it('should correctly produce the JUnit report for a run with TypeError', function (done) {
+    it('should correctly produce the JUnit report for a run with AssertionError/TypeError', function (done) {
         newman.run({
             collection: 'test/fixtures/run/newman-report-test.json',
             reporters: ['junit'],
             reporter: { junit: { export: outFile } }
         }, function (err, summary) {
             expect(err).to.be(null);
-            expect(summary.run.failures).to.have.length(1);
+            expect(summary.run.failures).to.have.length(2);
             fs.stat(outFile, done);
         });
     });


### PR DESCRIPTION
With this change, the JUnit reporter will add more information when AssertionErrors occur.

This is especially useful, when inspecting test reports in Jenkins (see screenshot).

Without this change: 
![junit-report-before](https://user-images.githubusercontent.com/5173254/35329847-8a428f62-0101-11e8-91e8-0d823990b984.png)

With this change:
![jenkins-test-report](https://user-images.githubusercontent.com/5173254/35329855-9035bd90-0101-11e8-9945-1972543ecd18.png)


