### PR TITLE
Display an appropriate error message when user wants to load resources from Postman API, but forget to provide "postmanApiKey"

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -157,9 +157,16 @@ util = {
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
-        if (!fs.existsSync(location) && POSTMAN_API_PATH_MAP[type] && postmanApiKey && UID_REGEX.test(location)) {
-            location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
-            headers[API_KEY_HEADER] = postmanApiKey;
+        if (!fs.existsSync(location) && POSTMAN_API_PATH_MAP[type] && UID_REGEX.test(location)) {
+            if (postmanApiKey) {
+                location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
+                headers[API_KEY_HEADER] = postmanApiKey;
+            } 
+            else {
+                var error = new Error('"postmanApiKey" not found');
+                return callback(_.set(error, 'help', `Please provide your "postmanApiKey" in the object you are passing to newman.run(), to retrieve the resources from Postman API`));
+            }
+            
         }
 
         return (/^https?:\/\/.*/).test(location) ?

--- a/lib/util.js
+++ b/lib/util.js
@@ -153,7 +153,8 @@ util = {
         !callback && _.isFunction(options) && (callback = options, options = {});
 
         var postmanApiKey = _.get(options, 'postmanApiKey'),
-            headers = { 'User-Agent': USER_AGENT_VALUE };
+            headers = { 'User-Agent': USER_AGENT_VALUE },
+            error;
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
@@ -161,12 +162,13 @@ util = {
             if (postmanApiKey) {
                 location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
                 headers[API_KEY_HEADER] = postmanApiKey;
-            } 
-            else {
-                var error = new Error('"postmanApiKey" not found');
-                return callback(_.set(error, 'help', `Please provide your "postmanApiKey" in the object you are passing to newman.run(), to retrieve the resources from Postman API`));
             }
-            
+            else {
+                error = new Error('postmanApiKey not found');
+
+                // eslint-disable-next-line max-len
+                return callback(_.set(error, 'help', 'Please provide your postmanApiKey in the object you are passing to newman.run(), to retrieve the resources from Postman API'));
+            }
         }
 
         return (/^https?:\/\/.*/).test(location) ?

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -134,7 +134,7 @@ describe('newman.run postmanApiKey', function () {
         newman.run({
             collection: '1234-588025f9-2497-46f7-b849-47f58b865807'
         }, function (err) {
-            expect(err).to.be.ok.that.match(/no such file or directory/);
+            expect(err).to.be.ok.that.match(/postmanApiKey not found/);
             sinon.assert.notCalled(request.get);
 
             done();


### PR DESCRIPTION
Fixes #2217 

### Issue:
When a user wants to load a resource from Postman API and forgets to provide "postmanApiKey", the following error message is displayed, which seems to be very inappropriate:

```
[Error: ENOENT: no such file or directory, open 'C:\Repos\postman-demo\7337586-64084678-a735-4b2e-9292-163bccfe6eca'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'C:\\Repos\\postman-demo\\7337586-64084678-a735-4b2e-9292-163bccfe6eca',
  help: 'unable to read data from file "7337586-64084678-a735-4b2e-9292-163bccfe6eca"'
}
```
It is expected to **suggest the user that "postmanApiKey" is missing in the object passed to newman.run()**

### Fix
Added a check for "postmanApiKey", when user wants to load the resource from Postman API (i.e. when user  provides UID of the resources to load) and throws an error right away when the "postmanApiKey" is not found in the above case, with a suggestion to provide "postmanApiKey" for successful execution of the request

![Screenshot (3)](https://user-images.githubusercontent.com/18217329/76165986-3ec51400-6181-11ea-95b4-86b009522564.png)


### Validation
Changes validated locally
