### PR TITLE
Adding feature to disable "snake-looking" output when waiting for response

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -159,6 +159,7 @@ var _ = require('lodash'),
             .option('--silent', 'Prevents newman from showing output to CLI', false)
             .option('--color', 'Force colored output (for use in CI environments)')
             .option('collection <path>', 'URL or path to a Postman Collection')
+            .option('--disable-wait-output', 'Remove the wait output that uses backslash b to reduce unnecessary output in some environments')
             .parse(rawArgs);
     },
 
@@ -200,6 +201,7 @@ var _ = require('lodash'),
             // commander had some issue with flags starting with --no, thus camelCased
             // resolved https://github.com/tj/commander.js/pull/709
             .option('--color', 'Force colored output (for use in CI environments).')
+            .option('--disable-wait-output', 'Remove the wait output that uses backslash b to reduce unnecessary output in some environments')
             .option('--no-color', 'Disable colored output.')
             .option('--timeout [n]', 'Specify a timeout for collection run (in milliseconds)', Integer, 0)
             .option('--timeout-request [n]', 'Specify a timeout for requests (in milliseconds).', Integer, 0)

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -159,7 +159,7 @@ var _ = require('lodash'),
             .option('--silent', 'Prevents newman from showing output to CLI', false)
             .option('--color', 'Force colored output (for use in CI environments)')
             .option('collection <path>', 'URL or path to a Postman Collection')
-            .option('--disable-wait-output', 'Remove the wait output that uses backslash b to reduce unnecessary output in some environments')
+            .option('--disable-wait-output', 'Remove the cont. output when waiting for http response')
             .parse(rawArgs);
     },
 
@@ -201,7 +201,7 @@ var _ = require('lodash'),
             // commander had some issue with flags starting with --no, thus camelCased
             // resolved https://github.com/tj/commander.js/pull/709
             .option('--color', 'Force colored output (for use in CI environments).')
-            .option('--disable-wait-output', 'Remove the wait output that uses backslash b to reduce unnecessary output in some environments')
+            .option('--disable-wait-output', 'Remove the cont. output when waiting for http response')
             .option('--no-color', 'Disable colored output.')
             .option('--timeout [n]', 'Specify a timeout for collection run (in milliseconds)', Integer, 0)
             .option('--timeout-request [n]', 'Specify a timeout for requests (in milliseconds).', Integer, 0)

--- a/lib/print/index.js
+++ b/lib/print/index.js
@@ -10,6 +10,8 @@ var format = require('util').format,
     WAIT_FRAMERATE = 100,
     print;
 
+
+var printWaitOutput = true
 /**
  * Function that prints to stdout using standard NodeJS util.format, without end newline.
  *
@@ -19,6 +21,10 @@ var format = require('util').format,
 print = function () {
     return print.print.apply(this, arguments);
 };
+
+print.setWaitOutput = function (waitoutputEnabled){
+    printWaitOutput = waitoutputEnabled
+}
 
 /**
  * Function that prints to stdout using standard NodeJS util.format, without end newline.
@@ -65,8 +71,10 @@ print.wait = function (color) {
 
     process.stdout.write(SPC);
     print.waiting = setInterval(function () {
-        process.stdout.write(BS +
+        if (printWaitOutput){
+            process.stdout.write(BS +
             (color ? color(WAIT_FRAMES[print._waitPosition++]) : WAIT_FRAMES[print._waitPosition++]));
+        }
         (print._waitPosition > WAIT_FRAMES_SIZE) && (print._waitPosition = 0); // move frame
     }, WAIT_FRAMERATE);
 

--- a/lib/print/index.js
+++ b/lib/print/index.js
@@ -8,10 +8,9 @@ var format = require('util').format,
         ['⠄', '⠆', '⠇', '⠋', '⠙', '⠸', '⠰', '⠠', '⠰', '⠸', '⠙', '⠋', '⠇', '⠆'],
     WAIT_FRAMES_SIZE = WAIT_FRAMES.length - 1,
     WAIT_FRAMERATE = 100,
-    print;
+    print,
+    printWaitOutput = true;
 
-
-var printWaitOutput = true
 /**
  * Function that prints to stdout using standard NodeJS util.format, without end newline.
  *
@@ -22,9 +21,9 @@ print = function () {
     return print.print.apply(this, arguments);
 };
 
-print.setWaitOutput = function (waitoutputEnabled){
-    printWaitOutput = waitoutputEnabled
-}
+print.setWaitOutput = function (waitoutputEnabled) {
+    printWaitOutput = waitoutputEnabled;
+};
 
 /**
  * Function that prints to stdout using standard NodeJS util.format, without end newline.
@@ -71,7 +70,7 @@ print.wait = function (color) {
 
     process.stdout.write(SPC);
     print.waiting = setInterval(function () {
-        if (printWaitOutput){
+        if (printWaitOutput) {
             process.stdout.write(BS +
             (color ? color(WAIT_FRAMES[print._waitPosition++]) : WAIT_FRAMES[print._waitPosition++]));
         }

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -25,6 +25,7 @@ colors.setTheme({
     error: 'red'
 });
 
+
 extractSNR = function (executions) {
     var snr;
 
@@ -62,6 +63,10 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
     // respect silent option to not report anything
     if (reporterOptions.silent || options.silent) {
         return; // we simply do not register anything!
+    }
+
+    if(options.disableWaitOutput != undefined && options.disableWaitOutput == true){
+        print.setWaitOutput(false)
     }
 
     // we register the `done` listener first so that in case user does not want to show results of collection run, we

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -65,8 +65,8 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
         return; // we simply do not register anything!
     }
 
-    if(options.disableWaitOutput != undefined && options.disableWaitOutput == true){
-        print.setWaitOutput(false)
+    if (options.disableWaitOutput !== undefined && options.disableWaitOutput === true) {
+        print.setWaitOutput(false);
     }
 
     // we register the `done` listener first so that in case user does not want to show results of collection run, we


### PR DESCRIPTION
When running newman in a C/I system we get console output presented in our browser. Some browser to not support seem to support the `BS = '\b'` which is used to continuously remove the last character (and create the flowing feel when waiting). Hence my PR adds the run option `--disable-wait-output` which will suppress the "snake"-output when waiting for http response and instead show nothing. This is intended for use cases where people are not staring at the terminal "live" during the run but rather are looking at the output in retrospect.