### PR TITLE
Add api-key-alias option

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -42,6 +42,7 @@ program
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
     .option('--export-collection <path>', 'Specify an output file to save the executed collection')
     .option('--postman-api-key <apiKey>', 'API Key used to load the resources from the Postman API.')
+    .option('--postman-api-key-alias <alias>', 'Specify the alias of the API Key to fetch remote resources using it.')
     .option('--delay-request [n]', 'Specify the extent of delay between requests (milliseconds)', util.cast.integer)
     .option('--bail [modifiers]',
         'Specify whether or not to gracefully stop a collection run on encountering an error' +

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -8,7 +8,8 @@ var cliOptions = {
         color: 'auto',
         timeout: 0,
         timeoutRequest: 0,
-        timeoutScript: 0
+        timeoutScript: 0,
+        postmanApiKeyAlias: 'default'
     }
 };
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,6 +1,7 @@
 var _ = require('lodash'),
     async = require('async'),
 
+    env = require('./process-env'),
     defaults = require('./defaults'),
     rcfile = require('./rc-file');
 
@@ -31,6 +32,11 @@ module.exports.get = (cliOptions, options, callback) => {
             }
 
             return rcfile.load(['home', 'cwd'], cb);
+        },
+
+        // Load Process Environment overrides
+        !options.ignoreProcessEnvironment ? env.load : (cb) => {
+            return cb(null, {});
         }
     ], (err, options) => {
         if (err) {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -43,6 +43,9 @@ module.exports.get = (cliOptions, options, callback) => {
             return callback(err);
         }
 
+        let [, rcOptions] = options,
+            aliasDetails;
+
         // get options specific to the command
         options = _.map(options, (obj) => {
             return obj && obj[command] ? obj[command] : {};
@@ -53,6 +56,18 @@ module.exports.get = (cliOptions, options, callback) => {
             // If the newer value is a null, do not override it.
             return (src === null) ? dest : undefined;
         });
+
+        // if the postmanApiKey is not available, store the details of the session-api-key-alias in its place
+        if (!options.postmanApiKey) {
+            rcOptions.login &&
+                ([aliasDetails] = _.filter(rcOptions.login._profiles, ['alias', options.postmanApiKeyAlias]));
+
+            aliasDetails && (options.postmanApiKey = aliasDetails);
+        }
+
+        // delete the api-key-alias since the corresponding information is already acquired and the library-run
+        // doesn't take alias as an input
+        delete options.postmanApiKeyAlias;
 
         return callback(null, options);
     });

--- a/lib/config/process-env.js
+++ b/lib/config/process-env.js
@@ -4,7 +4,7 @@ var _ = require('lodash'),
      * List of options with env-support for each command.
      */
     config = {
-        run: ['POSTMAN_API_KEY']
+        run: ['POSTMAN_API_KEY', 'POSTMAN_API_KEY_ALIAS']
     },
 
     /**

--- a/lib/config/process-env.js
+++ b/lib/config/process-env.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
      * List of options with env-support for each command.
      */
     config = {
-        run: ['POSTMAN_API_KEY', 'POSTMAN_API_KEY_ALIAS']
+        run: ['POSTMAN_API_KEY', 'POSTMAN_API_KEY_ALIAS'],
+        logout: ['POSTMAN_API_KEY_ALIAS']
     },
 
     /**

--- a/lib/config/process-env.js
+++ b/lib/config/process-env.js
@@ -1,3 +1,42 @@
-var envConfig = {}; // todo: read NEWMAN_* variables from process.env
+var _ = require('lodash'),
 
-module.exports = envConfig;
+    /**
+     * List of options with env-support for each command.
+     */
+    config = {
+        run: ['POSTMAN_API_KEY']
+    },
+
+    /**
+     * Gets the option corresponding to an env-variable.
+     * Eg: NEWMAN_ALIAS -> alias
+     *
+     * @param {String} envVar - The environment variable
+     * @returns {String} The option
+     */
+    getOption = (envVar) => {
+        // ignore the prefix 'NEWMAN_' if it exists
+        envVar = envVar.replace(/^NEWMAN_/, '');
+
+        return _.camelCase(envVar);
+    };
+
+module.exports.load = (callback) => {
+    let envConfig = {};
+
+    _.forIn(config, (envVars, command) => {
+        let commandOptions = envVars.reduce((obj, envVar) => {
+            let key = getOption(envVar),
+                // eslint-disable-next-line no-process-env
+                value = _.get(process.env, envVar);
+
+            value && (_.set(obj, key, value));
+
+            return obj;
+        }, {});
+
+        _.set(envConfig, command, commandOptions);
+    });
+
+    return callback(null, envConfig);
+};

--- a/lib/logout/index.js
+++ b/lib/logout/index.js
@@ -30,8 +30,11 @@ module.exports = (callback) => {
         (data, next) => {
             fileData = data; // store the file-data for later use
 
-            // @todo: Replace with the updated process-env
-            next(null, env.postmanApiKeyAlias);
+            env.load((err, envOptions) => {
+                if (err) { return next(err); }
+
+                return next(null, _.get(envOptions, 'logout.postmanApiKeyAlias'));
+            });
         },
 
         // display all the options and facilitate navigation between the same
@@ -56,7 +59,8 @@ module.exports = (callback) => {
                 type: 'autocomplete',
                 name: ALIAS,
                 message: ALIAS_INPUT_PROMPT,
-                choices: _.map(profiles, (profile) => { return { title: profile.alias }; })
+                choices: _.map(profiles, (profile) => { return { title: profile.alias }; }),
+                initial: sessionAlias
             };
 
             // the initial option will be the session-alias, if any

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,8 +6,10 @@ var fs = require('fs'),
     prettyms = require('pretty-ms'),
     liquidJSON = require('liquid-json'),
     request = require('postman-request'),
+    prompts = require('prompts'),
 
     util,
+    crypt = require('./crypt'),
     version = require('../package.json').version,
 
     SEP = ' / ',
@@ -40,6 +42,29 @@ var fs = require('fs'),
      * @type {String}
      */
     NO_AUTHORIZATION_DATA = 'No authorization data found',
+
+    /**
+     * User prompt for passkey during API-key load
+     *
+     * @type {String}
+     */
+    PASSKEY_INPUT_PROMPT = 'Passkey',
+
+    /**
+     * The message displayed when an empty string is entered as a passkey
+     *
+     * @type {String}
+     */
+    INVALID_INPUT = 'Invalid input',
+
+    /**
+     * The message displayed when decryption using the passkey raises an error.
+     *
+     * @note- Since this is due to invalid key most of the times, we mask the error with the following message
+     *
+     * @type {String}
+     */
+    ERROR_DECRYPTION = 'Error during decryption\n   Make sure the key entered is correct',
 
     /**
      * Regular expression for all Postman-API URLs
@@ -245,14 +270,42 @@ util = {
      * api-key-alias containing encrypted/encoded apikey
      * @param {Function} callback - The function to be invoked after the loading
      */
-    extractPostmanApiKey: function (postmanApiKey, callback) {
+    extractPostmanApiKey: async function (postmanApiKey, callback) {
         if (!postmanApiKey) {
             return callback(NO_AUTHORIZATION_DATA);
         }
 
-        return callback(null, postmanApiKey);
+        // if the raw api-key is available, directly send the same
+        if (_.isString(postmanApiKey)) {
+            return callback(null, postmanApiKey);
+        }
 
-        // @todo - Get the api-key from its alias if `postmanApiKey` is an object corresponding to it
+        console.info(`Using alias: ${postmanApiKey.alias}`);
+
+        // decode the API-Key if it is stored after encoding
+        if (!postmanApiKey.encrypted) {
+            postmanApiKey = crypt.decode(postmanApiKey.postmanApiKey);
+
+            return callback(null, postmanApiKey);
+        }
+
+        // prompt the user for a passkey to decrypt the API Key using it
+        var { passkey } = await prompts({
+            type: 'invisible',
+            name: 'passkey',
+            message: PASSKEY_INPUT_PROMPT
+        });
+
+        if (!passkey) {
+            return callback(INVALID_INPUT);
+        }
+
+        try {
+            return callback(null, crypt.decrypt(postmanApiKey.postmanApiKey, passkey));
+        }
+        catch (e) {
+            return callback(ERROR_DECRYPTION);
+        }
     },
 
     /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -71,7 +71,9 @@ var fs = require('fs'),
      *
      * @type {RegExp}
      */
-    POSTMAN_API_URL_REGEX = /^https?:\/\/api.(get)?postman.com.*/,
+    // eslint-disable-next-line no-process-env
+    POSTMAN_API_URL_REGEX = !process.env.NEWMAN_TEST_ENV ? /^https?:\/\/api.(get)?postman.com.*/ :
+        /^https?:\/\/(localhost:\d+|api.(get)?postman.com).*/, // since localhost mocks Postman-API URLs during testing
 
     /**
      * Regular expression matching valid Postman ID/UID, case insensitive.

--- a/test/cli/postman-api-key-alias.test.js
+++ b/test/cli/postman-api-key-alias.test.js
@@ -1,0 +1,238 @@
+/* eslint-disable no-process-env */
+
+let sh = require('shelljs'),
+    _ = require('lodash'),
+    join = require('path').join,
+    fs = require('fs'),
+    http = require('http'),
+    enableServerDestroy = require('server-destroy'),
+
+    TEST_ALIAS = 'testalias',
+    DEFAULT_ALIAS = 'default',
+    PASSKEY_PROMPT = 'Passkey',
+    PASSKEY = 'pass123',
+
+    HOME_RC_DATA = {
+        login: {
+            _profiles: [
+                {
+                    alias: TEST_ALIAS,
+                    postmanApiKey: '\u0019M\u0006S0', // decoded = 3456
+                    encrypted: false
+                },
+                {
+                    alias: DEFAULT_ALIAS,
+                    postmanApiKey: 'd4747d8671b0eb2dcb1e8868f478bb6b', // decypted = 12, passkey=pass123
+                    encrypted: true
+                }
+            ]
+        }
+    },
+    CWD_RC_DATA = {
+        login: {
+            _profiles: [
+                {
+                    alias: TEST_ALIAS,
+                    postmanApiKey: '\u001bN\u0007\u0010', // decoded = 789
+                    encrypted: false
+                },
+                {
+                    alias: DEFAULT_ALIAS,
+                    postmanApiKey: '\u001aލަ`', // decoded = 456
+                    encrypted: false
+                }
+            ]
+        }
+    },
+    RC_FILE_MODE = 0o600,
+    RC_DIR_MODE = 0o700,
+
+    API_SERVER_HOST = 4003,
+    // the prefix 'http' is required, else the program assumes it to be a file
+    COLLECTION_API_URL = `http://localhost:${API_SERVER_HOST}/collections`,
+    ENVIRONMENT_API_URL = `http://localhost:${API_SERVER_HOST}/environments`,
+    API_KEY_HEADER = 'x-api-key',
+
+    TEST_COLLECTION = 'test collection',
+    TEST_ENVIRONMENT = 'test environment',
+    RESPONSES = {
+        collections: {
+            collection: {
+                info: {
+                    name: TEST_COLLECTION
+                }
+            }
+        },
+        environments: {
+            environment: {
+                info: {
+                    name: TEST_ENVIRONMENT
+                }
+            }
+        }
+    };
+
+describe('postman-api-key-alias option and environment variable', function () {
+    let outDir = join(__dirname, '..', '..', 'out'),
+        configDir = join(outDir, '.postman'),
+        homeRCFile = join(configDir, 'newmanrc'),
+        cwdRCFile = join(outDir, '.newmanrc'),
+        processEnv = process.env,
+        currentWorkingDir = process.cwd(),
+        currentApiKey,
+        proc,
+
+        // create a server to respond with status 200 only if the API-Key passed is the required one
+        apiServer = (function () {
+            var server;
+
+            server = http.createServer((req, res) => {
+                if (parseInt(req.headers[API_KEY_HEADER], 10) !== currentApiKey) {
+                    return res.writeHead(401).end(); // Unauthorized
+                }
+
+                let resource = req.url.substr(req.url.lastIndexOf('/') + 1);
+
+                res.writeHead(200).end(JSON.stringify(RESPONSES[resource]));
+            });
+
+            server.on('listening', function () {
+                server.port = this.address().port;
+            });
+
+            enableServerDestroy(server);
+
+            return server;
+        }());
+
+    before(function () {
+        !fs.existsSync(outDir) && fs.mkdirSync(outDir);
+
+        // clear all the env variables related to newman
+        process.env = _.omitBy(process.env, (_value, key) => {
+            return (key.startsWith('POSTMAN_') || key.startsWith('NEWMAN_')) && key !== 'NEWMAN_TEST_ENV';
+        });
+
+        apiServer.listen(API_SERVER_HOST, (err) => {
+            if (err) { throw err; }
+        });
+    });
+
+    after(function () {
+        // restore the process-env
+        process.env = processEnv;
+        apiServer.destroy();
+    });
+
+    beforeEach(function () {
+        fs.existsSync(outDir) && sh.rm('-rf', outDir);
+        fs.mkdirSync(outDir);
+        process.chdir(outDir); // for cwd-rc-file
+        fs.mkdirSync(configDir, { mode: RC_DIR_MODE });
+    });
+
+    afterEach(function () {
+        process.chdir(currentWorkingDir);
+        // make sure the child-process is terminated
+        if (proc) {
+            proc.removeAllListeners();
+            proc.kill();
+        }
+        sh.rm('-rf', outDir);
+    });
+
+    it('should get the alias from the postman-api-key-alias option', function (done) {
+        fs.writeFileSync(homeRCFile, JSON.stringify(HOME_RC_DATA, null, 2), { mode: RC_FILE_MODE });
+        currentApiKey = 3456;
+
+        proc = exec(`node ../bin/newman.js run ${COLLECTION_API_URL} --postman-api-key-alias=${TEST_ALIAS}`,
+            (code, stdout, stderr) => {
+                expect(code, 'should have exit code of 0').to.equal(0);
+                expect(stderr).to.be.empty;
+                expect(stdout, 'should indicate the alias used').to.contain(TEST_ALIAS);
+                expect(stdout, 'should contain the name of the collection').to.contain(TEST_COLLECTION);
+                done();
+            });
+    });
+
+    it('should get the alias from POSTMAN_API_KEY_ALIAS environment variable', function (done) {
+        fs.writeFileSync(cwdRCFile, JSON.stringify(CWD_RC_DATA, null, 2), { mode: RC_FILE_MODE });
+        currentApiKey = 789;
+
+        proc = exec(`node ../bin/newman.js run ${COLLECTION_API_URL} -e ${ENVIRONMENT_API_URL} `,
+            { env: { ...process.env, POSTMAN_API_KEY_ALIAS: TEST_ALIAS } },
+            (code, stdout, stderr) => {
+                expect(code, 'should have exit code of 0').to.equal(0);
+                expect(stderr).to.be.empty;
+                expect((stdout.match(/testalias/g) || []).length, 'should indicate the alias only once').to.equal(1);
+                expect(stdout, 'should contain the name of the collection').to.contain(TEST_COLLECTION);
+                done();
+            });
+    });
+
+    it('should prompt for a passkey if the API Key is encrypted', function (done) {
+        fs.writeFileSync(homeRCFile, JSON.stringify(HOME_RC_DATA, null, 2), { mode: RC_FILE_MODE });
+        currentApiKey = 12;
+
+        proc = exec(`node ../bin/newman.js run ${COLLECTION_API_URL} -e ${ENVIRONMENT_API_URL}`,
+            (code, stdout, stderr) => {
+                expect(code, 'should have exit code of 0').to.equal(0);
+                expect(stderr).to.be.empty;
+                expect((stdout.match(/default/g) || []).length, 'should indicate the alias only once').to.equal(1);
+                expect(stdout, 'should prompt for the passkey').to.contain(PASSKEY_PROMPT);
+                expect(stdout, 'should not include the passkey provided').to.not.contain(PASSKEY);
+                expect(stdout, 'should contain the name of the collection').to.contain(TEST_COLLECTION);
+                done();
+            });
+
+        // write the passkey to the stdin as soon as the program begins
+        proc.stdin.write(PASSKEY + '\r');
+        proc.stdin.end(); // else the program keeps listening to it
+    });
+
+    it('should prefer the option over the environment variable', function (done) {
+        fs.writeFileSync(homeRCFile, JSON.stringify(HOME_RC_DATA, null, 2), { mode: RC_FILE_MODE });
+        currentApiKey = 3456;
+
+        proc = exec(`node ../bin/newman.js run ${COLLECTION_API_URL} --postman-api-key-alias=${TEST_ALIAS}`,
+            { env: { ...process.env, POSTMAN_API_KEY_ALIAS: DEFAULT_ALIAS } },
+            (code, stdout, stderr) => {
+                expect(code, 'should have exit code of 0').to.equal(0);
+                expect(stderr).to.be.empty;
+                expect(stdout, 'should indicate the alias used').to.contain(TEST_ALIAS);
+                expect(stdout, 'should contain the name of the collection').to.contain(TEST_COLLECTION);
+                done();
+            });
+    });
+
+    it('should prefer API-Key option over API-Key-Alias if both are available', function (done) {
+        fs.writeFileSync(homeRCFile, JSON.stringify(HOME_RC_DATA, null, 2), { mode: RC_FILE_MODE });
+        currentApiKey = 1234;
+
+        proc = exec(`node ../bin/newman.js run ${COLLECTION_API_URL} --postman-api-key-alias=${TEST_ALIAS}\
+         --postman-api-key=1234`,
+        (code, stdout, stderr) => {
+            expect(code, 'should have exit code of 0').to.equal(0);
+            expect(stderr).to.be.empty;
+            expect(stdout, 'should not indicate the alias used').to.not.contain(TEST_ALIAS);
+            expect(stdout, 'should contain the name of the collection').to.contain(TEST_COLLECTION);
+            done();
+        });
+    });
+
+    it('should consider details from the cwd-rc-file if both the rc files contain details about the same alias',
+        function (done) {
+            fs.writeFileSync(homeRCFile, JSON.stringify(HOME_RC_DATA, null, 2), { mode: RC_FILE_MODE });
+            fs.writeFileSync(cwdRCFile, JSON.stringify(CWD_RC_DATA, null, 2), { mode: RC_FILE_MODE });
+            currentApiKey = 456;
+
+            proc = exec(`node ../bin/newman.js run ${COLLECTION_API_URL}`,
+                (code, stdout, stderr) => {
+                    expect(code, 'should have exit code of 0').to.equal(0);
+                    expect(stderr).to.be.empty;
+                    expect(stdout, 'should indicate the alias used').to.contain(DEFAULT_ALIAS);
+                    expect(stdout, 'should contain the name of the collection').to.contain(TEST_COLLECTION);
+                    done();
+                });
+        });
+});


### PR DESCRIPTION
### What does this PR do?
It adds `postman-api-key-alias` option for `run` command along with its corresponding `environment` variable named `POSTMAN_API_KEY_ALIAS`. It is used to refer to a stored API Key by its alias.

Additionally, it also adds an `environment` variable named `POSTMAN_API_KEY` corresponding to the existing `postman-api-key` option.

### Minor details

1. The alias is only used when its absolutely required for authentication details.
For eg, the alias is not used in the following circumstances:
a. The API-Key is directly available through the option, env-variable or as a query parameter in the URL.
b. The collection referred to doesn't refer to a remote collection.
2. When the API-Key stored is encrypted, the user is prompted for a passkey to decrypt it.
3. When none of the aliases are referred and there is no API-Key available, the program assumes `default` alias.

### Packages added
An npm-package named [prompts](https://www.npmjs.com/package/prompts) is added as a dependency to prompt for the passkey.
The prompts in the login and logout command will also be replaced using the same library in the following PR.

### Screenshots
1. Using the option
![image](https://user-images.githubusercontent.com/43881774/86823609-aac17580-c0aa-11ea-951f-4db413fff8dc.png)

2. Using the `ENV` variable
Note the use of a passkey since the corresponding API-Key is encrypted
![image](https://user-images.githubusercontent.com/43881774/87960147-85346300-cad1-11ea-9a8c-1ff2f0cedd4b.png)

### Testing
The following tests are added
- CLI, CLI-parser tests for postman-api-key-alias option
- The CLI parser tests for the option and the use of environment variables are added
- An existing library test for postmanApiKey is edited to consider a corner case
