### PR TITLE
Add skipped status to beforeDone assertion summary

### DIFF
--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -178,6 +178,7 @@ _.assign(RunSummary, {
 
             (execution.assertions || (execution.assertions = [])).push({
                 assertion: o.assertion,
+                skipped: o.skipped,
                 error: err || undefined
             });
         });


### PR DESCRIPTION
Assertion summaries currently cover 2/3 possibilities for an assertion.

- If `error` is `undefined`, then it's assumed it `passed`
- Vice versa for error

If a test is skipped, it cannot be distinguished from a passed test at this level. This will be really useful for reporters where tests are aggregated/tabled, imagine a third column which would allow you to see what tests have skipped:

![image](https://user-images.githubusercontent.com/8490181/50036583-add3ad00-ffbe-11e8-8329-2e6542502c4e.png)

Whilst the `assertion` event contains the `skipped` status, there doesn't seem to be a clear way to join/aggregate assertions from `assertion` with `beforeDone`, so making `skipped` available within `assertions` on `beforeDone` seems to make most sense.