### PR TITLE
Reporter for unwrapped console logging

### DIFF
--- a/lib/reporters/logger/index.js
+++ b/lib/reporters/logger/index.js
@@ -1,0 +1,98 @@
+var _ = require('lodash'),
+    PostmanLoggerReporter;
+
+/**
+ * Reporter that simply logs the console calls to file (default: newman-run-logs.txt).
+ *
+ * @param {Object} emitter - The collection run object, with event hooks for reporting run details.
+ * @param {Object} reporterOptions - CLI reporter options object.
+ * @param {Object} collectionRunOptions - A set of collection run options.
+ * @param {String} collectionRunOptions.export - The path to which the logs must be written.
+ * @param {Boolean=} reporterOptions.clean - Boolean flag to log only console events.
+ * @returns {*}
+ */
+
+PostmanLoggerReporter = function (emitter, reporterOptions, collectionRunOptions) {
+    var collectionName = collectionRunOptions.collection.name,
+        preRequestLog,
+        requestLog,
+        testLog,
+        runState,
+        requestMethod,
+        requestUrl,
+        itemName,
+        finalLog;
+
+    emitter.on('beforeItem', function () {
+        preRequestLog = '';
+        requestLog = '';
+        testLog = '';
+        runState = 'pre-request';
+        itemName = '';
+        finalLog = [];
+    });
+
+    emitter.on('beforePrerequest', function (err) {
+        if (err) { return; }
+        runState = 'pre-request';
+    });
+
+    emitter.on('beforeRequest', function (err, o) {
+        if (err) { return; }
+        runState = 'request';
+        requestMethod = o.request.method;
+        requestUrl = o.request.url.toString();
+    });
+
+    emitter.on('beforeTest', function (err) {
+        if (err) { return; }
+        runState = 'test';
+    });
+
+    emitter.on('item', function (err, o) {
+        if (err) { return; }
+
+        itemName = `${o.item.name}\n `;
+        let PreReqLog = `pre-request:\n ${preRequestLog}\n `,
+            reqLog = `request:\n ${requestMethod} ${requestUrl}\n ${requestLog}\n test:\n ${testLog}\n `,
+            itemLog = (!reporterOptions.clean) ? itemName + PreReqLog + reqLog : ` ${preRequestLog}${requestLog}${testLog}`;
+
+        finalLog.push(itemLog);
+    });
+
+    emitter.on('console', function (err, o) {
+        if (err) { return; }
+
+        switch (runState) {
+            case 'pre-request':
+                preRequestLog += `${o.messages} \n `;
+                break;
+            case 'request':
+                requestLog += `${o.messages} \n `;
+                break;
+            case 'test':
+                testLog += `${o.messages} \n `;
+                break;
+            default:
+                break;
+        }
+    });
+
+    emitter.on('beforeDone', function (err) {
+        if (err) { return; }
+
+        _.reduce(finalLog, function(compiledLog, log) {
+            return compiledLog += `${log}\n\n`;
+        }, '');
+        finalLog = (!reporterOptions.clean) ? `${collectionName} \n\n ${finalLog}` : finalLog;
+
+        emitter.exports.push({
+            name: 'logger-reporter',
+            default: 'newman-run-logs.txt',
+            path: collectionRunOptions.export,
+            content: finalLog
+        });
+    });
+};
+
+module.exports = PostmanLoggerReporter;

--- a/lib/reporters/logger/index.js
+++ b/lib/reporters/logger/index.js
@@ -55,7 +55,11 @@ PostmanLoggerReporter = function (emitter, reporterOptions, collectionRunOptions
         itemName = `${o.item.name}\n `;
         let PreReqLog = `pre-request:\n ${preRequestLog}\n `,
             reqLog = `request:\n ${requestMethod} ${requestUrl}\n ${requestLog}\n test:\n ${testLog}\n `,
-            itemLog = (!reporterOptions.clean) ? itemName + PreReqLog + reqLog : ` ${preRequestLog}${requestLog}${testLog}`;
+            itemLog = itemName + PreReqLog + reqLog;
+
+        if (reporterOptions.clean) {
+            itemLog = ` ${preRequestLog}${requestLog}${testLog}`;
+        }
 
         finalLog.push(itemLog);
     });
@@ -81,8 +85,10 @@ PostmanLoggerReporter = function (emitter, reporterOptions, collectionRunOptions
     emitter.on('beforeDone', function (err) {
         if (err) { return; }
 
-        _.reduce(finalLog, function(compiledLog, log) {
-            return compiledLog += `${log}\n\n`;
+        _.reduce(finalLog, function (compiledLog, log) {
+            compiledLog += `${log}\n\n`;
+
+            return compiledLog;
         }, '');
         finalLog = (!reporterOptions.clean) ? `${collectionName} \n\n ${finalLog}` : finalLog;
 


### PR DESCRIPTION
fixes #2255 

Read issue for description
@shamasis @codenirvana This reporter normally pipes the log output to a file that can be specified via the export option. If the user doesn't use the `clean` flag, the output is somewhat like the following screenshot, including the collection name, item name, request details, and corresponding `console` events.

<img width="646" alt="Screenshot 2020-03-15 at 3 45 41 PM" src="https://user-images.githubusercontent.com/29275810/76699747-8514f880-66d6-11ea-8532-cff83af3ee25.png">

If the user gives the `clean` flag, only the `console` events are recorded, like so:

<img width="585" alt="Screenshot 2020-03-15 at 3 45 54 PM" src="https://user-images.githubusercontent.com/29275810/76699772-b7bef100-66d6-11ea-99c7-270421c0ca9a.png">


I was thinking of putting in one more flag, `update`, which could allow users to write to an existing file if set to true, otherwise create a new file. Also, I wasn't sure how to get this reviewed so I just put the index.js file of the reporter in a branch and opened a PR. I have tested locally by packaging this though.

#2167 also has some interesting ideas which can be easily incorporated here. Thoughts?