### PR TITLE
Feature: skip responses option for the JSON reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ To enable JSON reporter, provide `--reporters json` as a CLI option.
 | CLI Option  | Description       |
 |-------------|-------------------|
 | `--reporter-json-export <path>` | Specify a path where the output JSON file will be written to disk. If not specified, the file will be written to `newman/` in the current working directory. If the specified path does not exist, it will be created. However, if the specified path is a pre-existing directory, the report will be generated in that directory. |
+| `--reporter-json-skip-responses` | Skip API responses when writing output to file | 
 
 ### JUNIT/XML Reporter
 The built-in JUnit reporter can output a summary of the collection run to a JUnit compatible XML file. To enable the JUNIT reporter, provide

--- a/lib/reporters/json/index.js
+++ b/lib/reporters/json/index.js
@@ -6,17 +6,31 @@ var _ = require('lodash');
  * @param {Object} newman - The collection run object, with event hooks for reporting run details.
  * @param {Object} options - A set of collection run options.
  * @param {String} options.export - The path to which the summary object must be written.
+ * @param {Boolean} options.skipResponses - Do not log responses into the output file.
  * @returns {*}
  */
 module.exports = function (newman, options) {
     newman.on('beforeDone', function (err, o) {
         if (err) { return; }
+        var output = {},
+            summaryClone;
 
+        if (options.skipResponses) {
+            // Clone the summary object and remove the responses before JSON.stringify()
+            summaryClone = _.cloneDeep(_.omit(o.summary, 'exports'));
+            summaryClone.run.executions = _.map(summaryClone.run.executions, function (item) {
+                return _.omit(item, 'response');
+            });
+            output = JSON.stringify(summaryClone, 0, 2);
+        }
+        else {
+            output = JSON.stringify(_.omit(o.summary, 'exports'), 0, 2);
+        }
         newman.exports.push({
             name: 'json-reporter',
             default: 'newman-run-report.json',
             path: options.export,
-            content: JSON.stringify(_.omit(o.summary, 'exports'), 0, 2)
+            content: output
         });
     });
 };

--- a/test/cli/json-reporter-response.test.js
+++ b/test/cli/json-reporter-response.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const _ = require('lodash');
+
+describe('JSON reporter tests', function () {
+    const outFile = 'out/newman-report.json';
+
+    beforeEach(function (done) {
+        fs.stat('out', function (err) {
+            if (err) {
+                return fs.mkdir('out', done);
+            }
+
+            done();
+        });
+    });
+
+    afterEach(function (done) {
+        fs.stat(outFile, function (err) {
+            if (err) {
+                return done();
+            }
+
+            fs.unlink(outFile, done);
+        });
+    });
+
+    it('should correctly export json with API response ', function (done) {
+        // eslint-disable-next-line max-len
+        exec(`node ./bin/newman.js run test/fixtures/run/single-get-request.json -r json --reporter-json-export ${outFile}`, function (code) {
+            expect(code, 'should have exit code of 0').to.equal(0);
+
+            fs.readFile(outFile, 'utf8', function (err, contents) {
+                expect(err).to.be.null;
+                var report = JSON.parse(contents);
+
+                expect(_.has(report.run.executions[0], 'response')).to.be.true;
+                done();
+            });
+        });
+    });
+
+    it('should correctly export json without API response ', function (done) {
+        // eslint-disable-next-line max-len
+        exec(`node ./bin/newman.js run test/fixtures/run/single-get-request.json -r json --reporter-json-export ${outFile} --reporter-json-skip-responses`, function (code) {
+            expect(code, 'should have exit code of 0').to.equal(0);
+
+            fs.readFile(outFile, 'utf8', function (err, contents) {
+                expect(err).to.be.null;
+                var report = JSON.parse(contents);
+
+                expect(_.has(report.run.executions[0], 'response')).to.be.false;
+                done();
+            });
+        });
+    });
+});

--- a/test/library/json-reporter-responses.test.js
+++ b/test/library/json-reporter-responses.test.js
@@ -1,0 +1,60 @@
+var fs = require('fs'),
+    _ = require('lodash');
+
+describe('JSON reporter', function () {
+    var outFile = 'out/newman-report.json';
+
+    beforeEach(function (done) {
+        fs.stat('out', function (err) {
+            if (err) {
+                return fs.mkdir('out', done);
+            }
+
+            done();
+        });
+    });
+
+    afterEach(function (done) {
+        fs.stat(outFile, function (err) {
+            if (err) {
+                return done();
+            }
+
+            fs.unlink(outFile, done);
+        });
+    });
+
+    it('should correctly export json with API response ', function (done) {
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            reporters: ['json'],
+            reporter: { json: { export: outFile } }
+        }, function (err) {
+            if (err) { return done(err); }
+            fs.readFile(outFile, 'utf8', function (err, contents) {
+                expect(err).to.be.null;
+                var report = JSON.parse(contents);
+
+                expect(_.has(report.run.executions[0], 'response')).to.be.true;
+                done();
+            });
+        });
+    });
+
+    it('should correctly export json without API response ', function (done) {
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            reporters: ['json'],
+            reporter: { json: { export: outFile, skipResponses: true } }
+        }, function (err) {
+            if (err) { return done(err); }
+            fs.readFile(outFile, 'utf8', function (err, contents) {
+                expect(err).to.be.null;
+                var report = JSON.parse(contents);
+
+                expect(_.has(report.run.executions[0], 'response')).to.be.false;
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #1510
### What does this PR do?
This implements the `--reporter-json-skip-responses` in the JSON reporter (and consequently `skipResponses` key when using the library). The primary aim is to reduce the huge files size that JSON reporter causes by dumping the response body into the JSON report.

### Implementation
In the JSON reporter, if the related key was present then a deepClone of the run summary is made with lodash and response body is removed from that object. The resulting object was sent to be written into the exported file.

### Testing
As there wasn't much testing being done for the JSON reporter I created 2 filed in the `test` directory namely `test/cli/json-reporter-response.test.js` and `test/library/json-reporter-responses.test.js`. They test the JSON reporter with and without the skip responses option passed.