### PR TITLE
Feature/script details: Allows user to see the origin of each script

### DIFF
--- a/lib/reporters/cli/cli-utils.js
+++ b/lib/reporters/cli/cli-utils.js
@@ -1,4 +1,5 @@
-var inspect = require('util').inspect,
+var util = require('../../util'),
+    inspect = require('util').inspect,
     wrap = require('word-wrap'),
     symbols = require('./cli-utils-symbols'),
 
@@ -179,6 +180,30 @@ cliUtils = {
             exists: !(Boolean(process.env.CI) || !process.stdout.isTTY), // eslint-disable-line no-process-env
             width: width,
             height: height
+        };
+    },
+
+    /**
+     * A CLI utility helper method to return the details of the script with a given id
+     *
+     * @param {PostmanItem} item - The item on which the script is being executed
+     * @param {Number} scriptId - id of the script
+     * @returns {Object} - A set of properties of the script: location
+     * @todo Add additional property to the return object : symbol to represent location
+     */
+    getScriptDetails: function (item, scriptId) {
+        // get the Item, ItemGroup or Collection containing the script
+        var origin = item.findParentContaining(undefined, function (parent) {
+            return (parent.events && parent.events.members &&
+                    parent.events.members.find((member) => {
+                        return member.script && (member.script.id === scriptId);
+                    }));
+        });
+
+        return {
+            location: util.getFullName(origin) ||
+                // if the origin is a collection, location is its name
+                (origin && origin.name)
         };
     }
 };

