### PR TITLE
Feature/no success assertions

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -29,6 +29,7 @@ program
     .option('-d, --iteration-data <path>', 'Specify a data file to use for iterations (either json or csv).')
     .option('--export-environment <path>', 'Exports the environment to a file after completing the run.')
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
+    .option('--reporter-cli-no-success-assertions', 'Show no output on successful assertions')
     .option('--export-collection <path>', 'Specify an output file to save the executed collection')
     .option('--postman-api-key <apiKey>', 'API Key used to load the resources from the Postman API.')
     .option('--delay-request [n]', 'Specify the extent of delay between requests (milliseconds)', util.cast.integer, 0)

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -54,8 +54,8 @@ describe('cli parser', function () {
                         envVar: [],
                         folder: [],
                         insecureFileRead: true,
-                        // Removing the following non-comment line causes the test to fail.
-                        // Although the application functioning remains the same in either case.
+                        // Removing the following non-comment line causes the test to fail as
+                        // commander.js assigns default values for falgs containing "no"
                         reporterCliNoSuccessAssertions: true,
                         color: 'auto',
                         timeout: 0,

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -54,6 +54,9 @@ describe('cli parser', function () {
                         envVar: [],
                         folder: [],
                         insecureFileRead: true,
+                        // Removing the following non-comment line causes the test to fail.
+                        // Although the application functioning remains the same in either case.
+                        reporterCliNoSuccessAssertions: true,
                         color: 'auto',
                         timeout: 0,
                         timeoutRequest: 0,


### PR DESCRIPTION
This is a fix for #1902. 

When I looked into the codebase, the flag  ```--reporter-cli-no-success-assertions```  was present in passing tests but not in ```bin/newman.js``` (and consequently not in ```newman run -h``` command)

Adding it to ```bin/newman.js``` caused test to fail due to an assertion error. It appears to be a problem with commander.js where they assign default values to flags containing ```no```.  I have added the extra assertion in the test which passes the tests.

This could have been fixed better with some rework but I have left it as is to not potentially break the work-flow of anyone who may be currently using it.   