### PR TITLE
Remove indentation from CLI error logs

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -70,7 +70,7 @@ program
             const runError = err || summary.run.error || summary.run.failures.length;
 
             if (err) {
-                console.error(`\n  error: ${err.message || err}\n`);
+                console.error(`error: ${err.message || err}\n`);
                 err.friendly && console.error(`  ${err.friendly}\n`);
             }
             runError && !_.get(options, 'suppressExitCode') && process.exit(1);
@@ -79,7 +79,7 @@ program
 
 // Warn on invalid command and then exits.
 program.on('command:*', (command) => {
-    console.error(`\n  error: invalid command \`${command}\`\n`);
+    console.error(`error: invalid command \`${command}\`\n`);
     program.help();
 });
 
@@ -119,7 +119,7 @@ function run (argv, callback) {
 
         // in case of an error, log error message and print help message.
         if (error) {
-            console.error(`\n  error: ${error.message || error}\n`);
+            console.error(`error: ${error.message || error}\n`);
             program.help();
         }
     });

--- a/package.json
+++ b/package.json
@@ -41,13 +41,12 @@
   "dependencies": {
     "async": "2.6.1",
     "cli-progress": "2.1.0",
-    "cli-table3": "0.5.0",
+    "cli-table3": "0.5.1",
     "colors": "1.3.2",
-    "commander": "2.18.0",
+    "commander": "2.19.0",
     "csv-parse": "3.1.3",
     "eventemitter3": "3.1.0",
     "filesize": "3.6.1",
-    "handlebars": "4.0.11",
     "lodash": "4.17.11",
     "mkdirp": "0.5.1",
     "parse-json": "4.0.0",
@@ -63,11 +62,11 @@
     "xmlbuilder": "10.0.0"
   },
   "devDependencies": {
-    "chai": "4.1.2",
+    "chai": "4.2.0",
     "dockerfile_lint": "0.3.3",
     "editorconfig": "0.15.0",
-    "eslint": "5.0.1",
-    "eslint-plugin-jsdoc": "3.7.1",
+    "eslint": "5.6.1",
+    "eslint-plugin-jsdoc": "3.8.0",
     "eslint-plugin-lodash": "3.1.0",
     "eslint-plugin-mocha": "5.2.0",
     "eslint-plugin-security": "1.4.0",
@@ -82,7 +81,7 @@
     "parse-gitignore": "1.0.1",
     "postman-jsdoc-theme": "0.0.3",
     "recursive-readdir": "2.2.2",
-    "sinon": "6.1.3",
+    "sinon": "6.3.5",
     "xml2js": "0.4.19"
   },
   "engines": {

--- a/test/cli/run-options.test.js
+++ b/test/cli/run-options.test.js
@@ -65,7 +65,7 @@ describe('CLI run options', function () {
         // eslint-disable-next-line max-len
         exec('node ./bin/newman.js run test/integration/steph/steph.postman_collection.json --global-var', function (code, stdout, stderr) {
             expect(code, 'should have exit code of 1').to.equal(1);
-            expect(stderr).to.equal('\n  error: option `--global-var <value>\' argument missing\n\n');
+            expect(stderr).to.equal('error: option `--global-var <value>\' argument missing\n');
             done();
         });
     });

--- a/test/system/repository.test.js
+++ b/test/system/repository.test.js
@@ -70,7 +70,7 @@ describe('project repository', function () {
                 json.bin && Object.keys(json.bin).forEach(function (scriptName) {
                     var fileContent = fs.readFileSync(json.bin[scriptName]).toString();
 
-                    expect(/^#!\/(bin\/bash|usr\/bin\/env\snode)[\r\n][\W\w]*$/g.test(fileContent),
+                    expect((/^#!\/(bin\/bash|usr\/bin\/env\snode)[\r\n][\W\w]*$/g).test(fileContent),
                         `invalid or missing shebang in ${json.bin[scriptName]}`).to.be.ok;
                 });
             });
@@ -104,11 +104,11 @@ describe('project repository', function () {
                     fs.readFile(name, function (error, content) {
                         expect(error).to.equal(null);
                         if (fileDetails.ext === '.sh') {
-                            expect(/^#!\/bin\/bash[\r\n][\W\w]*$/g.test(content),
+                            expect((/^#!\/bin\/bash[\r\n][\W\w]*$/g).test(content),
                                 `invalid or missing hashbang in ${name}`).to.be.ok;
                         }
                         else {
-                            expect(/^#!\/usr\/bin\/env\snode[\r\n][\W\w]*$/g.test(content),
+                            expect((/^#!\/usr\/bin\/env\snode[\r\n][\W\w]*$/g).test(content),
                                 `invalid or missing hashbang in ${name}`).to.be.ok;
                         }
                     });


### PR DESCRIPTION
- Remove indentation from CLI error logs  
  > to have parity with commander@2.19.0
- Bumped dependencies
  > which are not updated via greenkeeper
- Removed `handlebars` dependency
  > no longer needed
- Fixed lint error in repository tests
  > because of eslint update

Closes #1741 