### PR TITLE
feature to run selective requests added

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -24,6 +24,7 @@ program
     .option('-g, --globals <path>', 'Specify a URL or Path to a file containing Postman Globals.')
     // eslint-disable-next-line max-len
     .option('--folder <path>', 'Specify folder to run from a collection. Can be specified multiple times to run multiple folders', util.cast.memoize, [])
+    .option('-s, --request-list [requests]', 'Pass the list of requests that needs to be run', util.cast.csvParse)
     .option('--working-dir <path>', 'The path of the directory to be used as the working directory')
     .option('--no-insecure-file-read', 'Prevents reading the files situated outside of the working directory')
     .option('-r, --reporters [reporters]', 'Specify the reporters to use for this run.', util.cast.csvParse, ['cli'])

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -162,6 +162,7 @@ module.exports = function (options, callback) {
             globals: options.globals,
             entrypoint: entrypoint,
             data: options.iterationData,
+            requestList: options.requestList,
             delay: {
                 item: options.delayRequest
             },


### PR DESCRIPTION
Solved issue #2339 
Before users were not able to run selective requests from a collection/collections.
Now, (After merging) users will be able to run selective requests from a collection/collections.

Screenshots:
**Newman Library**
Before:
Code:
```
const newman = require('newman');

newman.run({
    collection: require('./test1.json'),
    reporters: 'cli',
    iterationCount: 1,
}, function (err) {
    if (err) {
        throw err;
    }
    console.log('collection run complete!');
});

```
Output:
![newmanLibraryBefore](https://user-images.githubusercontent.com/35838512/83323781-9eadf100-a27e-11ea-881f-b2ba61e531b0.png)

After:
Code:
```
const newman = require('newman');

newman.run({
    collection: require('./test1.json'),
    reporters: 'cli',
    iterationCount: 1,
    requestList: ['get1','Reqres1']
}, function (err) {
    if (err) {
        throw err;
    }
    console.log('collection run complete!');
});
```
Output:
![newmanLibraryAfter](https://user-images.githubusercontent.com/35838512/83323800-b9806580-a27e-11ea-9780-cddbf9098da8.png)

**Newman Cli**
Before:
![newmanCliBefore](https://user-images.githubusercontent.com/35838512/83323819-dcab1500-a27e-11ea-9749-23da7b837e8a.png)
After:
![newmanCliAfter](https://user-images.githubusercontent.com/35838512/83323822-dfa60580-a27e-11ea-944c-82ee01711425.png)

@codenirvana @shamasis please review it. Also, to implement this feature i did some changes in postman-runtime repo and have opened a pull request([#1037](https://github.com/postmanlabs/postman-runtime/pull/1037)) there too.