### PR TITLE
Add different warnings for reporter not found and reporter not loaded

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  fixed bugs:
+    - '#2062 Added warnings for "reporter not found" and "reporter could not be loaded"'
+
 4.5.4:
   date: 2019-08-14
   chores:

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -344,9 +344,22 @@ module.exports = function (options, callback) {
                         return prefix + 'newman-reporter-' + name;
                     }(reporterName)));
                 }
-                // we suppress this error since, the check of missing error is done later
                 // @todo - maybe have a debug mode and log error there
-                catch (error) { } // eslint-disable-line no-empty
+                catch (error) {
+                    if (!defaultReporters[reporterName]) {
+                        // @todo: route this via print module to respect silent flags
+                        console.warn(`newman: could not find "${reporterName}" reporter`);
+                        console.warn('  ensure that the reporter is installed in the same directory as newman');
+
+                        // print install instruction in case a known reporter is missing
+                        if (knownReporterErrorMessages[reporterName]) {
+                            console.warn(knownReporterErrorMessages[reporterName]);
+                        }
+                        else {
+                            console.warn('  please install reporter using npm\n');
+                        }
+                    }
+                }
 
                 // load local reporter if its not an external reporter
                 !Reporter && (Reporter = defaultReporters[reporterName]);
@@ -360,21 +373,13 @@ module.exports = function (options, callback) {
                 catch (error) {
                     // if the reporter errored out during initialisation, we should not stop the run simply log
                     // the error stack trace for debugging
-                    // @todo: route this via print module to respect silent flags
-                    console.warn(error);
-                }
+                    console.warn(`newman: could not load "${reporterName}" reporter`);
 
-                // if the reporter is not loaded then we need to warn users
-                if (!(_.isFunction(Reporter) && _.isObject(emitter.reporters[reporterName]))) {
-                    // @todo: route this via print module to respect silent flags
-                    console.warn(`newman: "${reporterName}" reporter could not be loaded.`);
-                    // print install instruction in case a known reporter is missing
-                    if (knownReporterErrorMessages[reporterName]) {
-                        console.warn(knownReporterErrorMessages[reporterName]);
+                    if (!defaultReporters[reporterName]) {
+                        // @todo: route this via print module to respect silent flags
+                        console.warn(`  this seems to be a problem in the "${reporterName}" reporter.\n`);
                     }
-                    else {
-                        console.warn('  please install reporter using npm\n');
-                    }
+                    console.warn(error);
                 }
             });
 

--- a/test/unit/defaultReporter.test.js
+++ b/test/unit/defaultReporter.test.js
@@ -2,13 +2,15 @@ var sinon = require('sinon'),
     newman = require('../../');
 
 describe('Default reporter', function () {
+    beforeEach(function () {
+        sinon.replace(console, 'warn', sinon.fake());
+    });
+
     afterEach(function () {
         sinon.restore();
     });
 
     it('cli can be loaded', function (done) {
-        sinon.replace(console, 'warn', sinon.fake());
-
         newman.run({
             collection: 'test/fixtures/run/single-get-request.json',
             reporters: ['cli']
@@ -21,8 +23,6 @@ describe('Default reporter', function () {
     });
 
     it('json can be loaded', function (done) {
-        sinon.replace(console, 'warn', sinon.fake());
-
         newman.run({
             collection: 'test/fixtures/run/single-get-request.json',
             reporters: ['json']
@@ -35,8 +35,6 @@ describe('Default reporter', function () {
     });
 
     it('junit can be loaded', function (done) {
-        sinon.replace(console, 'warn', sinon.fake());
-
         newman.run({
             collection: 'test/fixtures/run/single-get-request.json',
             reporters: ['junit']
@@ -49,8 +47,6 @@ describe('Default reporter', function () {
     });
 
     it('progress can be loaded', function (done) {
-        sinon.replace(console, 'warn', sinon.fake());
-
         newman.run({
             collection: 'test/fixtures/run/single-get-request.json',
             reporters: ['progress']
@@ -63,8 +59,6 @@ describe('Default reporter', function () {
     });
 
     it('emojitrain can be loaded', function (done) {
-        sinon.replace(console, 'warn', sinon.fake());
-
         newman.run({
             collection: 'test/fixtures/run/single-get-request.json',
             reporters: ['emojitrain']

--- a/test/unit/defaultReporter.test.js
+++ b/test/unit/defaultReporter.test.js
@@ -1,0 +1,78 @@
+var sinon = require('sinon'),
+    newman = require('../../');
+
+describe('Default reporter', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('cli can be loaded', function (done) {
+        sinon.replace(console, 'warn', sinon.fake());
+
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            reporters: ['cli']
+        }, function (err) {
+            expect(err).to.be.null;
+            expect(console.warn.called).to.be.false;
+
+            done();
+        });
+    });
+
+    it('json can be loaded', function (done) {
+        sinon.replace(console, 'warn', sinon.fake());
+
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            reporters: ['json']
+        }, function (err) {
+            expect(err).to.be.null;
+            expect(console.warn.called).to.be.false;
+
+            done();
+        });
+    });
+
+    it('junit can be loaded', function (done) {
+        sinon.replace(console, 'warn', sinon.fake());
+
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            reporters: ['junit']
+        }, function (err) {
+            expect(err).to.be.null;
+            expect(console.warn.called).to.be.false;
+
+            done();
+        });
+    });
+
+    it('progress can be loaded', function (done) {
+        sinon.replace(console, 'warn', sinon.fake());
+
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            reporters: ['progress']
+        }, function (err) {
+            expect(err).to.be.null;
+            expect(console.warn.called).to.be.false;
+
+            done();
+        });
+    });
+
+    it('emojitrain can be loaded', function (done) {
+        sinon.replace(console, 'warn', sinon.fake());
+
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            reporters: ['emojitrain']
+        }, function (err) {
+            expect(err).to.be.null;
+            expect(console.warn.called).to.be.false;
+
+            done();
+        });
+    });
+});

--- a/test/unit/externalReporter.test.js
+++ b/test/unit/externalReporter.test.js
@@ -1,0 +1,23 @@
+var sinon = require('sinon'),
+    newman = require('../../');
+
+describe('External reporter', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('warns when not found', function (done) {
+        sinon.replace(console, 'warn', sinon.fake());
+
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            reporters: ['unknownreporter']
+        }, function (err) {
+            expect(err).to.be.null;
+            expect(console.warn.called).to.be.true;
+            expect(console.warn.calledWith('newman: could not find "unknownreporter" reporter')).to.be.true;
+
+            done();
+        });
+    });
+});

--- a/test/unit/externalReporter.test.js
+++ b/test/unit/externalReporter.test.js
@@ -2,13 +2,15 @@ var sinon = require('sinon'),
     newman = require('../../');
 
 describe('External reporter', function () {
+    beforeEach(function () {
+        sinon.replace(console, 'warn', sinon.fake());
+    });
+
     afterEach(function () {
         sinon.restore();
     });
 
     it('warns when not found', function (done) {
-        sinon.replace(console, 'warn', sinon.fake());
-
         newman.run({
             collection: 'test/fixtures/run/single-get-request.json',
             reporters: ['unknownreporter']


### PR DESCRIPTION
Warning when reporter not found:
```
newman: "teamcity" reporter could not be found.
  ensure that the reporter is installed in the same directory as newman
  run `npm install newman-reporter-teamcity`
```

Warning when reporter could not be loaded:
```
newman: "cli" reporter could not be loaded.
  this seems to be a problem in the reporter.
```

Ref: https://github.com/postmanlabs/newman/issues/1969
cc: @shamasis 