### PR TITLE
Add login command

### DIFF
--- a/.nycrc.js
+++ b/.nycrc.js
@@ -18,14 +18,16 @@ function configOverrides (testType) {
                 statements: 35,
                 branches: 20,
                 functions: 35,
-                lines: 35
+                lines: 35,
+                exclude: ['lib/crypt.js', 'lib/login']
             };
         case 'library':
             return {
                 statements: 55,
                 branches: 40,
                 functions: 55,
-                lines: 55
+                lines: 55,
+                exclude: ['lib/crypt.js', 'lib/login']
             };
         case 'unit':
             return {

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -3,12 +3,13 @@
 require('../lib/node-version-check'); // @note that this should not respect CLI --silent
 
 const _ = require('lodash'),
-    waterfall = require('async/waterfall'),
     { Command } = require('commander'),
     program = new Command(),
     version = require('../package.json').version,
     newman = require('../'),
-    util = require('./util');
+    util = require('./util'),
+
+    RUN_COMMAND = 'run';
 
 program
     .name('newman')
@@ -106,41 +107,33 @@ program.on('command:*', (command) => {
  * callback is required when this is required as a module in tests.
  *
  * @param {String[]} argv - Argument vector.
- * @param {?Function} callback - The callback function invoked on the completion of execution.
+ * @param {Function} [callback] - The callback function invoked on the completion of execution.
  */
 function run (argv, callback) {
-    waterfall([
-        (next) => {
-            // cache original argv, required to parse nested options later.
-            program._originalArgs = argv;
-            // omit custom nested options, otherwise commander will throw unknown options error
-            next(null, util.omitNestedOptions(argv, '--reporter-'));
-        },
-        (args, next) => {
-            let error = null;
+    let error = null;
 
-            try {
-                program.parse(args);
-            }
-            catch (err) {
-                error = err;
-            }
-            next(error);
-        },
-        (next) => {
-            // throw error if no argument is provided.
-            next(program.args.length ? null : new Error('no arguments provided'));
-        }
-    ], (error) => {
-        // invoke callback if this is required as module, used in tests.
-        if (callback) { return callback(error); }
+    if (argv[2] === RUN_COMMAND) {
+        // omit custom nested options, otherwise commander will throw unknown options error
+        program._originalArgs = argv;
+        // cache original argv, required to parse nested options later.
+        argv = util.omitNestedOptions(argv, '--reporter-');
+    }
 
-        // in case of an error, log error message and print help message.
-        if (error) {
-            console.error(`error: ${error.message || error}\n`);
-            program.help();
-        }
-    });
+    try {
+        program.parse(argv);
+    }
+    catch (err) {
+        error = err;
+    }
+
+    // invoke callback if this is required as module, used in tests.
+    if (callback) { return callback(error); }
+
+    if (error) {
+        // log error message and print help message.
+        console.error(`error: ${error.message || error}\n`);
+        program.help();
+    }
 }
 
 // This hack has been added from https://github.com/nodejs/node/issues/6456#issue-151760275

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -8,6 +8,7 @@ const _ = require('lodash'),
     version = require('../package.json').version,
     newman = require('../'),
     util = require('./util'),
+    login = require('../lib/login'),
 
     RUN_COMMAND = 'run';
 
@@ -88,6 +89,19 @@ program
                 err.friendly && console.error(`  ${err.friendly}\n`);
             }
             runError && !_.get(options, 'suppressExitCode') && process.exit(1);
+        });
+    });
+
+program
+    .command('login')
+    .description('Store the API-Key along with an alias to it, to reference it in the following commands.')
+    .action(() => {
+        login((err) => {
+            if (err) {
+                console.error(`error: ${err.message || err}\n`);
+                err.help && console.error(err.help);
+                process.exit(1);
+            }
         });
     });
 

--- a/lib/crypt.js
+++ b/lib/crypt.js
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 // Code for Base-122 encoding/decoding adapted from the following repo:
 // https://github.com/kevinAlbs/Base122
 

