### PR TITLE
Drop Node v4 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,9 +9,9 @@ init:
 # environment variables
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "10"
 
 # scripts that run after cloning repository
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-- '4'
 - '6'
 - '8'
+- '10'
 notifications:
   slack:
     secure: Fdl/sQMTl86jYN1r1CRRRQRgyFoslvrhkkfnM2JSdx4gODPgyg4nCPSKtU5j9wpSbbkq9A+YBeFv+Suh+xYNviegqa0AZbztydfFzVDS7xw43B/uR9Y4LwaP5Kis1WGuIOHawwFISNO3hTUei6aybKiKKlxvfqrARJaO01+Xxrg=

--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -34,8 +34,6 @@ var fs = require('fs'),
      */
     AGGREGATED_FIELDS = ['item', 'request', 'response', 'requestError'],
 
-    IS_NODE_V4 = _(process && process.version).split('.').get(0) === 'v4',
-
     PostmanHTMLReporter;
 
 /**
@@ -88,12 +86,7 @@ PostmanHTMLReporter = function (newman, options) {
                     if (reducedExecution.response && _.isFunction(reducedExecution.response.toJSON)) {
                         reducedExecution.response = reducedExecution.response.toJSON();
                         stream = reducedExecution.response.stream;
-
-                        // Use deprecated Buffer constructor for Node v4, contemporary one for other versions
-                        // @todo remove when dropping support for node < v6, to save some memory.
-                        // eslint-disable-next-line no-buffer-constructor
-                        reducedExecution.response.body = (IS_NODE_V4 ? new Buffer(stream && stream.data) :
-                            Buffer.from(stream)).toString();
+                        reducedExecution.response.body = Buffer.from(stream).toString();
                     }
 
                     // set sample request and response details for the current request

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "xml2js": "0.4.19"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "greenkeeper": {
     "ignore": [

--- a/test/system/repository.test.js
+++ b/test/system/repository.test.js
@@ -48,7 +48,7 @@ describe('project repository', function () {
                 expect(json.keywords).to.eql(['newman', 'postman', 'api', 'testing', 'ci', 'rest-client', 'rest']);
 
                 expect(json).to.have.property('engines');
-                expect(json.engines).to.eql({ node: '>=4' });
+                expect(json.engines).to.eql({ node: '>=6' });
             });
 
             it('should ignore applicable dependencies for GreenKeeper pull requests', function () {

--- a/test/system/travis-yml.test.js
+++ b/test/system/travis-yml.test.js
@@ -23,7 +23,7 @@ describe('travis.yml', function () {
     describe('strucure', function () {
         it('should have language to be set to node', function () {
             expect(travisYAML.language).to.equal('node_js');
-            expect(travisYAML.node_js).to.eql(['4', '6', '8']);
+            expect(travisYAML.node_js).to.eql(['6', '8', '10']);
         });
     });
 });


### PR DESCRIPTION
- Update travis and appveyor config
- Update package.json
- Update travis and repository tests
- Remove v4 Buffer support from HTML reporter