### PR TITLE
Multiple file support

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -26,6 +26,7 @@ program
     .option('--no-insecure-file-read', 'Prevents reading the files situated outside of the working directory')
     .option('-r, --reporters [reporters]', 'Specify the reporters to use for this run.', util.cast.csvParse, ['cli'])
     .option('-n, --iteration-count <n>', 'Define the number of iterations to run.', util.cast.integer)
+    // eslint-disable-next-line max-len
     .option('-d, --iteration-data <path>', 'Specify a data file to use for iterations (either json or csv).', util.cast.memoize, [])
     .option('--export-environment <path>', 'Exports the environment to a file after completing the run.')
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
@@ -106,7 +107,7 @@ program.on('command:*', (command) => {
  * @param {String[]} argv - Argument vector.
  * @param {?Function} callback - The callback function invoked on the completion of execution.
  */
-function run(argv, callback) {
+function run (argv, callback) {
     waterfall([
         (next) => {
             // cache original argv, required to parse nested options later.

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -26,7 +26,7 @@ program
     .option('--no-insecure-file-read', 'Prevents reading the files situated outside of the working directory')
     .option('-r, --reporters [reporters]', 'Specify the reporters to use for this run.', util.cast.csvParse, ['cli'])
     .option('-n, --iteration-count <n>', 'Define the number of iterations to run.', util.cast.integer)
-    .option('-d, --iteration-data <path>', 'Specify a data file to use for iterations (either json or csv).')
+    .option('-d, --iteration-data <path>', 'Specify a data file to use for iterations (either json or csv).', util.cast.memoize, [])
     .option('--export-environment <path>', 'Exports the environment to a file after completing the run.')
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
     .option('--export-collection <path>', 'Specify an output file to save the executed collection')
@@ -106,7 +106,7 @@ program.on('command:*', (command) => {
  * @param {String[]} argv - Argument vector.
  * @param {?Function} callback - The callback function invoked on the completion of execution.
  */
-function run (argv, callback) {
+function run(argv, callback) {
     waterfall([
         (next) => {
             // cache original argv, required to parse nested options later.

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -262,7 +262,7 @@ var _ = require('lodash'),
          */
         iterationData: function (location, options, callback) {
             // if location is array of objects - raw data
-            var data = [];
+            var parsedData = [];
 
             if (_.isArray(location)) {
                 if (!_.isObject(location[0])) {
@@ -271,11 +271,11 @@ var _ = require('lodash'),
                             if (err) {
                                 return callback(err);
                             }
-                            data.push(...data);
+                            parsedData.push(...data);
                         });
                     });
 
-                    return callback(null, data);
+                    return callback(null, parsedData);
                 }
 
                 return callback(null, location);
@@ -284,10 +284,10 @@ var _ = require('lodash'),
                 if (err) {
                     return callback(err);
                 }
-                data.push(...data);
+                parsedData.push(...data);
             });
 
-            return callback(null, data);
+            return callback(null, parsedData);
         },
 
         fetchLocationContent: function (location, callback) {

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -260,7 +260,56 @@ var _ = require('lodash'),
          * @returns {*}
          */
         iterationData: function (location, options, callback) {
-            if (_.isArray(location)) { return callback(null, location); }
+            // if location is array of objects - raw data
+
+            // if (_.isArray(location)) { return callback(null, location); }
+            if (_.isArray(location)) {
+                if (!_.isObject(location[0])) {
+                    var testData = [];
+
+                    location.forEach((location) => {
+                        util.fetch(location, function (err, data) {
+                            if (err) {
+                                return callback(err);
+                            }
+
+                            // Try loading as a JSON, fall-back to CSV. @todo: switch to file extension based loading.
+                            async.waterfall([
+                                (cb) => {
+                                    try {
+                                        return cb(null, liquidJSON.parse(data.trim()));
+                                    }
+                                    catch (e) {
+                                        return cb(null, undefined); // e masked to avoid displaying JSON parse errors for CSV files
+                                    }
+                                },
+                                (json, cb) => {
+                                    if (json) {
+                                        return cb(null, json);
+                                    }
+                                    // Wasn't JSON
+                                    parseCsv(data, {
+                                        columns: true,
+                                        escape: '\\',
+                                        cast: csvAutoParse,
+                                        trim: true
+                                    }, cb);
+                                }
+                            ], (err, parsed) => {
+                                if (err) {
+                                    // todo: Log meaningful stuff here
+                                    return callback(err);
+                                }
+                                testData.push(...parsed);
+                            });
+                        });
+                    });
+
+                    return callback(null, testData);
+                }
+
+                return callback(null, location);
+            }
 
             util.fetch(location, function (err, data) {
                 if (err) {

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 var _ = require('lodash'),
     fs = require('fs'),
     async = require('async'),
@@ -261,56 +262,35 @@ var _ = require('lodash'),
          */
         iterationData: function (location, options, callback) {
             // if location is array of objects - raw data
+            var data = [];
 
             if (_.isArray(location)) {
                 if (!_.isObject(location[0])) {
-                    var testData = [];
-
                     location.forEach((location) => {
-                        util.fetch(location, function (err, data) {
+                        this.fetchLocationContent(location, function (err, data) {
                             if (err) {
                                 return callback(err);
                             }
-
-                            // Try loading as a JSON, fall-back to CSV. @todo: switch to file extension based loading.
-                            async.waterfall([
-                                (cb) => {
-                                    try {
-                                        return cb(null, liquidJSON.parse(data.trim()));
-                                    }
-                                    catch (e) {
-                                        return cb(null, undefined);
-                                        // e masked to avoid displaying JSON parse errors for CSV files
-                                    }
-                                },
-                                (json, cb) => {
-                                    if (json) {
-                                        return cb(null, json);
-                                    }
-                                    // Wasn't JSON
-                                    parseCsv(data, {
-                                        columns: true,
-                                        escape: '\\',
-                                        cast: csvAutoParse,
-                                        trim: true
-                                    }, cb);
-                                }
-                            ], (err, parsed) => {
-                                if (err) {
-                                    // todo: Log meaningful stuff here
-                                    return callback(err);
-                                }
-                                testData.push(...parsed);
-                            });
+                            data.push(...data);
                         });
                     });
 
-                    return callback(null, testData);
+                    return callback(null, data);
                 }
 
                 return callback(null, location);
             }
+            this.fetchLocationContent(location, function (err, data) {
+                if (err) {
+                    return callback(err);
+                }
+                data.push(...data);
+            });
 
+            return callback(null, data);
+        },
+
+        fetchLocationContent: function (location, callback) {
             util.fetch(location, function (err, data) {
                 if (err) {
                     return callback(err);

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -279,7 +279,8 @@ var _ = require('lodash'),
                                         return cb(null, liquidJSON.parse(data.trim()));
                                     }
                                     catch (e) {
-                                        return cb(null, undefined); // e masked to avoid displaying JSON parse errors for CSV files
+                                        return cb(null, undefined);
+                                        // e masked to avoid displaying JSON parse errors for CSV files
                                     }
                                 },
                                 (json, cb) => {

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -262,7 +262,6 @@ var _ = require('lodash'),
         iterationData: function (location, options, callback) {
             // if location is array of objects - raw data
 
-            // if (_.isArray(location)) { return callback(null, location); }
             if (_.isArray(location)) {
                 if (!_.isObject(location[0])) {
                     var testData = [];


### PR DESCRIPTION
fix #2215 

Add multiple file support with --iteration-data flag. Right now it checks whether the location is array or not. If its an array then check whether it has an object inside it or not. If it has no object, then it is an array of location and data is parsed for each location and then passed on, and if not an array, location variable is treated as string.