--- a/lib/login/index.js
+++ b/lib/login/index.js
@@ -1,0 +1,179 @@
+const _ = require('lodash'),
+    waterfall = require('async/waterfall'),
+    readline = require('readline'),
+    Writable = require('stream').Writable,
+    rcfile = require('../config/rc-file'),
+    util = require('../util'),
+    crypt = require('../crypt'),
+    print = require('../print'),
+    colors = require('colors/safe'),
+
+    ALIAS = 'alias',
+    OVERRIDE_PERMISSION = 'overridePermission',
+    POSTMAN_API_KEY = 'postmanApiKey',
+    ENCRYPTED = 'encrypted',
+    PASSKEY = 'passkey',
+
+    INPUT_PROMPTS = {
+        alias: 'Alias: (default) ',
+        overridePermission: 'The alias already exists.\nDo you want to override it? (Y/N): ',
+        postmanApiKey: 'Postman API-Key: ',
+        encrypted: 'Do you want to have a passkey for authentication? (Y/N): ',
+        passkey: 'Passkey: '
+    },
+
+    SUCCESS_MESSAGE = 'API-Key added successfully.',
+    ABORT_MESSAGE = 'Login aborted.',
+    INVALID_INPUT = 'Invalid input.';
+
+/**
+ * Gets the details of the alias from interaction and writes it in the config file located in the home directory.
+ *
+ * @param {Function} callback - The callback function to be invoked to mark the end of the function.
+ * @returns {*}
+ */
+module.exports = (callback) => {
+    // Create a new stream to facilitate hiding of user input
+    let inputStream = new Writable({
+            write (chunk, _encoding, callback) {
+                if (!this.muted) {
+                    print(chunk.toString());
+                }
+                // else only print a newline, if any
+                else if (chunk.includes('\n')) {
+                    print('\n');
+                }
+
+                callback();
+            }
+        }),
+        rl = readline.createInterface({
+            input: process.stdin,
+            output: inputStream,
+            terminal: true
+        }),
+        options = {},
+        fileData,
+
+        /**
+         * Prompts the user for input, gets the same and stores it in the required field under `options`
+         *
+         * @param {String} field - The field to be asked for to the user
+         * @param {Object} [opts] - Options related to the input field
+         * @param {Boolean} opts.boolean - Indicates if the input field is boolean
+         * @param {Boolean} opts.mutedInput - Indicates if the user input for the field is to be muted
+         * @param {String} opts.default - Default value of the field, if any
+         * @param {Function} cb - The callback to be invoked after storing the input
+         */
+        getData = (field, opts, cb) => {
+            if (!cb && _.isFunction(opts)) {
+                cb = opts;
+                opts = {};
+            }
+
+            print(colors.yellow.bold(INPUT_PROMPTS[field]));
+            inputStream.muted = Boolean(opts.mutedInput); // mute the input-stream if required
+
+            rl.once('line', (answer) => {
+                inputStream.muted = true; // make sure the writable is not muted
+
+                !answer && (answer = opts.default);
+
+                if (opts.boolean) {
+                    answer.toLowerCase() === 'y' && (_.set(options, field, true));
+                    answer.toLowerCase() === 'n' && (_.set(options, field, false));
+                }
+                else {
+                    _.set(options, field, answer);
+                }
+
+                // exit the program if the user-input was invalid
+                if (_.isUndefined(options[field])) {
+                    console.error(INVALID_INPUT);
+                    process.exit(1);
+                }
+
+                cb();
+            });
+            util.signal(field); // signal the parent process(if any) for input
+        };
+
+    waterfall([
+        // get the data from home-rc-file
+        // this is done in the beginning to prevent errors caused by file-load in between the login-process
+        rcfile.load,
+
+        // get the api-key-alias
+        (data, next) => {
+            fileData = data; // store the file-data for future use
+
+            return getData(ALIAS, { default: 'default' }, next);
+        },
+
+        // delete the existing data about the alias(if any) with user consent
+        (next) => {
+            let previousData;
+
+            _.has(fileData, 'login._profiles') &&
+                (previousData = _.filter(fileData.login._profiles, [ALIAS, options.alias]));
+
+            if (_.isEmpty(previousData)) {
+                return next(null);
+            }
+
+            return getData(OVERRIDE_PERMISSION, { boolean: true }, () => {
+                if (!options.overridePermission) {
+                    console.error(ABORT_MESSAGE);
+                    process.exit(1);
+                }
+
+                // delete the old data related to the alias
+                fileData.login._profiles = _.reject(fileData.login._profiles, [ALIAS, options.alias]);
+
+                return next(null);
+            });
+        },
+
+        // get the postman-api-key
+        (next) => { return getData(POSTMAN_API_KEY, next); },
+
+        // get the `encrypted` option
+        (next) => { return getData(ENCRYPTED, { boolean: true }, next); },
+
+        // get the passkey if the user had choosen to use one
+        (next) => {
+            if (!options.encrypted) { return next(null); }
+
+            return getData(PASSKEY, { mutedInput: true }, next);
+        },
+
+        // encrypt/encode the API-Key and push the necessary fields into the `fileData`
+        (next) => {
+            // encrypt or encode the API Key
+            options.postmanApiKey = options.encrypted ?
+                crypt.encrypt(options.postmanApiKey, options.passkey) : crypt.encode(options.postmanApiKey);
+
+            // format the user data and push it into the array
+            !fileData.login && (fileData.login = {});
+            !fileData.login._profiles && (fileData.login._profiles = []);
+            fileData.login._profiles.push(_.pick(options, [ALIAS, POSTMAN_API_KEY, ENCRYPTED]));
+
+            return next(null, fileData);
+        },
+
+        // update the data in the config file
+        rcfile.store
+
+    ], (err) => {
+        inputStream.end();
+        rl.close();
+
+        if (err) {
+            return callback(err);
+        }
+
+        console.info(SUCCESS_MESSAGE);
+
+        return callback(null);
+    });
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -72,6 +72,15 @@ util = {
     userAgent: USER_AGENT_VALUE,
 
     /**
+     * Sends a message to the parent process if it is listening.
+     * Used for testing using child process module
+     *
+     * @param {String} message - The message
+     * @returns {*}
+     */
+    signal: (message) => { process.send && process.send(message); },
+
+    /**
      * A utility helper method that prettifies and returns raw millisecond counts.
      *
      * @param {Number} ms - The raw millisecond count, usually from response times.

--- a/test/cli/login.test.js
+++ b/test/cli/login.test.js
@@ -1,0 +1,243 @@
+/* eslint-disable no-process-env */
+
+const _ = require('lodash'),
+    // eslint-disable-next-line security/detect-child-process
+    child = require('child_process'),
+    sh = require('shelljs'),
+    join = require('path').join,
+    fs = require('fs'),
+    liquidJSON = require('liquid-json'),
+    colors = require('colors/safe'),
+
+    TEST_ALIAS = 'testalias',
+    DEFAULT_ALIAS = 'default',
+    POSTMAN_API_KEY = '123456&',
+    ENCODED_API_KEY = '\u0018LF3!TlҀ',
+    ENCRYPTED_API_KEY = 'decbcee5078b550b0cd7d0cd67e4ee70',
+    PASSKEY = 'pass123',
+
+    // prompt messages imported from the module
+    INPUT_PROMPTS = {
+        alias: 'Alias: (default) ',
+        overridePermission: 'The alias already exists.\nDo you want to override it? (Y/N): ',
+        postmanApiKey: 'Postman API-Key: ',
+        encrypted: 'Do you want to have a passkey for authentication? (Y/N): ',
+        passkey: 'Passkey: '
+    },
+
+    SUCCESS_MESSAGE = 'API-Key added successfully.',
+    ABORT_MESSAGE = 'Login aborted.';
+
+describe('Login command', function () {
+    let outDir = join(__dirname, '..', '..', 'out'),
+        configDir = join(outDir, '.postman'),
+        rcFile = join(configDir, 'newmanrc'),
+        isWin = (/^win/).test(process.platform),
+        homeDir = process.env[isWin ? 'userprofile' : 'HOME'],
+        proc,
+        stdout,
+        stderr,
+
+        spawn = (responses) => {
+            proc = child.spawn('node', ['./bin/newman.js', 'login'], {
+                stdio: ['pipe', 'pipe', 'pipe', 'ipc'] // to enable inter process communication through messages
+            });
+
+            proc.stdout.setEncoding('utf-8');
+            proc.stderr.setEncoding('utf-8');
+
+            // listen to prompt messages and feed the answers to the queries
+            proc.on('message', (prompt) => {
+                expect(responses).to.have.property(prompt);
+                // '\r' stands for carriage return which indicates that the input is complete
+                proc.stdin.write(responses[prompt] + '\r');
+            });
+
+            proc.stdout.on('data', (data) => {
+                stdout += data;
+            });
+
+            proc.stderr.on('data', (data) => {
+                stderr += data;
+            });
+        },
+
+        testStdout = (responses) => {
+            _.forIn(responses, (value, key) => {
+                if (key === 'passkey') {
+                    expect(stdout, 'should contain the prompt for passkey')
+                        .to.contain(colors.yellow.bold(INPUT_PROMPTS[key]));
+                    expect(stdout, 'should not contain the user input for passkey').to.not.contain(value);
+                }
+                else {
+                    expect(stdout, 'should contain the prompt and the user input for ' + key)
+                        .to.contain(colors.yellow.bold(INPUT_PROMPTS[key]) + value);
+                }
+            });
+        };
+
+    before(function () {
+        // change the home directory to alter the location of the rc file
+        process.env[isWin ? 'userprofile' : 'HOME'] = outDir;
+    });
+
+    after(function () {
+        // update the home directory back to its original value
+        process.env[isWin ? 'userprofile' : 'HOME'] = homeDir;
+    });
+
+    beforeEach(function () {
+        sh.test('-d', outDir) && sh.rm('-rf', outDir);
+        sh.mkdir('-p', outDir);
+
+        stdout = '';
+        stderr = '';
+    });
+
+    afterEach(function () {
+        // make sure the child-process is terminated
+        if (proc) {
+            proc.removeAllListeners();
+            proc.kill();
+        }
+
+        sh.rm('-rf', outDir);
+    });
+
+    it('should display help with -h option', function (done) {
+        exec('node ./bin/newman.js login -h', (code, stdout) => {
+            expect(code, 'should have exit code of 0').to.equal(0);
+            expect(stdout).to.match(/Usage: newman login*/);
+            done();
+        });
+    });
+
+    it('should work without a passkey', function (done) {
+        let responses = {
+                alias: TEST_ALIAS,
+                postmanApiKey: POSTMAN_API_KEY,
+                encrypted: 'n'
+            },
+            result = {
+                login: {
+                    _profiles: [
+                        { alias: TEST_ALIAS, postmanApiKey: ENCODED_API_KEY, encrypted: false }
+                    ]
+                }
+            };
+
+        spawn(responses);
+
+        proc.on('close', (code) => {
+            expect(code, 'should have exit code of 0').to.equal(0);
+            expect(stdout, 'should contain the success message').to.contain(SUCCESS_MESSAGE);
+            testStdout(responses);
+
+            fs.readFile(rcFile, (err, data) => {
+                expect(err).to.be.null;
+                data = liquidJSON.parse(data.toString());
+                expect(data).to.eql(result);
+                done();
+            });
+        });
+    });
+
+    it('should work with a passkey', function (done) {
+        let responses = {
+                alias: '',
+                postmanApiKey: POSTMAN_API_KEY,
+                encrypted: 'y',
+                passkey: PASSKEY
+            },
+            result = {
+                login: {
+                    _profiles: [
+                        { alias: DEFAULT_ALIAS, postmanApiKey: ENCRYPTED_API_KEY, encrypted: true }
+                    ]
+                }
+            };
+
+        spawn(responses);
+
+        proc.on('close', (code) => {
+            expect(code, 'should have exit code of 0').to.equal(0);
+            expect(stdout, 'should contain the success message').to.contain(SUCCESS_MESSAGE);
+            testStdout(responses);
+
+            fs.readFile(rcFile, (err, data) => {
+                expect(err).to.be.null;
+                data = liquidJSON.parse(data.toString());
+                expect(data).to.eql(result);
+                done();
+            });
+        });
+    });
+
+    it('should work if the alias already exists', function (done) {
+        let responses = {
+                alias: '',
+                overridePermission: 'y',
+                postmanApiKey: POSTMAN_API_KEY,
+                encrypted: 'n'
+            },
+            initialData = {
+                login: {
+                    _profiles: [
+                        { alias: DEFAULT_ALIAS, postmanApiKey: '12345', encrypted: false }
+                    ]
+                }
+            },
+            resultantData = {
+                login: {
+                    _profiles: [
+                        { alias: DEFAULT_ALIAS, postmanApiKey: ENCODED_API_KEY, encrypted: false }
+                    ]
+                }
+            };
+
+        fs.mkdirSync(configDir);
+        fs.writeFileSync(rcFile, JSON.stringify(initialData, null, 2), { mode: 0o600 });
+
+        spawn(responses);
+
+        proc.on('close', (code) => {
+            expect(code, 'should have exit code of 0').to.equal(0);
+            expect(stdout, 'should contain the success message').to.contain(SUCCESS_MESSAGE);
+            testStdout(responses);
+
+            fs.readFile(rcFile, (err, data) => {
+                expect(err).to.be.null;
+                data = liquidJSON.parse(data.toString());
+                expect(data).to.eql(resultantData);
+                done();
+            });
+        });
+    });
+
+    it('should exit if user denies permission to override', function (done) {
+        let responses = {
+                alias: TEST_ALIAS,
+                overridePermission: 'n'
+            },
+            fileData = {
+                login: {
+                    _profiles: [
+                        { alias: TEST_ALIAS, postmanApiKey: '12345', encrypted: false }
+                    ]
+                }
+            };
+
+        fs.mkdirSync(configDir);
+        fs.writeFileSync(rcFile, JSON.stringify(fileData, null, 2), { mode: 0o600 });
+
+        spawn(responses);
+
+        proc.on('close', (code) => {
+            expect(code, 'should have exit code of 1').to.equal(1);
+            testStdout(responses);
+            expect(stderr, 'should contain failure message').to.contain(ABORT_MESSAGE);
+
+            done();
+        });
+    });
+});

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -299,4 +299,31 @@ describe('cli parser', function () {
                 });
         });
     });
