### PR TITLE
Corrected request aggregation logic in the HTML reporter

### DIFF
--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -58,6 +58,7 @@ PostmanHTMLReporter = function (newman, options) {
             netTestCounts = {},
             aggregations = [],
             traversedRequests = {},
+            aggregatedExecutions = {},
             executions = _.get(this, 'summary.run.executions'),
             assertions = _.transform(executions, function (result, currentExecution) {
                 var stream,
@@ -131,6 +132,10 @@ PostmanHTMLReporter = function (newman, options) {
                         },
                         cumulativeTests: netTestCounts[execution.item.id]
                     });
+
+                if (aggregatedExecutions[execution.id]) { return; }
+
+                aggregatedExecutions[execution.id] = true;
 
                 if (previous && parent.id === previous.parent.id) {
                     previous.executions.push(current);


### PR DESCRIPTION
* A (potentially long-standing) bug prevented the HTML reporter from aggregating results correctly when collections with folders were run with multiple iterations. This has now been fixed.

Discovered in #1527