### PR TITLE
Change the precedence among different rc files

### DIFF
--- a/lib/config/rc-file.js
+++ b/lib/config/rc-file.js
@@ -32,9 +32,9 @@ module.exports.load = (callback) => {
 
         configFiles = [];
 
-    configFiles.push(join(process.cwd(), '.' + FILE_NAME));
-    home && configFiles.push(join(home, '.' + POSTMAN_CONFIG_DIR, FILE_NAME));
     !iswin && configFiles.push(join('/etc', POSTMAN_CONFIG_DIR, FILE_NAME));
+    home && configFiles.push(join(home, '.' + POSTMAN_CONFIG_DIR, FILE_NAME));
+    configFiles.push(join(process.cwd(), '.' + FILE_NAME));
 
     async.mapSeries(configFiles, (path, cb) => {
         fs.readFile(path, (err, data) => {


### PR DESCRIPTION
The priorities among different rc files in increasing order before the commit were as follows:
1. `.newmanrc` in the working directory
2. `~/postman/.newmanrc`
3. `/etc/postman/newmanrc`

This  PR changes it to the following:
1. `/etc/postman/newmanrc`
2. `~/postman/.newmanrc`
3. `.newmanrc` in the working directory