+
+    describe('Login command', function () {
+        let spy;
+
+        before(function () {
+            // create a new spy
+            spy = sinon.spy();
+
+            // replace the function to be exported from the login module with the spy
+            require.cache[require.resolve('../../lib/login')] = {
+                exports: spy
+            };
+        });
+
+        after(function () {
+            // restore original `login` module.
+            delete require.cache[require.resolve('../../lib/login')];
+        });
+
+        it('should invoke the login function', function (done) {
+            cli('node newman.js login'.split(' '), 'login', function (err) {
+                expect(err).to.be.null;
+                expect(spy.calledOnce).to.be.true;
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
### What does this PR do?
It adds the login command.

### Usage
```console
newman login
```

### Description
The command gets the following details by interaction:
1. Alias: The alias to be used to refer to the API Key.
2. API Key: The Postman-API-Key to get the resources from Postman-APIs.
3. Passkey(if any): If opted for one, stores the API Key in an encrypted form with the passkey provided used as the key to the encryption. If not provided, the API Key will be converted to its Base-122 encoding.

These details are formatted and stored in the RC file located in the home directory

### Screenshots
#### Action
<img src="https://user-images.githubusercontent.com/43881774/86810157-41396b00-c09a-11ea-847a-172f48dacba9.png" width="500">

#### Result
<img src="https://user-images.githubusercontent.com/43881774/86810218-53b3a480-c09a-11ea-9238-4599b059b3d9.png" width="500">

### Testing
The CLI and the parser tests for the login command are added.