### PR TITLE
Add ability to run collection via UID reference

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -27,7 +27,7 @@ program
     .option('--export-environment <path>', 'Exports the environment to a file after completing the run.')
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
     .option('--export-collection <path>', 'Specify an output file to save the executed collection')
-    .option('--postman-api-key <apiKey>', 'Postman cloud API Key to load the resource from Postman Cloud using UID.')
+    .option('--postman-api-key <apiKey>', 'API Key used to load the resources via UID from the Postman Cloud.')
     .option('--delay-request [n]', 'Specify the extent of delay between requests (milliseconds)', util.cast.integer, 0)
     .option('--bail [modifiers]',
         'Specify whether or not to gracefully stop a collection run on encountering an error' +

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -27,7 +27,7 @@ program
     .option('--export-environment <path>', 'Exports the environment to a file after completing the run.')
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
     .option('--export-collection <path>', 'Specify an output file to save the executed collection')
-    .option('--postman-api-key <apiKey>', 'API Key used to load the resources via UID from the Postman Cloud.')
+    .option('--postman-api-key <apiKey>', 'API Key used to load the resources from the Postman API.')
     .option('--delay-request [n]', 'Specify the extent of delay between requests (milliseconds)', util.cast.integer, 0)
     .option('--bail [modifiers]',
         'Specify whether or not to gracefully stop a collection run on encountering an error' +

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -27,6 +27,7 @@ program
     .option('--export-environment <path>', 'Exports the environment to a file after completing the run.')
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
     .option('--export-collection <path>', 'Specify an output file to save the executed collection')
+    .option('--postman-api-key <apiKey>', 'Postman cloud API Key to load the resource from Postman Cloud using UID.')
     .option('--delay-request [n]', 'Specify the extent of delay between requests (milliseconds)', util.cast.integer, 0)
     .option('--bail [modifiers]',
         'Specify whether or not to gracefully stop a collection run on encountering an error' +

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -21,7 +21,8 @@ var _ = require('lodash'),
 module.exports.get = (overrides, options, callback) => {
     !callback && _.isFunction(options) && (callback = options, options = {});
 
-    var loaders = options.loaders;
+    var loaders = options.loaders,
+        commonOptions = _.pick(overrides, ['postmanApiKey']);
 
     async.waterfall([
         // Load RC Files.
@@ -57,7 +58,7 @@ module.exports.get = (overrides, options, callback) => {
         }
 
         async.mapValues(options, (value, name, cb) => {
-            return (value && _.isFunction(loaders[name])) ? loaders[name](value, cb) : cb(null, value);
+            return (value && _.isFunction(loaders[name])) ? loaders[name](value, commonOptions, cb) : cb(null, value);
         }, callback);
     });
 };

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -59,11 +59,12 @@ var _ = require('lodash'),
      *
      * @param {String} type - The type of data to load.
      * @param {String} location - The location to load from (file path or URL).
+     * @param {Object} options - The set of wrapped options.
      * @param {function} cb - The callback function whose invocation marks the end of the external load routine.
      * @returns {*}
      */
-    externalLoader = function (type, location, cb) {
-        return _.isString(location) ? util.fetchJson(location, function (err, data) {
+    externalLoader = function (type, location, options, cb) {
+        return _.isString(location) ? util.fetchJson(type, location, options, function (err, data) {
             if (err) {
                 return cb(err);
             }
@@ -90,9 +91,10 @@ var _ = require('lodash'),
      * @private
      * @param {String} type - The type of resource to load: collection, environment, etc.
      * @param {String|Object} value - The value derived from the CLI or run command.
+     * @param {Object} options - The set of wrapped options.
      * @param {Function} callback - The function invoked when the scope has been loaded.
      */
-    loadScopes = function (type, value, callback) {
+    loadScopes = function (type, value, options, callback) {
         var done = function (err, scope) {
             if (err) { return callback(err); }
 
@@ -107,7 +109,7 @@ var _ = require('lodash'),
             return done(null, value);
         }
 
-        externalLoader(type, value, done);
+        externalLoader(type, value, options, done);
     },
 
     /**
@@ -153,10 +155,11 @@ var _ = require('lodash'),
          * The collection file load helper for the current run.
          *
          * @param {Object|String} value - The collection, specified as a JSON object, or the path to it's file.
+         * @param {Object} options - The set of wrapped options.
          * @param {Function} callback - The callback function invoked to mark the end of the collection load routine.
          * @returns {*}
          */
-        collection: function (value, callback) {
+        collection: function (value, options, callback) {
             /**
              * The post collection load handler.
              *
@@ -190,7 +193,7 @@ var _ = require('lodash'),
                 return processCollection(value, done);
             }
 
-            externalLoader('collection', value, function (err, data) {
+            externalLoader('collection', value, options, function (err, data) {
                 if (err) {
                     return done(err);
                 }
@@ -221,10 +224,11 @@ var _ = require('lodash'),
          *
          * @param {String|Object[]} location - The path to the iteration data file for the current collection run, or
          * the array of iteration data objects.
+         * @param {Object} options - The set of wrapped options.
          * @param {Function} callback - The function invoked to indicate the end of the iteration data loading routine.
          * @returns {*}
          */
-        iterationData: function (location, callback) {
+        iterationData: function (location, options, callback) {
             if (_.isArray(location)) { return callback(null, location); }
 
             util.fetch(location, function (err, data) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -19,9 +19,9 @@ var fs = require('fs'),
      */
     FILESIZE_OPTIONS = { spacer: '' },
 
-    POSTMAN_API_PROTOCOL = 'https',
-
     POSTMAN_API_HOST = 'api.getpostman.com',
+
+    POSTMAN_API_URL = 'https://api.getpostman.com',
 
     /**
      * Map of resource type and its equivalent API pathname.
@@ -115,7 +115,7 @@ util = {
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
         if (!fs.existsSync(location) && POSTMAN_API_PATH[type] && postmanApiKey && UID_REGEX.test(location)) {
-            location = `${POSTMAN_API_PROTOCOL}://${POSTMAN_API_HOST}/${POSTMAN_API_PATH[type]}/${location}`;
+            location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH[type]}/${location}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -19,9 +19,24 @@ var fs = require('fs'),
      */
     FILESIZE_OPTIONS = { spacer: '' },
 
+    POSTMAN_API_PROTOCOL = 'https',
+
     POSTMAN_API_HOST = 'api.getpostman.com',
+
+    /**
+     * Map of resource type and its equivalent API pathname.
+     *
+     * @type {Object}
+     */
+    POSTMAN_API_PATH = {
+        collection: 'collections',
+        environment: 'environments'
+    },
+
     API_KEY_HEADER = 'X-Api-Key',
+
     USER_AGENT_VALUE = 'Newman/' + version,
+
     UID_REGEX = /^[0-9A-Z]+-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
 util = {
@@ -95,14 +110,12 @@ util = {
         !callback && _.isFunction(options) && (callback = options, options = {});
 
         var postmanApiKey = _.get(options, 'postmanApiKey'),
-            headers = { 'User-Agent': USER_AGENT_VALUE },
-            endpoint;
+            headers = { 'User-Agent': USER_AGENT_VALUE };
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
-        if (!fs.existsSync(location) && postmanApiKey && UID_REGEX.test(location)) {
-            endpoint = (type === 'collection' ? 'collections' : 'environments') + '/' + location;
-            location = `https://${POSTMAN_API_HOST}/${endpoint}`;
+        if (!fs.existsSync(location) && POSTMAN_API_PATH[type] && postmanApiKey && UID_REGEX.test(location)) {
+            location = `${POSTMAN_API_PROTOCOL}://${POSTMAN_API_HOST}/${POSTMAN_API_PATH[type]}/${location}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,8 +20,8 @@ var fs = require('fs'),
     FILESIZE_OPTIONS = { spacer: '' },
 
     PRO_API_HOST = 'api.getpostman.com',
+    API_KEY_HEADER = 'X-Api-Key',
     USER_AGENT_VALUE = 'Newman/' + version,
-
     UID_REGEX = /^[0-9A-Z]+-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
 util = {
@@ -103,7 +103,7 @@ util = {
         if (postmanApiKey && UID_REGEX.test(location) && !fs.existsSync(location)) {
             endpoint = (type === 'collection' ? 'collections' : 'environments') + '/' + location;
             location = `https://${PRO_API_HOST}/${endpoint}`;
-            headers['X-Api-Key'] = postmanApiKey;
+            headers[API_KEY_HEADER] = postmanApiKey;
         }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -100,12 +100,11 @@ util = {
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
-        if (postmanApiKey && UID_REGEX.test(location) && !fs.existsSync(location)) {
+        if (!fs.existsSync(location) && postmanApiKey && UID_REGEX.test(location)) {
             endpoint = (type === 'collection' ? 'collections' : 'environments') + '/' + location;
             location = `https://${PRO_API_HOST}/${endpoint}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }
-
 
         return (/^https?:\/\/.*/).test(location) ?
             // Load from URL

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,14 +21,14 @@ var fs = require('fs'),
 
     POSTMAN_API_HOST = 'api.getpostman.com',
 
-    POSTMAN_API_URL = 'https://api.getpostman.com',
+    POSTMAN_API_URL = 'https://' + POSTMAN_API_HOST,
 
     /**
      * Map of resource type and its equivalent API pathname.
      *
      * @type {Object}
      */
-    POSTMAN_API_PATH = {
+    POSTMAN_API_PATH_MAP = {
         collection: 'collections',
         environment: 'environments'
     },
@@ -38,6 +38,7 @@ var fs = require('fs'),
     USER_AGENT_VALUE = 'Newman/' + version,
 
     // Matches valid Postman UID, case insensitive.
+    // Same used for validation on the Postman API side.
     UID_REGEX = /^[0-9A-Z]+-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
 util = {
@@ -102,7 +103,7 @@ util = {
      * @param {String} type - The type of data to load.
      * @param {String} location - Can be an HTTP URL, a local file path or an UID.
      * @param {Object=} options - A set of options for JSON data loading.
-     * @param {Object} options.postmanApiKey - API Key used to load the resources via UID from the Postman Cloud.
+     * @param {Object} options.postmanApiKey - API Key used to load the resources via UID from the Postman API.
      * @param {Function} callback - The function whose invocation marks the end of the JSON fetch routine.
      * @returns {*}
      */
@@ -115,8 +116,8 @@ util = {
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
-        if (!fs.existsSync(location) && POSTMAN_API_PATH[type] && postmanApiKey && UID_REGEX.test(location)) {
-            location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH[type]}/${location}`;
+        if (!fs.existsSync(location) && POSTMAN_API_PATH_MAP[type] && postmanApiKey && UID_REGEX.test(location)) {
+            location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -37,6 +37,7 @@ var fs = require('fs'),
 
     USER_AGENT_VALUE = 'Newman/' + version,
 
+    // Matches valid Postman UID, case insensitive.
     UID_REGEX = /^[0-9A-Z]+-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
 util = {

--- a/lib/util.js
+++ b/lib/util.js
@@ -84,7 +84,7 @@ util = {
      * Loads JSON data from the given location.
      *
      * @param {String} type - The type of data to load.
-     * @param {String} location - Can be an HTTP URL or a local file path.
+     * @param {String} location - Can be an HTTP URL, a local file path or an UID.
      * @param {Object=} options - A set of options for JSON data loading.
      * @param {Object} options.postmanApiKey - API Key used to load the resources via UID from the Postman Cloud.
      * @param {Function} callback - The function whose invocation marks the end of the JSON fetch routine.
@@ -95,12 +95,14 @@ util = {
         !callback && _.isFunction(options) && (callback = options, options = {});
 
         var postmanApiKey = _.get(options, 'postmanApiKey'),
-            headers = { 'User-Agent': USER_AGENT_VALUE };
+            headers = { 'User-Agent': USER_AGENT_VALUE },
+            endpoint;
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
-        if (UID_REGEX.test(location) && !fs.existsSync(location) && postmanApiKey) {
-            location = `https://${PRO_API_HOST}/${type === 'collection' ? 'collections' : 'environments'}/${location}`;
+        if (postmanApiKey && UID_REGEX.test(location) && !fs.existsSync(location)) {
+            endpoint = (type === 'collection' ? 'collections' : 'environments') + '/' + location;
+            location = `https://${PRO_API_HOST}/${endpoint}`;
             headers['X-Api-Key'] = postmanApiKey;
         }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -19,7 +19,7 @@ var fs = require('fs'),
      */
     FILESIZE_OPTIONS = { spacer: '' },
 
-    PRO_API_HOST = 'api.getpostman.com',
+    POSTMAN_API_HOST = 'api.getpostman.com',
     API_KEY_HEADER = 'X-Api-Key',
     USER_AGENT_VALUE = 'Newman/' + version,
     UID_REGEX = /^[0-9A-Z]+-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
@@ -102,7 +102,7 @@ util = {
         // Fetch from file in case a file with valid UID name is present.
         if (!fs.existsSync(location) && postmanApiKey && UID_REGEX.test(location)) {
             endpoint = (type === 'collection' ? 'collections' : 'environments') + '/' + location;
-            location = `https://${PRO_API_HOST}/${endpoint}`;
+            location = `https://${POSTMAN_API_HOST}/${endpoint}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }
 
@@ -131,7 +131,7 @@ util = {
                 if (response.statusCode !== 200) {
                     urlObj = url.parse(location);
 
-                    (urlObj.hostname === PRO_API_HOST) &&
+                    (urlObj.hostname === POSTMAN_API_HOST) &&
                         (resource = _(urlObj.path).split('/').get(1).slice(0, -1) || resource);
 
                     error = new Error(_.get(body, 'error.message',

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,7 +20,9 @@ var fs = require('fs'),
     FILESIZE_OPTIONS = { spacer: '' },
 
     PRO_API_HOST = 'api.getpostman.com',
-    USER_AGENT_VALUE = 'Newman/' + version;
+    USER_AGENT_VALUE = 'Newman/' + version,
+
+    UID_REGEX = /^[0-9A-Z]+-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
 util = {
 
@@ -81,21 +83,32 @@ util = {
     /**
      * Loads JSON data from the given location.
      *
+     * @param {String} type - The type of data to load.
      * @param {String} location - Can be an HTTP URL or a local file path.
      * @param {Object=} options - A set of options for JSON data loading.
-     * @param {Object} options.apikey - Postman's cloud API Key (if the resource is being loaded from Postman Cloud).
+     * @param {Object} options.postmanApiKey - Postman cloud API Key to load the resource from Postman Cloud using UID.
      * @param {Function} callback - The function whose invocation marks the end of the JSON fetch routine.
      * @returns {*}
      */
-    fetchJson: function (location, options, callback) {
+
+    fetchJson: function (type, location, options, callback) {
         !callback && _.isFunction(options) && (callback = options, options = {});
+
+        var postmanApiKey = _.get(options, 'postmanApiKey'),
+            headers = { 'User-Agent': USER_AGENT_VALUE };
+
+        if (UID_REGEX.test(location) && !fs.existsSync(location) && postmanApiKey) {
+            location = `https://${PRO_API_HOST}/${type === 'collection' ? 'collections' : 'environments'}/${location}`;
+            headers['X-Api-Key'] = postmanApiKey;
+        }
+
 
         return (/^https?:\/\/.*/).test(location) ?
             // Load from URL
             request.get({
                 url: location,
                 json: true,
-                headers: { 'User-Agent': USER_AGENT_VALUE }
+                headers: headers
             }, (err, response, body) => {
                 if (err) {
                     return callback(_.set(err, 'help', `unable to fetch data from url "${location}"`));

--- a/lib/util.js
+++ b/lib/util.js
@@ -86,7 +86,7 @@ util = {
      * @param {String} type - The type of data to load.
      * @param {String} location - Can be an HTTP URL or a local file path.
      * @param {Object=} options - A set of options for JSON data loading.
-     * @param {Object} options.postmanApiKey - Postman cloud API Key to load the resource from Postman Cloud using UID.
+     * @param {Object} options.postmanApiKey - API Key used to load the resources via UID from the Postman Cloud.
      * @param {Function} callback - The function whose invocation marks the end of the JSON fetch routine.
      * @returns {*}
      */
@@ -97,6 +97,8 @@ util = {
         var postmanApiKey = _.get(options, 'postmanApiKey'),
             headers = { 'User-Agent': USER_AGENT_VALUE };
 
+        // build API URL if `location` is a valid UID and api key is provided.
+        // Fetch from file in case a file with valid UID name is present.
         if (UID_REGEX.test(location) && !fs.existsSync(location) && postmanApiKey) {
             location = `https://${PRO_API_HOST}/${type === 'collection' ? 'collections' : 'environments'}/${location}`;
             headers['X-Api-Key'] = postmanApiKey;

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jsdoc": "3.5.5",
     "jsdoc-to-markdown": "4.0.1",
     "mocha": "5.2.0",
+    "nock": "9.4.3",
     "nsp": "3.2.1",
     "nyc": "12.0.2",
     "packity": "0.3.2",

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -130,7 +130,7 @@ describe('newman.run postmanApiKey', function () {
         });
     });
 
-    it('should throw error if UID is passed without postmanApiKey and there\'s no such file exists', function (done) {
+    it('should end with an error if UID is passed without postmanApiKey and no such file exists', function (done) {
         newman.run({
             collection: '1234-588025f9-2497-46f7-b849-47f58b865807'
         }, function (err) {

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -12,8 +12,8 @@ const fs = require('fs'),
         }]
     },
     VARIABLE = {
-        id: 'V1',
-        name: 'Variable',
+        id: 'E1',
+        name: 'Environment',
         values: [{
             key: 'foo',
             value: 'bar'
@@ -51,7 +51,7 @@ describe('newman.run postmanApiKey', function () {
             postmanApiKey: '12345678'
         }, function (err, summary) {
             expect(err).to.be.null;
-            expect(request.get.calledOnce).to.be.true;
+            sinon.assert.calledOnce(request.get);
 
             let requestArg = request.get.firstCall.args[0];
 
@@ -61,11 +61,11 @@ describe('newman.run postmanApiKey', function () {
                 .that.is.equal('https://api.getpostman.com/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
 
             expect(requestArg.headers).to.be.an('object')
-                .that.has.property('X-Api-Key').to.equal('12345678');
+                .that.has.property('X-Api-Key', '12345678');
 
             expect(summary).to.be.an('object')
                 .that.has.property('collection').to.be.an('object')
-                .and.that.include({ id: 'C1', name: 'Collection' });
+                .and.include({ id: 'C1', name: 'Collection' });
 
             done();
         });
@@ -78,7 +78,7 @@ describe('newman.run postmanApiKey', function () {
             postmanApiKey: '12345678'
         }, function (err, summary) {
             expect(err).to.be.null;
-            expect(request.get.calledOnce).to.be.true;
+            sinon.assert.calledOnce(request.get);
 
             let requestArg = request.get.firstCall.args[0];
 
@@ -88,38 +88,11 @@ describe('newman.run postmanApiKey', function () {
                 .that.is.equal('https://api.getpostman.com/environments/1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f');
 
             expect(requestArg.headers).to.be.an('object')
-                .that.has.property('X-Api-Key').to.equal('12345678');
+                .that.has.property('X-Api-Key', '12345678');
 
             expect(summary).to.be.an('object')
                 .that.has.property('environment').to.be.an('object')
-                .and.that.include({ id: 'V1', name: 'Variable' });
-
-            done();
-        });
-    });
-
-    it('should fetch globals via UID', function (done) {
-        newman.run({
-            collection: 'test/fixtures/run/single-get-request.json',
-            globals: '1234-6863abf8-6630-4eec-b9cc-2a58f5efe589',
-            postmanApiKey: '12345678'
-        }, function (err, summary) {
-            expect(err).to.be.null;
-            expect(request.get.calledOnce).to.be.true;
-
-            let requestArg = request.get.firstCall.args[0];
-
-            expect(requestArg).to.be.an('object').with.keys(['url', 'json', 'headers']);
-
-            expect(requestArg.url).to.be.a('string')
-                .that.is.equal('https://api.getpostman.com/environments/1234-6863abf8-6630-4eec-b9cc-2a58f5efe589');
-
-            expect(requestArg.headers).to.be.an('object')
-                .that.has.property('X-Api-Key').to.equal('12345678');
-
-            expect(summary).to.be.an('object')
-                .that.has.property('globals').to.be.an('object')
-                .and.that.include({ id: 'V1', name: 'Variable' });
+                .and.include({ id: 'E1', name: 'Environment' });
 
             done();
         });
@@ -129,17 +102,15 @@ describe('newman.run postmanApiKey', function () {
         newman.run({
             collection: '1234-588025f9-2497-46f7-b849-47f58b865807',
             environment: '1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
-            globals: '1234-6863abf8-6630-4eec-b9cc-2a58f5efe589',
             postmanApiKey: '12345678'
         }, function (err, summary) {
             expect(err).to.be.null;
-            expect(request.get.calledThrice).to.be.true;
+            sinon.assert.calledTwice(request.get);
 
             expect(summary).to.be.an('object').with.keys(['collection', 'environment', 'globals', 'run']);
 
             expect(summary.collection).to.include({ id: 'C1', name: 'Collection' });
-            expect(summary.environment).to.include({ id: 'V1', name: 'Variable' });
-            expect(summary.globals).to.include({ id: 'V1', name: 'Variable' });
+            expect(summary.environment).to.include({ id: 'E1', name: 'Environment' });
 
             done();
         });
@@ -183,11 +154,11 @@ describe('newman.run postmanApiKey', function () {
                 postmanApiKey: '12345678'
             }, function (err, summary) {
                 expect(err).to.be.null;
-                expect(request.get.called).to.be.false;
+                sinon.assert.notCalled(request.get);
 
                 expect(summary).to.be.an('object')
                     .that.has.property('collection').to.be.an('object')
-                    .and.that.include({ id: 'C1', name: 'Collection' });
+                    .and.include({ id: 'C1', name: 'Collection' });
 
                 done();
             });

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -121,7 +121,7 @@ describe('newman.run postmanApiKey', function () {
             collection: '1234-588025f9-2497-46f7-b849-47f58b865807'
         }, function (err) {
             expect(err).to.be.ok.that.match(/no such file or directory/);
-            expect(request.get.called).to.be.false;
+            sinon.assert.notCalled(request.get);
 
             done();
         });

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -1,32 +1,35 @@
-describe('newman.run postmanApiKey', function () {
-    const fs = require('fs'),
-        nock = require('nock'),
-        sinon = require('sinon'),
-        request = require('postman-request'),
-        COLLECTION = {
-            id: 'C1',
-            name: 'Collection',
-            item: [{
-                id: 'ID1',
-                name: 'R1',
-                request: 'https://postman-echo.com/get'
-            }]
-        },
-        VARIABLE = {
-            id: 'V1',
-            name: 'Variable',
-            values: [{ key: 'foo', value: 'bar' }]
-        };
+const fs = require('fs'),
+    nock = require('nock'),
+    sinon = require('sinon'),
+    request = require('postman-request'),
+    COLLECTION = {
+        id: 'C1',
+        name: 'Collection',
+        item: [{
+            id: 'ID1',
+            name: 'R1',
+            request: 'https://postman-echo.com/get'
+        }]
+    },
+    VARIABLE = {
+        id: 'V1',
+        name: 'Variable',
+        values: [{
+            key: 'foo',
+            value: 'bar'
+        }]
+    };
 
+describe('newman.run postmanApiKey', function () {
     before(function () {
         nock('https://api.getpostman.com')
+            .persist()
             .get(/^\/collections/)
-            .times(Infinity)
             .reply(200, COLLECTION);
 
         nock('https://api.getpostman.com')
+            .persist()
             .get(/^\/environments/)
-            .times(Infinity)
             .reply(200, VARIABLE);
     });
 

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -57,8 +57,8 @@ describe('newman.run postmanApiKey', function () {
 
             expect(requestArg).to.be.an('object').with.keys(['url', 'json', 'headers']);
 
-            expect(requestArg.url).to.be.a('string')
-                .that.is.equal('https://api.getpostman.com/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+            expect(requestArg.url)
+                .to.equal('https://api.getpostman.com/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
 
             expect(requestArg.headers).to.be.an('object')
                 .that.has.property('X-Api-Key', '12345678');
@@ -66,6 +66,9 @@ describe('newman.run postmanApiKey', function () {
             expect(summary).to.be.an('object')
                 .that.has.property('collection').to.be.an('object')
                 .and.include({ id: 'C1', name: 'Collection' });
+
+            expect(summary.run.failures).to.be.empty;
+            expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
 
             done();
         });
@@ -84,8 +87,8 @@ describe('newman.run postmanApiKey', function () {
 
             expect(requestArg).to.be.an('object').with.keys(['url', 'json', 'headers']);
 
-            expect(requestArg.url).to.be.a('string')
-                .that.is.equal('https://api.getpostman.com/environments/1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f');
+            expect(requestArg.url)
+                .to.equal('https://api.getpostman.com/environments/1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f');
 
             expect(requestArg.headers).to.be.an('object')
                 .that.has.property('X-Api-Key', '12345678');
@@ -93,6 +96,9 @@ describe('newman.run postmanApiKey', function () {
             expect(summary).to.be.an('object')
                 .that.has.property('environment').to.be.an('object')
                 .and.include({ id: 'E1', name: 'Environment' });
+
+            expect(summary.run.failures).to.be.empty;
+            expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
 
             done();
         });
@@ -111,6 +117,9 @@ describe('newman.run postmanApiKey', function () {
 
             expect(summary.collection).to.include({ id: 'C1', name: 'Collection' });
             expect(summary.environment).to.include({ id: 'E1', name: 'Environment' });
+
+            expect(summary.run.failures).to.be.empty;
+            expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
 
             done();
         });
@@ -159,6 +168,9 @@ describe('newman.run postmanApiKey', function () {
                 expect(summary).to.be.an('object')
                     .that.has.property('collection').to.be.an('object')
                     .and.include({ id: 'C1', name: 'Collection' });
+
+                expect(summary.run.failures).to.be.empty;
+                expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
 
                 done();
             });

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -1,0 +1,193 @@
+describe('newman.run postmanApiKey', function () {
+    const fs = require('fs'),
+        nock = require('nock'),
+        sinon = require('sinon'),
+        request = require('postman-request'),
+        COLLECTION = {
+            id: 'C1',
+            name: 'Collection',
+            item: [{
+                id: 'ID1',
+                name: 'R1',
+                request: 'https://postman-echo.com/get'
+            }]
+        },
+        VARIABLE = {
+            id: 'V1',
+            name: 'Variable',
+            values: [{ key: 'foo', value: 'bar' }]
+        };
+
+    before(function () {
+        nock('https://api.getpostman.com')
+            .get(/^\/collections/)
+            .times(Infinity)
+            .reply(200, COLLECTION);
+
+        nock('https://api.getpostman.com')
+            .get(/^\/environments/)
+            .times(Infinity)
+            .reply(200, VARIABLE);
+    });
+
+    after(function () {
+        nock.restore();
+    });
+
+    beforeEach(function () {
+        sinon.spy(request, 'get');
+    });
+
+    afterEach(function () {
+        request.get.restore();
+    });
+
+    it('should fetch collection via UID', function (done) {
+        newman.run({
+            collection: '1234-588025f9-2497-46f7-b849-47f58b865807',
+            postmanApiKey: '12345678'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(request.get.calledOnce).to.be.true;
+
+            let requestArg = request.get.firstCall.args[0];
+
+            expect(requestArg).to.be.an('object').with.keys(['url', 'json', 'headers']);
+
+            expect(requestArg.url).to.be.a('string')
+                .that.is.equal('https://api.getpostman.com/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+
+            expect(requestArg.headers).to.be.an('object')
+                .that.has.property('X-Api-Key').to.equal('12345678');
+
+            expect(summary).to.be.an('object')
+                .that.has.property('collection').to.be.an('object')
+                .and.that.include({ id: 'C1', name: 'Collection' });
+
+            done();
+        });
+    });
+
+    it('should fetch environment via UID', function (done) {
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            environment: '1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
+            postmanApiKey: '12345678'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(request.get.calledOnce).to.be.true;
+
+            let requestArg = request.get.firstCall.args[0];
+
+            expect(requestArg).to.be.an('object').with.keys(['url', 'json', 'headers']);
+
+            expect(requestArg.url).to.be.a('string')
+                .that.is.equal('https://api.getpostman.com/environments/1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f');
+
+            expect(requestArg.headers).to.be.an('object')
+                .that.has.property('X-Api-Key').to.equal('12345678');
+
+            expect(summary).to.be.an('object')
+                .that.has.property('environment').to.be.an('object')
+                .and.that.include({ id: 'V1', name: 'Variable' });
+
+            done();
+        });
+    });
+
+    it('should fetch globals via UID', function (done) {
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            globals: '1234-6863abf8-6630-4eec-b9cc-2a58f5efe589',
+            postmanApiKey: '12345678'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(request.get.calledOnce).to.be.true;
+
+            let requestArg = request.get.firstCall.args[0];
+
+            expect(requestArg).to.be.an('object').with.keys(['url', 'json', 'headers']);
+
+            expect(requestArg.url).to.be.a('string')
+                .that.is.equal('https://api.getpostman.com/environments/1234-6863abf8-6630-4eec-b9cc-2a58f5efe589');
+
+            expect(requestArg.headers).to.be.an('object')
+                .that.has.property('X-Api-Key').to.equal('12345678');
+
+            expect(summary).to.be.an('object')
+                .that.has.property('globals').to.be.an('object')
+                .and.that.include({ id: 'V1', name: 'Variable' });
+
+            done();
+        });
+    });
+
+    it('should fetch all resources via UID', function (done) {
+        newman.run({
+            collection: '1234-588025f9-2497-46f7-b849-47f58b865807',
+            environment: '1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
+            globals: '1234-6863abf8-6630-4eec-b9cc-2a58f5efe589',
+            postmanApiKey: '12345678'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(request.get.calledThrice).to.be.true;
+
+            expect(summary).to.be.an('object').with.keys(['collection', 'environment', 'globals', 'run']);
+
+            expect(summary.collection).to.include({ id: 'C1', name: 'Collection' });
+            expect(summary.environment).to.include({ id: 'V1', name: 'Variable' });
+            expect(summary.globals).to.include({ id: 'V1', name: 'Variable' });
+
+            done();
+        });
+    });
+
+    it('should throw error without postmanApiKey', function (done) {
+        newman.run({
+            collection: '1234-588025f9-2497-46f7-b849-47f58b865807'
+        }, function (err) {
+            expect(err).to.be.ok.that.match(/no such file or directory/);
+            expect(request.get.called).to.be.false;
+
+            done();
+        });
+    });
+
+    describe('read file', function () {
+        const UID = '1234-96771253-046f-4ad7-81f9-a2d3c433492b';
+
+        beforeEach(function (done) {
+            fs.stat(UID, function (err) {
+                if (err) {
+                    return fs.writeFile(UID, JSON.stringify(COLLECTION), done);
+                }
+
+                done();
+            });
+        });
+
+        afterEach(function (done) {
+            fs.stat(UID, function (err) {
+                if (err) { return done(); }
+
+                fs.unlink(UID, done);
+            });
+        });
+
+        it('should fetch from file having UID name', function (done) {
+            newman.run({
+                collection: UID,
+                postmanApiKey: '12345678'
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(request.get.called).to.be.false;
+
+                expect(summary).to.be.an('object')
+                    .that.has.property('collection').to.be.an('object')
+                    .and.that.include({ id: 'C1', name: 'Collection' });
+
+                done();
+            });
+        });
+    });
+});

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -130,7 +130,7 @@ describe('newman.run postmanApiKey', function () {
         });
     });
 
-    it('should throw error without postmanApiKey', function (done) {
+    it('should throw error if UID is passed without postmanApiKey and there\'s no such file exists', function (done) {
         newman.run({
             collection: '1234-588025f9-2497-46f7-b849-47f58b865807'
         }, function (err) {
@@ -141,7 +141,7 @@ describe('newman.run postmanApiKey', function () {
         });
     });
 
-    it('should not pass API Key header for Postman Cloud URLs', function (done) {
+    it('should not pass API Key header for Postman API URLs', function (done) {
         newman.run({
             collection: 'https://api.getpostman.com/collections?apikey=12345678',
             postmanApiKey: '12345678'
@@ -164,7 +164,7 @@ describe('newman.run postmanApiKey', function () {
         });
     });
 
-    it('should not pass API Key header for non Postman Cloud URLs', function (done) {
+    it('should not pass API Key header for non Postman API URLs', function (done) {
         newman.run({
             collection: 'https://example.com/collection.json',
             postmanApiKey: '12345678'

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -141,7 +141,30 @@ describe('newman.run postmanApiKey', function () {
         });
     });
 
-    it('should not pass API Key header with URL ', function (done) {
+    it('should not pass API Key header for Postman Cloud URLs', function (done) {
+        newman.run({
+            collection: 'https://api.getpostman.com/collections?apikey=12345678',
+            postmanApiKey: '12345678'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            sinon.assert.calledOnce(request.get);
+
+            let requestArg = request.get.firstCall.args[0];
+
+            expect(requestArg).to.be.an('object').with.keys(['url', 'json', 'headers']);
+
+            expect(requestArg.url).to.equal('https://api.getpostman.com/collections?apikey=12345678');
+
+            expect(requestArg.headers).to.not.have.property('X-Api-Key');
+
+            expect(summary.run.failures).to.be.empty;
+            expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
+
+            done();
+        });
+    });
+
+    it('should not pass API Key header for non Postman Cloud URLs', function (done) {
         newman.run({
             collection: 'https://example.com/collection.json',
             postmanApiKey: '12345678'

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -88,6 +88,7 @@ describe('cli parser', function () {
             '--folder myFolder ' +
             '--export-environment exported_env.json ' +
             '--export-globals exported_glob.json ' +
+            '--postman-api-key POSTMAN_API_KEY ' +
             '--reporter-cli-no-summary ' +
             '--iteration-count 23 ' +
             '--reporters json ' +
@@ -111,6 +112,7 @@ describe('cli parser', function () {
                 expect(opts.iterationData).to.equal('path/to/csv.csv');
                 expect(opts.globals).to.equal('myGlobals.json');
                 expect(opts.exportGlobals).to.equal('exported_glob.json');
+                expect(opts.postmanApiKey).to.equal('POSTMAN_API_KEY');
                 expect(opts.delayRequest, 'should have delayRequest of 12000').to.equal(12000);
                 expect(opts.timeout, 'should have timeout of 10000').to.equal(10000);
                 expect(opts.timeoutRequest, 'should have timeoutRequest of 5000').to.equal(5000);


### PR DESCRIPTION
**Behavior:**
- Pass API key using `--postman-api-key` flag.
- External resources can be loaded using UID.
  - Check for a valid UID first.
  - Check if no file exists with the same UID name.
  - Finally, check if `postmanApiKey` is present.