### PR TITLE
#2255 - Add cli reporter option to print plain unwrapped console logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ such a scenario.
 | `--reporter-cli-no-success-assertions`  | This turns off the output for successful assertions as they happen. |
 | `--reporter-cli-no-console`     | This turns off the output of `console.log` (and other console calls) from collection's scripts. |
 | `--reporter-cli-no-banner`      | This turns off the `newman` banner shown at the beginning of each collection run. |
+| `--reporter-cli-clean-console`  | Prints the output of `console.log` (and other console calls) in a plain unwrapped way. |
 
 ### JSON Reporter
 The built-in JSON reporter is useful in producing a comprehensive output of the run summary. It takes the path to the

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -57,6 +57,7 @@ extractSNR = function (executions) {
  * @param {Boolean=} reporterOptions.noFailures - Boolean flag to turn off failure reporting altogether, if set to true.
  * @param {Boolean=} reporterOptions.noConsole - Boolean flag to turn off console logging, if set to true.
  * @param {Boolean=} reporterOptions.noBanner - Boolean flag to turn off newman banner, if set to true.
+ * @param {Boolean=} reporterOptions.cleanConsole - Boolean flag to print console logging in a plain unwrapped way.
  * @param {Object} options - A set of generic collection run options.
  * @returns {*}
  */
@@ -246,16 +247,23 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
         var color = colors[o.level] || colors.gray,
             message;
 
-        // we first merge all messages to a string. while merging we run the values to util.inspect to colour code the
-        // messages based on data type
-        message = wrap(_.reduce(o.messages, function (log, message) { // wrap the whole message to the window size
-            return (log += (log ? colors.white(', ') : '') + inspect(message));
-        }, E), `  ${color(symbols.console.middle)} `); // add an indentation line at the beginning
+        if (reporterOptions.cleanConsole) { // merge all messages to a string, with no indentation or wrap according
+            message = _.reduce(o.messages, function (log, message) { return message; }, E);
+            print.nobuffer(colors.gray(message.replace(/\n\s*\n/g, LF) + LF));
+        }
+        else {
+            // we first merge all messages to a string.
+            // while merging we run the values to util.inspect to colour code the
+            // messages based on data type
+            message = wrap(_.reduce(o.messages, function (log, message) { // wrap the whole message to the window size
+                return (log += (log ? colors.white(', ') : '') + inspect(message));
+            }, E), `  ${color(symbols.console.middle)} `); // add an indentation line at the beginning
 
-        print.buffer(color(`  ${symbols.console.top}\n`), color(`  ${symbols.console.bottom}\n`))
-            // tweak the message to ensure that its surrounding is not brightly coloured.
-            // also ensure to remove any blank lines generated due to util.inspect
-            .nobuffer(colors.gray(message.replace(/\n\s*\n/g, LF) + LF));
+            print.buffer(color(`  ${symbols.console.top}\n`), color(`  ${symbols.console.bottom}\n`))
+                // tweak the message to ensure that its surrounding is not brightly coloured.
+                // also ensure to remove any blank lines generated due to util.inspect
+                .nobuffer(colors.gray(message.replace(/\n\s*\n/g, LF) + LF));
+        }
     });
 };
 


### PR DESCRIPTION
Related ticket: #2255 
Related community discussion: https://community.postman.com/t/remove-from-newman-cli-output/11229

/cc @DannyDainton 