--- a/lib/reporters/cli/cli-utils.js
+++ b/lib/reporters/cli/cli-utils.js
@@ -188,10 +188,10 @@ cliUtils = {
      *
      * @param {PostmanItem} item - The item on which the script is being executed
      * @param {Number} scriptId - id of the script
-     * @returns {Object} - A set of properties of the script: location
-     * @todo Add additional property to the return object : symbol to represent location
+     * @param {Object} symbols - symbols of required encoding
+     * @returns {Object} - A set of properties of the script: location, and symbol (to represent the location).
      */
-    getScriptDetails: function (item, scriptId) {
+    getScriptDetails: function (item, scriptId, symbols) {
         // get the Item, ItemGroup or Collection containing the script
         var origin = item.findParentContaining(undefined, function (parent) {
             return (parent.events && parent.events.members &&
@@ -203,7 +203,11 @@ cliUtils = {
         return {
             location: util.getFullName(origin) ||
                 // if the origin is a collection, location is its name
-                (origin && origin.name)
+                (origin && origin.name),
+            symbol: (origin &&
+            { PostmanItemGroup: symbols.folder,
+                PostmanCollection: symbols.root
+            }[origin.constructor.name]) || ' '
         };
     }
 };

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -215,28 +215,36 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 
     // Print script errors in real time
     emitter.on('script', function (err, o) {
+        var scriptDetails = cliUtils.getScriptDetails(o.item, o.cursor.scriptId);
+
         err && print.lf(colors.red.bold('%s⠄ %s in %s-script'), pad(this.summary.run.failures.length, 3, SPC), err.name,
             o.event && o.event.listen || 'unknown');
+
+        err && options.verbose &&
+            print.lf('%s', format(colors.gray('     inside "%s"'), scriptDetails.location || 'unknown'));
     });
 
     !reporterOptions.noAssertions && emitter.on('assertion', function (err, o) {
-        var passed = !err;
-
-        // handle skipped test display
-        if (o.skipped && !reporterOptions.noSuccessAssertions) {
-            print.lf('%s %s', colors.cyan('  - '), colors.cyan('[skipped] ' + o.assertion));
-
-            return;
-        }
+        var passed = !err,
+            scriptDetails = cliUtils.getScriptDetails(o.item, o.cursor.scriptId);
 
         if (passed && reporterOptions.noSuccessAssertions) {
             return;
         }
 
-        // print each test assertions
-        print.lf('%s %s', passed ? colors.green(`  ${symbols.ok} `) :
-            colors.red.bold(pad(this.summary.run.failures.length, 3, SPC) + symbols.dot), passed ?
-            colors.gray(o.assertion) : colors.red.bold(o.assertion));
+        if (o.skipped && !reporterOptions.noSuccessAssertions) {
+            // handle skipped test display
+            print.lf('%s %s', colors.cyan('  - '), colors.cyan('[skipped] ' + o.assertion));
+        }
+        else {
+            // print each test assertions
+            print.lf('%s %s', passed ? colors.green(`  ${symbols.ok} `) :
+                colors.red.bold(pad(this.summary.run.failures.length, 3, SPC) + symbols.dot), passed ?
+                colors.gray(o.assertion) : colors.red.bold(o.assertion));
+        }
+
+        options.verbose &&
+            print.lf('%s', format(colors.gray('     inside "%s"'), scriptDetails.location || 'unknown'));
     });
 
     // show user console logs in a neatly formatted way (provided user has not disabled the same)

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -215,18 +215,19 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 
     // Print script errors in real time
     emitter.on('script', function (err, o) {
-        var scriptDetails = cliUtils.getScriptDetails(o.item, o.cursor.scriptId);
+        var scriptDetails = cliUtils.getScriptDetails(o.item, o.cursor.scriptId, symbols);
 
-        err && print.lf(colors.red.bold('%s⠄ %s in %s-script'), pad(this.summary.run.failures.length, 3, SPC), err.name,
-            o.event && o.event.listen || 'unknown');
+        err && print.lf(colors.red.bold('  %s%s⠄ %s in %s-script'),
+            scriptDetails.symbol, pad(this.summary.run.failures.length, 3, SPC),
+            err.name, o.event && o.event.listen || 'unknown');
 
         err && options.verbose &&
-            print.lf('%s', format(colors.gray('     inside "%s"'), scriptDetails.location || 'unknown'));
+            print.lf('%s', format(colors.gray('        inside "%s"'), scriptDetails.location || 'unknown'));
     });
 
     !reporterOptions.noAssertions && emitter.on('assertion', function (err, o) {
         var passed = !err,
-            scriptDetails = cliUtils.getScriptDetails(o.item, o.cursor.scriptId);
+            scriptDetails = cliUtils.getScriptDetails(o.item, o.cursor.scriptId, symbols);
 
         if (passed && reporterOptions.noSuccessAssertions) {
             return;
@@ -234,17 +235,20 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 
         if (o.skipped && !reporterOptions.noSuccessAssertions) {
             // handle skipped test display
-            print.lf('%s %s', colors.cyan('  - '), colors.cyan('[skipped] ' + o.assertion));
+            print.lf('  %s%s %s', colors.cyan(scriptDetails.symbol),
+                colors.cyan('  - '), colors.cyan('[skipped] ' + o.assertion));
         }
         else {
             // print each test assertions
-            print.lf('%s %s', passed ? colors.green(`  ${symbols.ok} `) :
-                colors.red.bold(pad(this.summary.run.failures.length, 3, SPC) + symbols.dot), passed ?
-                colors.gray(o.assertion) : colors.red.bold(o.assertion));
+            print.lf('  %s%s %s', format(passed ? colors.gray('%s') : colors.red.bold('%s'),
+                scriptDetails.symbol),
+            passed ? colors.green(`  ${symbols.ok} `) :
+                colors.red.bold(pad(this.summary.run.failures.length, 3, SPC) + symbols.dot),
+            passed ? colors.gray(o.assertion) : colors.red.bold(o.assertion));
         }
 
         options.verbose &&
-            print.lf('%s', format(colors.gray('     inside "%s"'), scriptDetails.location || 'unknown'));
+            print.lf('%s', format(colors.gray('        inside "%s"'), scriptDetails.location || 'unknown'));
     });
 
     // show user console logs in a neatly formatted way (provided user has not disabled the same)

--- a/test/unit/cli-utils.test.js
+++ b/test/unit/cli-utils.test.js
@@ -1,0 +1,76 @@
+var _ = require('lodash'),
+    sdk = require('postman-collection'),
+    cliUtils = require('../../lib/reporters/cli/cli-utils');
+
+describe('cli-utility helpers', function () {
+    describe('getScriptDetails', function () {
+        var collection = new sdk.Collection({
+                variables: [],
+                info: {
+                    name: 'C1',
+                    description: 'A simple V2 collection to test out multi level scripts',
+                    schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                },
+                item: [{
+                    name: 'F1',
+                    item: [{ name: 'F1.R1', event: [{ script: { id: 1 } }, { script: { id: 2 } }] }]
+                }, {
+                    name: 'F2',
+                    item: [{
+                        name: 'F2.F3',
+                        item: [{ name: 'F2.F3.R2' }, { name: 'F2.F3.R3' }],
+                        event: [{ script: { id: 3 } }]
+                    }],
+                    event: [{ script: { id: 4 } }]
+                }],
+                event: [{ script: { id: 5 } }] // collection-level script
+            }),
+            // symbols can be in any encoding. Here, we use plainText.
+            symbols = cliUtils.symbols(true),
+            itemScripts = [
+                { id: 1, item: collection.oneDeep('F1.R1'), location: 'F1 / F1.R1' },
+                { id: 2, item: collection.oneDeep('F1.R1'), location: 'F1 / F1.R1' }
+            ],
+            itemGroupScripts = [
+                { id: 3, item: collection.oneDeep('F2.F3.R2'), location: 'F2 / F2.F3' },
+                { id: 3, item: collection.oneDeep('F2.F3.R3'), location: 'F2 / F2.F3' },
+                { id: 4, item: collection.oneDeep('F2.F3.R2'), location: 'F2' },
+                { id: 4, item: collection.oneDeep('F2.F3.R3'), location: 'F2' }
+            ],
+            collectionScripts = [
+                { id: 5, item: collection.oneDeep('F1.R1'), location: 'C1' },
+                { id: 5, item: collection.oneDeep('F2.F3.R2'), location: 'C1' },
+                { id: 5, item: collection.oneDeep('F2.F3.R3'), location: 'C1' }
+            ];
+
+        it('should handle item-level scripts correctly', function () {
+            _.forEach(itemScripts, function (o) {
+                var scriptDetails = cliUtils.getScriptDetails(o.item, o.id, symbols);
+
+                expect(_.keys(scriptDetails).sort()).to.eql(['location', 'symbol'].sort());
+                expect(scriptDetails.location).to.eql(o.location);
+                expect(scriptDetails.symbol).to.eql(' ');
+            });
+        });
+
+        it('should handle itemGroup-level scripts correctly', function () {
+            _.forEach(itemGroupScripts, function (o) {
+                var scriptDetails = cliUtils.getScriptDetails(o.item, o.id, symbols);
+
+                expect(_.keys(scriptDetails).sort()).to.eql(['location', 'symbol'].sort());
+                expect(scriptDetails.location).to.eql(o.location);
+                expect(scriptDetails.symbol).to.eql(symbols.folder);
+            });
+        });
+
+        it('should handle collection-level scripts correctly', function () {
+            _.forEach(collectionScripts, function (o) {
+                var scriptDetails = cliUtils.getScriptDetails(o.item, o.id, symbols);
+
+                expect(_.keys(scriptDetails).sort()).to.eql(['location', 'symbol'].sort());
+                expect(scriptDetails.location).to.eql(o.location);
+                expect(scriptDetails.symbol).to.eql(symbols.root);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #2022 

### What does this PR do?

1. It lets the user see the location of each script in the line following the assertion or script-error when the verbose option is true.

2. It hints at the location of each script by a symbol corresponding to it.
The symbols used are:
   -  `symbols.root` for a script in the collection.
   -  `symbols.folder` for a script in a folder.
   -  space(blank) for a script in the item itself.

### Screenshots

1.  With verbose false
   - Before
![before](https://user-images.githubusercontent.com/43881774/76927840-f4bcfa80-6905-11ea-8542-5a7f4d214042.jpg)

   - After
![after](https://user-images.githubusercontent.com/43881774/76927852-01415300-6906-11ea-9fcc-335cce6a541f.jpg)

2.  With verbose true
   - Before
![before_with_verbose](https://user-images.githubusercontent.com/43881774/76927892-14ecb980-6906-11ea-82a9-0f2f938d20ce.jpg)

   - After
![after_with_verbose](https://user-images.githubusercontent.com/43881774/76927923-2930b680-6906-11ea-9ebd-90aa3e0631a4.jpg)

### Implementation

1.  Added a function in cli-utils to get the location and the symbol. It takes in `PostmanItem` on which the script is executed, `scriptId` and the `symbols` object with the required encoding.
2. Use the return object before and after each assertion and script-error.

### Testing

For testing this function, a unit-test has been added in a new file `test/unit/cli-utils.test.js`. It tests the function for all three levels of scripts.