### PR TITLE
Add RC file controller

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -26,8 +26,12 @@ module.exports.get = (overrides, options, callback) => {
 
     async.waterfall([
         // Load RC Files.
-        !options.ignoreRcFile ? rcfile.load : (cb) => {
-            return cb(null, {});
+        (cb) => {
+            if (options.ignoreRcFile) {
+                return cb(null, {});
+            }
+
+            return rcfile.load(['home', 'cwd'], cb);
         },
         // Load Process Environment overrides
         (fileOptions, cb) => {

--- a/lib/config/rc-file.js
+++ b/lib/config/rc-file.js
@@ -1,59 +1,159 @@
 /* eslint-disable no-process-env */
 var _ = require('lodash'),
     fs = require('fs'),
+    waterfall = require('async/waterfall'),
     join = require('path').join,
     async = require('async'),
     util = require('../util'),
     liquidJSON = require('liquid-json'),
+    os = require('os'),
 
     /**
-     * Name of the directory that contains the file denoted by FILE_NAME.
+     * Name of the directory that contains Postman config files.
      *
      * @type {String}
      */
-    POSTMAN_CONFIG_DIR = 'postman',
+    DIR_NAME = 'postman',
 
     /**
-     * Name of the file that contains Newman compliant confguration information.
+     * Octal number indicating the permission/mode of the config directory in *nix systems.
+     * Gives read, write and enter permissions only to the owner
+     *
+     * @note In Windows systems, since the directory is in the User directory, it cannot be read by any other user
+     *
+     * @type {Number}
+     */
+    CONFIG_DIR_MODE = 0o700,
+
+    /**
+     * Folder in the home directory that contains Postman config files.
      *
      * @type {String}
      */
-    FILE_NAME = 'newmanrc';
+    HOME_CONFIG_DIR = join(os.homedir(), '.' + DIR_NAME),
 
-/**
- * Configuration loader to acquire run settings from a file present in the home directory: POSTMAN_CONFIG_DIR/FILE_NAME.
- *
- * @param {Function} callback - The callback function invoked to mark the completion of the config loading routine.
- * @returns {*}
- */
-module.exports.load = (callback) => {
-    var iswin = (/^win/).test(process.platform),
-        home = iswin ? process.env.USERPROFILE : process.env.HOME,
+    /**
+     * Name of the file that contains Newman compliant configuration information.
+     *
+     * @type {String}
+     */
+    FILE_NAME = 'newmanrc',
 
-        configFiles = [];
+    /**
+     * Octal number indicating the permission/mode of the config file in *nix systems.
+     * Gives read and write permissions only to the owner
+     *
+     * @type {Number}
+     */
+    CONFIG_FILE_MODE = 0o600,
 
-    !iswin && configFiles.push(join('/etc', POSTMAN_CONFIG_DIR, FILE_NAME));
-    home && configFiles.push(join(home, '.' + POSTMAN_CONFIG_DIR, FILE_NAME));
-    configFiles.push(join(process.cwd(), '.' + FILE_NAME));
+    /**
+     * List of config files across the system
+     *
+     * @type {String[]}
+     */
+    CONFIG_FILES = {
+        home: join(HOME_CONFIG_DIR, FILE_NAME),
+        cwd: join(process.cwd(), '.' + FILE_NAME)
+    },
 
-    async.mapSeries(configFiles, (path, cb) => {
-        fs.readFile(path, (err, data) => {
-            if (err) {
-                return cb(null, {}); // err masked to avoid overpopulating terminal with missing .newmanrc messages
-            }
-            data && data.toString && (data = data.toString(util.detectEncoding(data)).trim());
-            try {
-                return cb(null, liquidJSON.parse(data));
-            }
-            catch (e) {
-                return cb(_.set(e, 'help', `The file at ${path} contains invalid data.`));
-            }
-        });
-    }, (err, files) => {
-        if (err) {
-            return callback(err);
+    // List of possible error messages
+    DIR_CREATE_ERROR = (dir) => { return `Couldn't create the config directory at ${dir}.`; },
+    INVALID_DATA_ERROR = (file) => { return `The config file at ${file} contains invalid data.`; },
+    FILE_WRITE_ERROR = (file) => { return `Couldn't write into the config file at ${file}.`; };
+
+module.exports = {
+    /**
+     * Configuration loader to acquire and merge settings from the requested config files.
+     *
+     * Data corresponding to an inexistent file is taken as an empty object
+     *
+     * @param {String[]} [types=['home']] - Types of the config files to be read.
+     * @param {Function} callback - The callback function invoked to mark the completion of the config loading routine
+     * @returns {*}
+     */
+    load: (types, callback) => {
+        if (!callback && _.isFunction(types)) {
+            callback = types;
+            types = ['home'];
         }
 
-        return callback(null, _.merge.apply(this, files));
-    });
+        var files = [];
+
+        _.forEach(types, (type) => {
+            CONFIG_FILES[type] && files.push(CONFIG_FILES[type]);
+        });
+
+        async.mapSeries(files, (path, cb) => {
+            fs.readFile(path, (err, data) => {
+                if (err) {
+                    return cb(null, {}); // err masked to avoid overpopulating terminal with missing .newmanrc messages
+                }
+
+                data && data.toString && (data = data.toString(util.detectEncoding(data)).trim());
+
+                try {
+                    return cb(null, liquidJSON.parse(data));
+                }
+                catch (e) {
+                    return cb(new Error(INVALID_DATA_ERROR(path)));
+                }
+            });
+        }, (err, fileData) => {
+            if (err) {
+                return callback(err);
+            }
+
+            return callback(null, _.merge.apply(this, fileData));
+        });
+    },
+
+    /**
+     * Updates the config file with the data passed.
+     *
+     * If the file doesn't exist, creates one with read and write permissions only to the owner.
+     *
+     * @param {Object} data - The config object to be stored in the file
+     * @param {String} [type='home'] - Type of the config file. Assumes 'home' by default
+     * @param {Function} callback - The callback which is invoked after the write
+     * @returns {*}
+     */
+    store: (data, type, callback) => {
+        if (!callback && _.isFunction(type)) {
+            callback = type;
+            type = 'home';
+        }
+
+        let file = _.get(CONFIG_FILES, type);
+
+        waterfall([
+            (next) => {
+                // ensure the config directory exists if `type` is home
+                if (type === 'home' && !fs.existsSync(HOME_CONFIG_DIR)) {
+                    fs.mkdir(HOME_CONFIG_DIR, { mode: CONFIG_DIR_MODE }, (err) => {
+                        if (err) {
+                            return next(new Error(DIR_CREATE_ERROR(HOME_CONFIG_DIR)));
+                        }
+
+                        return next(null);
+                    });
+                }
+                else {
+                    return next(null);
+                }
+            },
+            (next) => {
+                // it also creates the file with the given permissions if it doesn't exist
+                fs.writeFile(file, JSON.stringify(data, null, 2), { mode: CONFIG_FILE_MODE }, (err) => {
+                    if (err) {
+                        return next(new Error(FILE_WRITE_ERROR(file)));
+                    }
+
+                    return next(null);
+                });
+            }
+        ], (err) => {
+            callback(err);
+        });
+    }
 };

--- a/test/unit/rc-file.test.js
+++ b/test/unit/rc-file.test.js
@@ -1,0 +1,185 @@
+/* eslint-disable no-process-env */
+var fs = require('fs'),
+    sh = require('shelljs'),
+    sinon = require('sinon'),
+    join = require('path').join,
+    liquidJSON = require('liquid-json'),
+    rcFile,
+
+    CONFIG_DIR_MODE = 0o700,
+    CONFIG_FILE_MODE = 0o600;
+
+describe('RC File Module', function () {
+    let outDir = join(__dirname, '..', '..', 'out'),
+        homeRCDir = join(outDir, '.postman'),
+        homeRCFile = join(homeRCDir, 'newmanrc'),
+        cwdRCFile = join(outDir, '.newmanrc'),
+        isWin = (/^win/).test(process.platform),
+        homeDir = process.env[isWin ? 'userprofile' : 'HOME'],
+        currentWorkingDir = process.cwd(),
+        testData = { test: 123 };
+
+    // all the tests take place assuming 'outDir' is the home directory and the current working directory
+    before(function () {
+        process.env[isWin ? 'userprofile' : 'HOME'] = outDir; // the same variables are checked in os.homeDir() function
+        !fs.existsSync(outDir) && fs.mkdirSync(outDir); // else the next step will throw an error
+        process.chdir(outDir);
+
+        // since the module contains cached data related to home, current working directory
+        delete require.cache[require.resolve('../../lib/config/rc-file')];
+        rcFile = require('../../lib/config/rc-file');
+    });
+
+    after(function () {
+        // update the home, current working directory back to its original value
+        process.env[isWin ? 'userprofile' : 'HOME'] = homeDir;
+        process.chdir(currentWorkingDir);
+    });
+
+    beforeEach(function () {
+        sh.test('-d', outDir) && sh.rm('-rf', outDir);
+        sh.mkdir('-p', outDir);
+    });
+
+    afterEach(function () {
+        sh.rm('-rf', outDir);
+    });
+
+    describe('load', function () {
+        it('should load data from rc file in the home directory by default', function (done) {
+            fs.mkdirSync(homeRCDir, { mode: CONFIG_DIR_MODE });
+            fs.writeFileSync(homeRCFile, JSON.stringify(testData, null, 2), { mode: CONFIG_FILE_MODE });
+
+            rcFile.load((err, fileData) => {
+                expect(err).to.be.null;
+                expect(fileData, 'should parse the data to give the JSON object').to.eql(testData);
+                done();
+            });
+        });
+
+        it('should load data from rc file in the current working directory if specified', function (done) {
+            fs.writeFileSync(cwdRCFile, JSON.stringify(testData, null, 2), { mode: CONFIG_FILE_MODE });
+
+            rcFile.load(['cwd'], (err, fileData) => {
+                expect(err).to.be.null;
+                expect(fileData, 'should parse the data to give the JSON object').to.eql(testData);
+                done();
+            });
+        });
+
+        it('should send an error if the rc file contains invalid data', function (done) {
+            let data = '{';
+
+            fs.mkdirSync(homeRCDir, { mode: CONFIG_DIR_MODE });
+            fs.writeFileSync(homeRCFile, data, { mode: CONFIG_FILE_MODE });
+
+            rcFile.load(['home', 'cwd'], (err) => {
+                expect(err).to.not.be.null;
+                expect(err).to.have.property('message');
+                expect(err.message, 'should send the error message indicating invalid data').to.match(/invalid data/);
+                done();
+            });
+        });
+
+        it('should send an empty JSON object without any error if the file doesn\'t exist', function (done) {
+            rcFile.load((err, fileData) => {
+                expect(err).to.be.null;
+                expect(fileData).to.eql({});
+                done();
+            });
+        });
+
+        it('should merge the data from different rc files according to their priority', function (done) {
+            let homeData = {
+                    run: { bail: true },
+                    login: {
+                        _profiles: [
+                            { alias: 'default', postmanApiKey: '123' },
+                            { alias: 'testAlias', postmanApiKey: '456' }
+                        ]
+                    }
+                },
+                cwdData = {
+                    run: { bail: false },
+                    login: {
+                        _profiles: [
+                            { alias: 'default', postmanApiKey: '789' }
+                        ]
+                    }
+                },
+                mergedData = {
+                    run: { bail: false },
+                    login: {
+                        _profiles: [
+                            { alias: 'default', postmanApiKey: '789' },
+                            { alias: 'testAlias', postmanApiKey: '456' }
+                        ]
+                    }
+                };
+
+            fs.mkdirSync(homeRCDir, { mode: CONFIG_DIR_MODE });
+            fs.writeFileSync(homeRCFile, JSON.stringify(homeData, null, 2), { mode: CONFIG_FILE_MODE });
+
+            fs.writeFileSync(cwdRCFile, JSON.stringify(cwdData, null, 2), { mode: CONFIG_FILE_MODE });
+
+            rcFile.load(['home', 'cwd'], (err, data) => {
+                expect(err).to.be.null;
+                expect(data, 'should merge the data correctly').to.be.eql(mergedData);
+                done();
+            });
+        });
+    });
+
+    describe('store', function () {
+        it('should create the home-rc-file and store data in it by default',
+            function (done) {
+                rcFile.store(testData, (err) => {
+                    expect(err).to.be.null;
+                    expect(fs.existsSync(homeRCDir), 'should create the config directory').to.be.true;
+                    !isWin && expect(fs.statSync(homeRCDir).mode,
+                        'config dir should have \'rwx\' permissions only to the owner').to.be.equal(0o40700);
+                    expect(fs.existsSync(homeRCFile), 'should create the rc file').to.be.true;
+                    !isWin && expect(fs.statSync(homeRCFile).mode,
+                        'config file should have \'rw\' permissions only to the owner').to.be.equal(0o100600);
+
+                    fs.readFile(homeRCFile, (err, fileData) => {
+                        expect(err).to.be.null;
+                        expect(liquidJSON.parse(fileData.toString()), 'file should contain passed data')
+                            .to.be.eql(testData);
+                        done();
+                    });
+                });
+            });
+
+        it('should create the cwd-rc-file and store data in it if specified', function (done) {
+            rcFile.store(testData, 'cwd', (err) => {
+                expect(err).to.be.null;
+                expect(fs.existsSync(cwdRCFile), 'should create the rc file').to.be.true;
+                !isWin && expect(fs.statSync(cwdRCFile).mode,
+                    'config file should have \'rw\' permissions only to the owner').to.be.equal(0o100600);
+
+                fs.readFile(cwdRCFile, (err, fileData) => {
+                    expect(err).to.be.null;
+                    expect(liquidJSON.parse(fileData.toString()), 'file should contain passed data')
+                        .to.be.eql(testData);
+                    done();
+                });
+            });
+        });
+
+        it('should handle the error gracefully if there is one during folder creation', function (done) {
+            // fake the error
+            sinon.stub(fs, 'mkdir').callsFake((_dir, _options, cb) => {
+                return cb(new Error());
+            });
+
+            rcFile.store(testData, 'home', (err) => {
+                expect(err).to.not.be.null;
+                expect(err).to.have.property('message');
+                expect(err.message, 'should send the error indicating dir-create error').to.match(/config directory/);
+                fs.mkdir.restore();
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
### What does this PR do?
It adds functions for loading and storing configurations from different RC files across the system.

### Minor details
1. The function for loading returns an empty object if the file doesn't exist.
2. The function for storing creates the file if it doesn't exist. 
   - In *nix based systems, the new file created has read and write permissions only to the owner of the file.
   - In Windows, since the file is stored in the User directory, it cannot be read by any other user.

### Testing
1. The unit tests for both the functions are added.
   - The whole testing process is done by changing the environment variable providing the home directory, to the `outDir` used in other tests.