### PR TITLE
Fix: Alter logic to load config only for CLI-run

### DIFF
--- a/.nycrc.js
+++ b/.nycrc.js
@@ -19,7 +19,7 @@ function configOverrides (testType) {
                 branches: 20,
                 functions: 35,
                 lines: 35,
-                exclude: ['lib/crypt.js', 'lib/login']
+                exclude: ['lib/crypt.js', 'lib/login', 'lib/config']
             };
         case 'library':
             return {
@@ -27,7 +27,7 @@ function configOverrides (testType) {
                 branches: 40,
                 functions: 55,
                 lines: 55,
-                exclude: ['lib/crypt.js', 'lib/login']
+                exclude: ['lib/crypt.js', 'lib/login', 'lib/config']
             };
         case 'unit':
             return {

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -20,6 +20,9 @@ program
     .addHelpCommand(false)
     .version(version, '-v, --version');
 
+// @note - Specify default options for commands in lib/config/defaults.js. This is done to give config-options from
+// rc-file and environment higher priority than default options.
+
 // The `run` command allows you to specify a collection to be run with the provided options.
 program
     .command('run <collection>')

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -25,17 +25,18 @@ program
     .option('-e, --environment <path>', 'Specify a URL or Path to a Postman Environment.')
     .option('-g, --globals <path>', 'Specify a URL or Path to a file containing Postman Globals.')
     // eslint-disable-next-line max-len
-    .option('--folder <path>', 'Specify folder to run from a collection. Can be specified multiple times to run multiple folders', util.cast.memoize, [])
+    .option('--folder <path>', 'Specify folder to run from a collection. Can be specified multiple times to run multiple folders', util.cast.memoize)
     .option('--working-dir <path>', 'The path of the directory to be used as the working directory')
     .option('--no-insecure-file-read', 'Prevents reading the files situated outside of the working directory')
-    .option('-r, --reporters [reporters]', 'Specify the reporters to use for this run.', util.cast.csvParse, ['cli'])
+    .option('-r, --reporters [reporters]', 'Specify the reporters to use for this run. (default: ["cli"])',
+        util.cast.csvParse)
     .option('-n, --iteration-count <n>', 'Define the number of iterations to run.', util.cast.integer)
     .option('-d, --iteration-data <path>', 'Specify a data file to use for iterations (either json or csv).')
     .option('--export-environment <path>', 'Exports the environment to a file after completing the run.')
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
     .option('--export-collection <path>', 'Specify an output file to save the executed collection')
     .option('--postman-api-key <apiKey>', 'API Key used to load the resources from the Postman API.')
-    .option('--delay-request [n]', 'Specify the extent of delay between requests (milliseconds)', util.cast.integer, 0)
+    .option('--delay-request [n]', 'Specify the extent of delay between requests (milliseconds)', util.cast.integer)
     .option('--bail [modifiers]',
         'Specify whether or not to gracefully stop a collection run on encountering an error' +
         'and whether to end the run with an error based on the optional modifier.', util.cast.csvParse)
@@ -46,14 +47,14 @@ program
         'Forces unicode compliant symbols to be replaced by their plain text equivalents')
     .option('--global-var <value>',
         'Allows the specification of global variables via the command line, in a key=value format',
-        util.cast.memoizeKeyVal, [])
+        util.cast.memoizeKeyVal)
     .option('--env-var <value>',
         'Allows the specification of environment variables via the command line, in a key=value format',
-        util.cast.memoizeKeyVal, [])
-    .option('--color <value>', 'Enable/Disable colored output. (auto|on|off)', util.cast.colorOptions, 'auto')
-    .option('--timeout [n]', 'Specify a timeout for collection run (in milliseconds)', util.cast.integer, 0)
-    .option('--timeout-request [n]', 'Specify a timeout for requests (in milliseconds).', util.cast.integer, 0)
-    .option('--timeout-script [n]', 'Specify a timeout for script (in milliseconds).', util.cast.integer, 0)
+        util.cast.memoizeKeyVal)
+    .option('--color <value>', 'Enable/Disable colored output. (auto|on|off) (default: "auto")', util.cast.colorOptions)
+    .option('--timeout [n]', 'Specify a timeout for collection run (in milliseconds)', util.cast.integer)
+    .option('--timeout-request [n]', 'Specify a timeout for requests (in milliseconds).', util.cast.integer)
+    .option('--timeout-script [n]', 'Specify a timeout for script (in milliseconds).', util.cast.integer)
     .option('--ignore-redirects', 'If present, Newman will not follow HTTP Redirects.')
     .option('-k, --insecure', 'Disables SSL validations.')
     .option('--ssl-client-cert-list <path>',

--- a/bin/util.js
+++ b/bin/util.js
@@ -30,6 +30,8 @@ module.exports = {
          * @returns {String[]} - The array of argument values collected.
          */
         memoize: (val, memo) => {
+            !memo && (memo = []);
+
             memo.push(val);
 
             return memo;
@@ -45,6 +47,8 @@ module.exports = {
          * @returns {Array} - [{key, value}] - The object representation of the current CLI variable.
          */
         memoizeKeyVal: (val, memo) => {
+            !memo && (memo = []);
+
             let arg,
                 eqIndex = val.indexOf('=');
 

--- a/bin/util.js
+++ b/bin/util.js
@@ -29,9 +29,7 @@ module.exports = {
          * @param {String[]} memo - The array that is populated by argument values.
          * @returns {String[]} - The array of argument values collected.
          */
-        memoize: (val, memo) => {
-            !memo && (memo = []);
-
+        memoize: (val, memo = []) => {
             memo.push(val);
 
             return memo;
@@ -46,9 +44,7 @@ module.exports = {
          * @param {Array} memo - The array that is populated by key value pairs.
          * @returns {Array} - [{key, value}] - The object representation of the current CLI variable.
          */
-        memoizeKeyVal: (val, memo) => {
-            !memo && (memo = []);
-
+        memoizeKeyVal: (val, memo = []) => {
             let arg,
                 eqIndex = val.indexOf('=');
 

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1,0 +1,22 @@
+var cliOptions = {
+    run: {
+        folder: [],
+        reporters: ['cli'],
+        delayRequest: 0,
+        globalVar: [],
+        envVar: [],
+        color: 'auto',
+        timeout: 0,
+        timeoutRequest: 0,
+        timeoutScript: 0
+    }
+};
+
+/**
+ * Load default options for CLI commands
+ *
+ * @param {Function} callback - The callback to be invoked after the process
+ */
+module.exports.load = (callback) => {
+    return callback(null, cliOptions);
+};

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -2,7 +2,6 @@ var _ = require('lodash'),
     async = require('async'),
 
     defaults = require('./defaults'),
-    env = require('./process-env'),
     rcfile = require('./rc-file');
 
 /**
@@ -14,13 +13,12 @@ var _ = require('lodash'),
  * @param {String} options.command - Command name. Used for loading the required options from the config file.
  * @param {Boolean=} options.ignoreRcFile - If true, the RC file is ignored.
  * @param {Boolean=} options.ignoreProcessEnvironment - If true, the process environment variables are ignored.
- * @param {Object=} options.loaders - Custom loaders for specific configuration options.
  * @param {Function} callback - Is called after merging values from the overrides with the values from the rc file and
  * environment variables.
  * @returns {*}
  */
 module.exports.get = (cliOptions, options, callback) => {
-    var { loaders, command } = options;
+    var { command } = options;
 
     async.parallel([
         // Load the default options for all commands
@@ -33,11 +31,6 @@ module.exports.get = (cliOptions, options, callback) => {
             }
 
             return rcfile.load(['home', 'cwd'], cb);
-        },
-
-        // Load Process Environment overrides
-        !options.ignoreProcessEnvironment ? env : (cb) => {
-            return cb(null, {});
         }
     ], (err, options) => {
         if (err) {
@@ -55,22 +48,6 @@ module.exports.get = (cliOptions, options, callback) => {
             return (src === null) ? dest : undefined;
         });
 
-        if (_.isEmpty(loaders)) {
-            return callback(null, options);
-        }
-        // sanitize environment option
-        if (!options.environment) {
-            options.environment = {};
-        }
-        // sanitize globals option
-        if (!options.globals) {
-            options.globals = {};
-        }
-
-        let commonOptions = _.pick(options, ['postmanApiKey']);
-
-        async.mapValues(options, (value, name, cb) => {
-            return (value && _.isFunction(loaders[name])) ? loaders[name](value, commonOptions, cb) : cb(null, value);
-        }, callback);
+        return callback(null, options);
     });
 };

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,14 +1,15 @@
 var _ = require('lodash'),
     async = require('async'),
 
+    defaults = require('./defaults'),
     env = require('./process-env'),
     rcfile = require('./rc-file');
 
 /**
- * Reads configuration from config file, environment variables and CLI arguments. The CLI arguments override environment
- * variables and environment variables override the configuration read from a file.
+ * Reads and merges configuration from default options, config file, environment variables and CLI arguments.
+ * Priority among these configurations: CLI options > Environment variables > Config file > Default options
  *
- * @param {Object} overrides - Configuration overrides (these usually come from the CLI).
+ * @param {Object} cliOptions - The options passed from the CLI arguments.
  * @param {Object} options - The wrapper object of settings used for selective configuration loading.
  * @param {String} options.command - Command name. Used for loading the required options from the config file.
  * @param {Boolean=} options.ignoreRcFile - If true, the RC file is ignored.
@@ -18,13 +19,13 @@ var _ = require('lodash'),
  * environment variables.
  * @returns {*}
  */
-module.exports.get = (overrides, options, callback) => {
-    !callback && _.isFunction(options) && (callback = options, options = {});
+module.exports.get = (cliOptions, options, callback) => {
+    var { loaders, command } = options;
 
-    var loaders = options.loaders,
-        commonOptions = _.pick(overrides, ['postmanApiKey']);
+    async.parallel([
+        // Load the default options for all commands
+        defaults.load,
 
-    async.waterfall([
         // Load RC Files.
         (cb) => {
             if (options.ignoreRcFile) {
@@ -33,18 +34,23 @@ module.exports.get = (overrides, options, callback) => {
 
             return rcfile.load(['home', 'cwd'], cb);
         },
-        // Load Process Environment overrides
-        (fileOptions, cb) => {
-            fileOptions[options.command] && (fileOptions = fileOptions[options.command]);
 
-            return cb(null, _.merge(fileOptions, options.ignoreProcessEnvironment ? {} : env));
+        // Load Process Environment overrides
+        !options.ignoreProcessEnvironment ? env : (cb) => {
+            return cb(null, {});
         }
     ], (err, options) => {
         if (err) {
             return callback(err);
         }
 
-        options = _.mergeWith({}, options, overrides, (dest, src) => {
+        // get options specific to the command
+        options = _.map(options, (obj) => {
+            return obj && obj[command] ? obj[command] : {};
+        });
+
+        // merge the options from all the sources
+        options = _.assignWith({}, ...options, cliOptions, (dest, src) => {
             // If the newer value is a null, do not override it.
             return (src === null) ? dest : undefined;
         });
@@ -60,6 +66,8 @@ module.exports.get = (overrides, options, callback) => {
         if (!options.globals) {
             options.globals = {};
         }
+
+        let commonOptions = _.pick(options, ['postmanApiKey']);
 
         async.mapValues(options, (value, name, cb) => {
             return (value && _.isFunction(loaders[name])) ? loaders[name](value, commonOptions, cb) : cb(null, value);

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -7,7 +7,6 @@ var _ = require('lodash'),
     liquidJSON = require('liquid-json'),
     parseCsv = require('csv-parse'),
     util = require('../util'),
-    config = require('../config'),
 
     /**
      * The message displayed when the specified collection file can't be loaded.
@@ -338,7 +337,7 @@ var _ = require('lodash'),
     };
 
 /**
- * The helper function to load all file based information for the current collection run.
+ * The helper function to load all file/cloud-API based information for the current collection run.
  *
  * @param {Object} options - The set of generic collection run options.
  * @param {Function} callback - The function called to mark the completion of the configuration load routine.
@@ -354,13 +353,27 @@ module.exports = function (options, callback) {
     // allow insecure file read by default
     options.insecureFileRead = Boolean(_.get(options, 'insecureFileRead', true));
 
-    config.get(options, { loaders: configLoaders, command: 'run' }, function (err, result) {
+    // sanitize environment and globals
+    !options.environment && (options.environment = {});
+    !options.globals && (options.globals = {});
+
+    let commonOptions = _.pick(options, ['postmanApiKey']);
+
+    async.mapValuesSeries(options, (value, name, cb) => {
+        if (value && _.isFunction(configLoaders[name])) {
+            return configLoaders[name](value, commonOptions, cb);
+        }
+
+        return cb(null, value);
+    }, (err, result) => {
         if (err) { return callback(err); }
 
+        // mutate globals to add global variables passed from CLI
         !_.isEmpty(options.globalVar) && _.forEach(options.globalVar, function (variable) {
             variable && (result.globals.set(variable.key, variable.value));
         });
 
+        // mutate environment to add env-variables passed from CLI
         !_.isEmpty(options.envVar) && _.forEach(options.envVar, function (variable) {
             variable && (result.environment.set(variable.key, variable.value));
         });

--- a/npm/test-cli.js
+++ b/npm/test-cli.js
@@ -4,6 +4,7 @@ require('colors');
 
 var Mocha = require('mocha'),
     expect = require('chai').expect,
+    join = require('path').join,
     recursive = require('recursive-readdir'),
 
     execOptions = { silent: true },
@@ -16,6 +17,13 @@ var Mocha = require('mocha'),
     SPEC_SOURCE_DIR = './test/cli';
 
 module.exports = function (exit) {
+    let isWin = (/^win/).test(process.platform),
+        outDir = join(__dirname, '..', 'out');
+
+    // change the home directory to make sure the home-rc-file doesn't interfere in tests
+    // eslint-disable-next-line no-process-env
+    process.env[isWin ? 'userprofile' : 'HOME'] = outDir;
+
     // banner line
     console.info('Running CLI integration tests using mocha and shelljs...'.yellow.bold);
 

--- a/npm/test-unit.js
+++ b/npm/test-unit.js
@@ -15,6 +15,13 @@ var path = require('path'),
     SPEC_SOURCE_DIR = path.join(__dirname, '..', 'test', 'unit');
 
 module.exports = function (exit) {
+    let isWin = (/^win/).test(process.platform),
+        outDir = path.join(__dirname, '..', 'out');
+
+    // change the home directory to make sure the home-rc-file doesn't interfere in tests
+    // eslint-disable-next-line no-process-env
+    process.env[isWin ? 'userprofile' : 'HOME'] = outDir;
+
     // banner line
     console.info('Running unit tests using mocha...'.yellow.bold);
 

--- a/test/cli/login.test.js
+++ b/test/cli/login.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-process-env */
-
 const _ = require('lodash'),
     // eslint-disable-next-line security/detect-child-process
     child = require('child_process'),
@@ -32,8 +30,6 @@ describe('Login command', function () {
     let outDir = join(__dirname, '..', '..', 'out'),
         configDir = join(outDir, '.postman'),
         rcFile = join(configDir, 'newmanrc'),
-        isWin = (/^win/).test(process.platform),
-        homeDir = process.env[isWin ? 'userprofile' : 'HOME'],
         proc,
         stdout,
         stderr,
@@ -75,16 +71,6 @@ describe('Login command', function () {
                 }
             });
         };
-
-    before(function () {
-        // change the home directory to alter the location of the rc file
-        process.env[isWin ? 'userprofile' : 'HOME'] = outDir;
-    });
-
-    after(function () {
-        // update the home directory back to its original value
-        process.env[isWin ? 'userprofile' : 'HOME'] = homeDir;
-    });
 
     beforeEach(function () {
         sh.test('-d', outDir) && sh.rm('-rf', outDir);

--- a/test/unit/rc-file.test.js
+++ b/test/unit/rc-file.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-process-env */
 var fs = require('fs'),
     sh = require('shelljs'),
     sinon = require('sinon'),
@@ -15,13 +14,11 @@ describe('RC File Module', function () {
         homeRCFile = join(homeRCDir, 'newmanrc'),
         cwdRCFile = join(outDir, '.newmanrc'),
         isWin = (/^win/).test(process.platform),
-        homeDir = process.env[isWin ? 'userprofile' : 'HOME'],
         currentWorkingDir = process.cwd(),
         testData = { test: 123 };
 
     // all the tests take place assuming 'outDir' is the home directory and the current working directory
     before(function () {
-        process.env[isWin ? 'userprofile' : 'HOME'] = outDir; // the same variables are checked in os.homeDir() function
         !fs.existsSync(outDir) && fs.mkdirSync(outDir); // else the next step will throw an error
         process.chdir(outDir);
 
@@ -31,8 +28,6 @@ describe('RC File Module', function () {
     });
 
     after(function () {
-        // update the home, current working directory back to its original value
-        process.env[isWin ? 'userprofile' : 'HOME'] = homeDir;
         process.chdir(currentWorkingDir);
     });
 


### PR DESCRIPTION
### What does this PR do?
Currently, details from RC-file and environment are loaded even for library runs.
This PR separates out code related to config sources from the library, to not let this happen.

Additionally, the PR makes sure that options mentioned in the RC File get higher priority than the default-options.

### Implementation details
1. The `lib/config` module initially used in `lib/run/options.js` is now used in `bin/newman.js`.
2. An additional file `lib/config/defaults.js` is created to mention all the default options to give these options lesser priority than the ones in rc-file.

### Testing
1. CLI-Parser tests are added to make sure proper merging of options take place from different sources.
2. The home directory is changed to `outDir` in CLI, unit test-suites to make sure the RC file used by the developers doesn't interfere in the tests.