### PR TITLE
Fix issue causing incomplete junit report to be generated for nested requests 

### DIFF
--- a/lib/reporters/junit/index.js
+++ b/lib/reporters/junit/index.js
@@ -31,8 +31,8 @@ JunitReporter = function (newman, reporterOptions) {
         root.att('tests', _.get(newman, 'summary.run.stats.tests.total', 'unknown'));
 
         cache = _.transform(report, function (accumulator, execution) {
-            accumulator[execution.id] = accumulator[execution.id] || [];
-            accumulator[execution.id].push(execution);
+            accumulator[execution.item.id] = accumulator[execution.id] || [];
+            accumulator[execution.item.id].push(execution);
         }, {});
 
         timestamp = new Date(_.get(newman, 'summary.run.timings.started')).toISOString();

--- a/test/cli/shallow-junit-reporter.test.js
+++ b/test/cli/shallow-junit-reporter.test.js
@@ -84,6 +84,7 @@ describe('JUnit reporter', function () {
                         expect(testcase.failure[0].$).to.have.property('type', 'AssertionFailure');
 
                         expect(testcase.failure).to.not.be.empty;
+
                         done();
                     });
                 });
@@ -148,6 +149,91 @@ describe('JUnit reporter', function () {
             function (code) {
                 expect(code, 'should have exit code of 0').to.equal(0);
                 fs.stat(outFile, done);
+            });
+    });
+
+    it('should correctly generate the junit report for a run with nested requests', function (done) {
+        // eslint-disable-next-line max-len
+        exec(`node ./bin/newman.js run test/fixtures/run/nested-requests-report-test.json -r junit --reporter-junit-export ${outFile}`,
+            function (code) {
+                expect(code, 'should have exit code of 0').to.equal(0);
+                fs.readFile(outFile, function (err, data) {
+                    expect(err).to.not.be.ok;
+
+                    parseXml(data, function (error, result) {
+                        expect(error).to.not.be.ok;
+
+                        var suite = _.get(result.testsuites, 'testsuite.0');
+
+                        expect(result.testsuites.$).to.not.be.empty;
+                        expect(result.testsuites.$.time).to.match(/^\d+\.\d{3}$/);
+
+                        expect(suite).to.not.be.empty;
+                        expect(suite.$).to.not.be.empty;
+                        expect(suite.$.time).to.match(/^\d+\.\d{3}$/);
+                        expect(suite.testcase).to.not.be.empty;
+
+                        expect(suite.$).to.have.property('tests', '2');
+                        expect(suite.$).to.have.property('failures', '0');
+                        expect(suite.$).to.have.property('errors', '0');
+
+                        done();
+                    });
+                });
+            });
+    });
+
+    it('should correctly generate the junit report for a failed run with nested requests', function (done) {
+        // eslint-disable-next-line max-len
+        exec(`node ./bin/newman.js run test/fixtures/run/nested-requests-fail-report-test.json -r junit --reporter-junit-export ${outFile}`,
+            function (code) {
+                expect(code, 'should have exit code of 0').to.equal(1);
+                fs.readFile(outFile, function (err, data) {
+                    expect(err).to.not.be.ok;
+
+                    parseXml(data, function (error, result) {
+                        expect(error).to.not.be.ok;
+
+                        var testcase,
+                            suite = _.get(result.testsuites, 'testsuite.0');
+
+                        expect(result.testsuites.$).to.not.be.empty;
+                        expect(result.testsuites.$.time).to.match(/^\d+\.\d{3}$/);
+
+                        expect(suite).to.not.be.empty;
+                        expect(suite.$).to.not.be.empty;
+                        expect(suite.$.time).to.match(/^\d+\.\d{3}$/);
+                        expect(suite.testcase).to.not.be.empty;
+
+                        expect(suite.$).to.have.property('tests', '2');
+                        expect(suite.$).to.have.property('failures', '2');
+                        expect(suite.$).to.have.property('errors', '0');
+
+                        testcase = suite.testcase[0];
+                        expect(testcase).to.not.be.empty;
+
+                        expect(testcase.$).to.have.property('classname', 'Nested request test');
+                        expect(testcase.$.time).to.match(/^\d+\.\d{3}$/);
+                        expect(testcase.failure).to.not.be.empty;
+                        expect(testcase.failure[0]._).to.not.be.empty;
+                        expect(testcase.failure[0].$).to.have.property('type', 'AssertionFailure');
+
+                        expect(testcase.failure).to.not.be.empty;
+
+                        testcase = suite.testcase[1];
+                        expect(testcase).to.not.be.empty;
+
+                        expect(testcase.$).to.have.property('classname', 'Nested request test');
+                        expect(testcase.$.time).to.match(/^\d+\.\d{3}$/);
+                        expect(testcase.failure).to.not.be.empty;
+                        expect(testcase.failure[0]._).to.not.be.empty;
+                        expect(testcase.failure[0].$).to.have.property('type', 'AssertionFailure');
+
+                        expect(testcase.failure).to.not.be.empty;
+
+                        done();
+                    });
+                });
             });
     });
 });

--- a/test/fixtures/run/nested-requests-fail-report-test.json
+++ b/test/fixtures/run/nested-requests-fail-report-test.json
@@ -1,0 +1,66 @@
+{
+	"info": {
+		"_postman_id": "eb3db066-938a-4fe9-8d6d-d1d288b1c25c",
+		"name": "Nested request in test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Nested request test",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "63864333-932a-49b1-8daf-2bfb98650ae6",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(400);",
+							"});",
+							"pm.sendRequest({",
+							"    url: 'https://postman-echo.com/get?key2=val2',",
+							"    method: 'GET'",
+							"}, (err, res) => {",
+							"    if (err) {",
+							"        console.log(err);",
+							"    } else {",
+							"        var resData = JSON.parse(res.stream.toString()).args;",
+							"",
+							"        pm.test('Nested request JSON response: \"key2\": \"val2\"', () => {",
+							"            pm.expect('val2').to.equal('wrongValue');",
+							"        });",
+							"    }",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "https://postman-echo.com/get?foo1=bar1",
+					"protocol": "https",
+					"host": [
+						"postman-echo",
+						"com"
+					],
+					"path": [
+						"get"
+					],
+					"query": [
+						{
+							"key": "foo1",
+							"value": "bar1"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/test/fixtures/run/nested-requests-report-test.json
+++ b/test/fixtures/run/nested-requests-report-test.json
@@ -1,0 +1,66 @@
+{
+	"info": {
+		"_postman_id": "eb3db066-938a-4fe9-8d6d-d1d288b1c25c",
+		"name": "Nested request in test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Nested request test",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "63864333-932a-49b1-8daf-2bfb98650ae6",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"pm.sendRequest({",
+							"    url: 'https://postman-echo.com/get?key2=val2',",
+							"    method: 'GET'",
+							"}, (err, res) => {",
+							"    if (err) {",
+							"        console.log(err);",
+							"    } else {",
+							"        var resData = JSON.parse(res.stream.toString()).args;",
+							"",
+							"        pm.test('Nested request JSON response: \"key2\": \"val2\"', () => {",
+							"            pm.expect('val2').to.equal(resData.key2);",
+							"        });",
+							"    }",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "https://postman-echo.com/get?foo1=bar1",
+					"protocol": "https",
+					"host": [
+						"postman-echo",
+						"com"
+					],
+					"path": [
+						"get"
+					],
+					"query": [
+						{
+							"key": "foo1",
+							"value": "bar1"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
When given a collection with nested requests i.e requests in test scripts, Junit reporter is unable to generate a complete report. 

Fixes #1461 