### PR TITLE
Fix cli reporter not showing [errored] on request errors

### DIFF
--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -151,15 +151,18 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 
     // output the response code, reason and time
     emitter.on('request', function (err, o) {
-        if (err) { return; }
+        if (err) {
+            print.lf(colors.red('[errored]'));
+
+            return;
+        }
 
         var size = o.response && o.response.size();
 
         size = size && (size.header || 0) + (size.body || 0) || 0;
 
-        err ? print.lf(colors.red('[errored]')) :
-            print.lf(colors.gray('[%d %s, %s, %s]'), o.response.code, o.response.reason(),
-                util.filesize(size), util.prettyms(o.response.responseTime));
+        print.lf(colors.gray('[%d %s, %s, %s]'), o.response.code, o.response.reason(),
+            util.filesize(size), util.prettyms(o.response.responseTime));
     });
 
     // Print script errors in real time


### PR DESCRIPTION
The check for err prevented the message being displayed.