### PR TITLE
Add API module to interact with Postman using APIs

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+    // @todo - Add PostmanAPIManager
+    PostmanResource: require('./postman-resource')
+};

--- a/lib/api/postman-resource.js
+++ b/lib/api/postman-resource.js
@@ -28,7 +28,8 @@ let _ = require('lodash'),
      */
     REQUEST_METHOD_MAP = {
         fetch: 'get',
-        sync: 'put'
+        sync: 'put',
+        delete: 'delete'
     },
 
     /**
@@ -40,7 +41,8 @@ let _ = require('lodash'),
      */
     OPERATION_VERB_MAP = {
         fetch: 'fetching',
-        sync: 'syncing'
+        sync: 'syncing',
+        delete: 'deleting'
     },
 
     /**
@@ -154,6 +156,16 @@ class PostmanResource {
         this.data = data;
 
         return remoteOperation('sync', this, callback);
+    }
+
+    /**
+     * Deletes the remote resource using Postman-API
+     *
+     * @param {Function} callback - The function to be invoked after the deletion
+     * @returns {*}
+     */
+    delete (callback) {
+        return remoteOperation('delete', this, callback);
     }
 }
 

--- a/lib/api/postman-resource.js
+++ b/lib/api/postman-resource.js
@@ -1,0 +1,98 @@
+let _ = require('lodash'),
+    util = require('../util'),
+
+    /**
+     * Map of resource type and its equivalent API pathname.
+     *
+     * @type {Object}
+     */
+    POSTMAN_API_PATH_MAP = {
+        collection: 'collections',
+        environment: 'environments'
+    },
+
+    POSTMAN_API_HOST = 'api.postman.com',
+
+    POSTMAN_API_URL = 'https://' + POSTMAN_API_HOST,
+
+    DEFAULT_HEADERS = {
+        'User-Agent': util.userAgent
+    };
+
+/** Class representing a resource in Postman-Cloud */
+class PostmanResource {
+    /**
+     * Creates an instance of PostmanResource
+     *
+     * @param {String} type - The type of the resource, for eg: 'collection', 'environment' etc
+     * @param {String} location - The UID/ID/URL representing the remote resource
+     * @param {String} apikey - The API-Key to be used to perform operations on the resource
+     */
+    constructor (type, location, apikey) {
+        this.type = type;
+        this.apikey = apikey;
+
+        if ((/^https?:\/\/.*/).test(location)) {
+            this.url = location;
+        }
+        else {
+            // build API URL if `location` is an UID/ID
+            this.url = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
+        }
+    }
+
+    /**
+     * Gets the remote resource using Postman-API
+     *
+     * @param {Function} callback - The function to be invoked after the load
+     * @returns {*}
+     */
+    get (callback) {
+        let headers = {
+            ...DEFAULT_HEADERS,
+            'X-Api-Key': this.apikey
+        };
+
+        return util.apiRequest('GET', {
+            url: this.url,
+            json: true,
+            headers: headers,
+            // Temporary fix to fetch the collection from https URL on Node v12
+            // @todo find the root cause in postman-request
+            // Refer: https://github.com/postmanlabs/newman/issues/1991
+            agentOptions: {
+                keepAlive: true
+            }
+        }, this.type, (err, response) => {
+            if (err) { return callback(err); }
+
+            // get the respective field from the body
+            return callback(null, _.get(response, this.type));
+        });
+    }
+
+    /**
+     * Updates the remote resource using Postman-API
+     *
+     * @param {Object} data - The updated value of the resource
+     * @param {Function} callback - The function to be invoked after the update
+     * @returns {*}
+     */
+    update (data, callback) {
+        let headers = {
+            ...DEFAULT_HEADERS,
+            'X-Api-Key': this.apikey,
+            'Content-Type': 'application/json'
+        };
+
+        (data = _.set({}, this.type, data)); // format the data to indicate the field
+
+        return util.apiRequest('PUT', {
+            url: this.url,
+            headers: headers,
+            body: JSON.stringify(data)
+        }, this.type, callback);
+    }
+}
+
+module.exports = PostmanResource;

--- a/lib/api/postman-resource.js
+++ b/lib/api/postman-resource.js
@@ -1,5 +1,7 @@
 let _ = require('lodash'),
     util = require('../util'),
+    request = require('postman-request'),
+    liquidJSON = require('liquid-json'),
 
     /**
      * Map of resource type and its equivalent API pathname.
@@ -17,6 +19,84 @@ let _ = require('lodash'),
 
     DEFAULT_HEADERS = {
         'User-Agent': util.userAgent
+    },
+
+    /**
+     * Map of operation-name to the request-method
+     *
+     * @type {Object}
+     */
+    REQUEST_METHOD_MAP = {
+        fetch: 'get',
+        sync: 'put'
+    },
+
+    /**
+     * Map of operation-name to the its verb form
+     *
+     * Used to form error messages
+     *
+     * @type {Object}
+     */
+    OPERATION_VERB_MAP = {
+        fetch: 'fetching',
+        sync: 'syncing'
+    },
+
+    /**
+     * Performs an operation on a given remote-resource using Postman-APIs
+     *
+     * @param {String} operation - The name of the operation, for eg: 'fetch', 'sync'
+     * @param {PostmanResource} resource - The resource on which the operation has to be done
+     * @param {Function} callback - The function to be invoked after the operation
+     */
+    remoteOperation = (operation, resource, callback) => {
+        let { url, apikey, type, data } = resource,
+            headers = {
+                ...DEFAULT_HEADERS,
+                'X-Api-Key': apikey
+            },
+            requestOptions = {
+                url: url,
+                headers: headers,
+                json: true
+            },
+            requestMethod = REQUEST_METHOD_MAP[operation];
+
+        if (operation === 'sync') {
+            data = _.set({}, type, data); // format the data to indicate the field
+            requestOptions.body = JSON.stringify(data);
+            requestOptions.headers['Content-Type'] = 'application/json';
+        }
+
+        return request[requestMethod](requestOptions, (err, response, body) => {
+            if (err) {
+                return callback(_.set(err, 'help', `unable to ${operation} data from url "${url}"`));
+            }
+
+            try {
+                _.isString(body) && (body = liquidJSON.parse(body.trim()));
+            }
+            catch (e) {
+                return callback(_.set(e, 'help', `the url "${url}" did not provide valid JSON data`));
+            }
+
+            // if the status code is not in 200s, get the error from the body
+            if (!(/2../).test(response.statusCode)) {
+                var error;
+
+                error = new Error(_.get(body, 'error.message', `Error ${OPERATION_VERB_MAP[operation]} ${type}, ` +
+                    `the provided URL returned status code: ${response.statusCode}`));
+
+                return callback(_.assign(error, {
+                    name: _.get(body, 'error.name', _.capitalize(type) + _.capitalize(operation) + 'Error'),
+                    help: `Error ${OPERATION_VERB_MAP[operation]} the ${type} from the provided URL. ` +
+                        'Ensure that the URL is valid.'
+                }));
+            }
+
+            return callback(null, body);
+        });
     };
 
 /** Class representing a resource in Postman-Cloud */
@@ -31,6 +111,7 @@ class PostmanResource {
     constructor (type, location, apikey) {
         this.type = type;
         this.apikey = apikey;
+        this.data = undefined; // used to cache the resource to prevent repetitive network calls
 
         if ((/^https?:\/\/.*/).test(location)) {
             this.url = location;
@@ -42,32 +123,23 @@ class PostmanResource {
     }
 
     /**
-     * Gets the remote resource using Postman-API
+     * Gets the remote resource using Postman-API or the cached data
      *
      * @param {Function} callback - The function to be invoked after the load
      * @returns {*}
      */
     get (callback) {
-        let headers = {
-            ...DEFAULT_HEADERS,
-            'X-Api-Key': this.apikey
-        };
+        if (this.data) {
+            return callback(null, this.data);
+        }
 
-        return util.apiRequest('GET', {
-            url: this.url,
-            json: true,
-            headers: headers,
-            // Temporary fix to fetch the collection from https URL on Node v12
-            // @todo find the root cause in postman-request
-            // Refer: https://github.com/postmanlabs/newman/issues/1991
-            agentOptions: {
-                keepAlive: true
-            }
-        }, this.type, (err, response) => {
+        return remoteOperation('fetch', this, (err, response) => {
             if (err) { return callback(err); }
 
-            // get the respective field from the body
-            return callback(null, _.get(response, this.type));
+            // get the respective field from the body and cache it to prevent future remote-requests
+            this.data = _.get(response, this.type);
+
+            return callback(null, this.data);
         });
     }
 
@@ -79,19 +151,9 @@ class PostmanResource {
      * @returns {*}
      */
     update (data, callback) {
-        let headers = {
-            ...DEFAULT_HEADERS,
-            'X-Api-Key': this.apikey,
-            'Content-Type': 'application/json'
-        };
+        this.data = data;
 
-        (data = _.set({}, this.type, data)); // format the data to indicate the field
-
-        return util.apiRequest('PUT', {
-            url: this.url,
-            headers: headers,
-            body: JSON.stringify(data)
-        }, this.type, callback);
+        return remoteOperation('sync', this, callback);
     }
 }
 

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -80,6 +80,7 @@ var _ = require('lodash'),
  * @param {String} options.exportGlobals - The relative path to export the globals file from the current run to.
  * @param {String} options.exportEnvironment - The relative path to export the environment file from the current run to.
  * @param {String} options.exportCollection - The relative path to export the collection from the current run to.
+ * @param {String} options.postmanApiKey - The Postman API Key for fetching/updating remote resources.
  * @param {Function} callback - The callback function invoked to mark the end of the collection run.
  * @returns {EventEmitter} - An EventEmitter instance with done and error event attachments.
  */

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -42,13 +42,13 @@ var _ = require('lodash'),
     COLLECTION_TRANSFORMER_OPTION = { inputVersion: '1.0.0', outputVersion: '2.1.0' },
 
     /**
-     * Gets a set of PostmanResource instances corresponding to all the options which represents one
+     * Initialises a set of PostmanResource instances corresponding to all the options which represents one
      *
      * @param {Object} options - Set of run options
      * @param {Function} callback - The function to be invoked after process
      * @returns {*}
      */
-    getPostmanResources = function (options, callback) {
+    createPostmanResources = function (options, callback) {
         return async.mapValuesSeries(_.pick(options, ['collection', 'environment']), (value, type, cb) => {
             // if the option doesn't represent a postman-resource, ignore it
             if (!util.isPostmanResource(value)) {
@@ -399,7 +399,7 @@ module.exports = function (options, callback) {
     async.waterfall([
         // get PostmanResource instances corresponding to each option which represents a postman-resource
         (next) => {
-            return getPostmanResources(options, next);
+            return createPostmanResources(options, next);
         },
 
         (_postmanResources, next) => {

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -6,6 +6,7 @@ var _ = require('lodash'),
     transformer = require('postman-collection-transformer'),
     liquidJSON = require('liquid-json'),
     parseCsv = require('csv-parse'),
+    PostmanResource = require('../api').PostmanResource,
     util = require('../util'),
 
     /**
@@ -41,6 +42,41 @@ var _ = require('lodash'),
     COLLECTION_TRANSFORMER_OPTION = { inputVersion: '1.0.0', outputVersion: '2.1.0' },
 
     /**
+     * Gets a set of PostmanResource instances corresponding to all the options which represents one
+     *
+     * @param {Object} options - Set of run options
+     * @param {Function} callback - The function to be invoked after process
+     * @returns {*}
+     */
+    getPostmanResources = function (options, callback) {
+        return async.mapValuesSeries(_.pick(options, ['collection', 'environment']), (value, type, cb) => {
+            // if the option doesn't represent a postman-resource, ignore it
+            if (!util.isPostmanResource(value)) {
+                return cb(null);
+            }
+
+            // if the option has an api-key as a query-param, use that api-key to communicate with Postman
+            if ((/https?.*apikey=.*/).test(value)) {
+                let urlObj = new URL(value),
+                    apikey = urlObj.searchParams.get('apikey');
+
+                urlObj.searchParams.delete('apikey'); // delete the query-param for security concerns
+
+                return cb(null, new PostmanResource(type, urlObj.href, apikey));
+            }
+
+            // use the session-api-key in other cases
+            return util.extractPostmanApiKey(options.postmanApiKey, (err, apikey) => {
+                if (err) { return cb(err); }
+
+                options.postmanApiKey = apikey; // store the loaded apikey
+
+                return cb(null, new PostmanResource(type, value, apikey));
+            });
+        }, callback);
+    },
+
+    /**
      * Accepts an object, and extracts the property inside an object which is supposed to contain the required data.
      * In case of variables, it also extracts them into plain JS objects.
      *
@@ -66,13 +102,16 @@ var _ = require('lodash'),
      * Loads the given data of type from a specified external location
      *
      * @param {String} type - The type of data to load.
-     * @param {String} location - The location to load from (file path or URL).
-     * @param {Object} options - The set of wrapped options.
+     * @param {String|PostmanResource} location - The location to load from (file path/URL/PostmanResource instance).
      * @param {function} cb - The callback function whose invocation marks the end of the external load routine.
      * @returns {*}
      */
-    externalLoader = function (type, location, options, cb) {
-        return _.isString(location) ? util.fetchJson(type, location, options, function (err, data) {
+    externalLoader = function (type, location, cb) {
+        if (location instanceof PostmanResource) {
+            return location.get(cb);
+        }
+
+        return _.isString(location) ? util.fetchJson(location, type, function (err, data) {
             if (err) {
                 return cb(err);
             }
@@ -108,11 +147,10 @@ var _ = require('lodash'),
      *
      * @private
      * @param {String} type - The type of resource to load: collection, environment, etc.
-     * @param {String|Object} value - The value derived from the CLI or run command.
-     * @param {Object} options - The set of wrapped options.
+     * @param {String|Object|PostmanResource} value - The value of the resource.
      * @param {Function} callback - The function invoked when the scope has been loaded.
      */
-    loadScopes = function (type, value, options, callback) {
+    loadScopes = function (type, value, callback) {
         var done = function (err, scope) {
             if (err) { return callback(new Error(LOAD_ERROR_MESSAGE + `${type}\n  ${err.message || err}`)); }
 
@@ -123,11 +161,12 @@ var _ = require('lodash'),
             callback(null, new VariableScope(VariableScope.isVariableScope(scope) ? scope.toJSON() : scope));
         };
 
-        if (_.isObject(value)) {
-            return done(null, value);
+        // if the value represents a location to be fetched from, load it from the same
+        if (_.isString(value) || value instanceof PostmanResource) {
+            return externalLoader(type, value, done);
         }
 
-        externalLoader(type, value, options, done);
+        return done(null, value);
     },
 
     /**
@@ -166,12 +205,11 @@ var _ = require('lodash'),
         /**
          * The collection file load helper for the current run.
          *
-         * @param {Object|String} value - The collection, specified as a JSON object, or the path to it's file.
-         * @param {Object} options - The set of wrapped options.
+         * @param {Object|String|PostmanResource} value - The value of the collection (JSON/location/PostmanResource)
          * @param {Function} callback - The callback function invoked to mark the end of the collection load routine.
          * @returns {*}
          */
-        collection: function (value, options, callback) {
+        collection: function (value, callback) {
             /**
              * The post collection load handler.
              *
@@ -200,23 +238,24 @@ var _ = require('lodash'),
                 callback(null, collection);
             };
 
-            // if the collection has been specified as an object, convert to V2 if necessary and return the result
-            if (_.isObject(value)) {
-                return processCollection(value, done);
-            }
-
-            externalLoader('collection', value, options, function (err, data) {
-                if (err) {
-                    return done(new Error(COLLECTION_LOAD_ERROR_MESSAGE +
+            // if the collection represents a location, fetch it from the same
+            if (_.isString(value) || value instanceof PostmanResource) {
+                return externalLoader('collection', value, function (err, data) {
+                    if (err) {
+                        return done(new Error(COLLECTION_LOAD_ERROR_MESSAGE +
                         (err.help ? `\n  ${err.help}` : '') +
                         `\n  ${err.message || err}`));
-                }
-                if (!_.isObject(data)) {
-                    return done(new Error(COLLECTION_LOAD_ERROR_MESSAGE));
-                }
+                    }
+                    if (!_.isObject(data)) {
+                        return done(new Error(COLLECTION_LOAD_ERROR_MESSAGE));
+                    }
 
-                return processCollection(data, done);
-            });
+                    return processCollection(data, done);
+                });
+            }
+
+            // if the collection is an object, convert it to V2 if necessary and return the result
+            return processCollection(value, done);
         },
 
         /**
@@ -237,11 +276,10 @@ var _ = require('lodash'),
          * Helper function to sanitize folder option.
          *
          * @param {String[]|String} value - The list of folders to execute
-         * @param {Object} options - The set of wrapped options.
          * @param {Function} callback - The callback function invoked to mark the end of the folder load routine.
          * @returns {*}
          */
-        folder: function (value, options, callback) {
+        folder: function (value, callback) {
             if (!value.length) {
                 return callback(); // avoids empty string or array
             }
@@ -258,11 +296,10 @@ var _ = require('lodash'),
          *
          * @param {String|Object[]} location - The path to the iteration data file for the current collection run, or
          * the array of iteration data objects.
-         * @param {Object} options - The set of wrapped options.
          * @param {Function} callback - The function invoked to indicate the end of the iteration data loading routine.
          * @returns {*}
          */
-        iterationData: function (location, options, callback) {
+        iterationData: function (location, callback) {
             if (_.isArray(location)) { return callback(null, location); }
 
             util.fetch(location, function (err, data) {
@@ -305,7 +342,7 @@ var _ = require('lodash'),
             });
         },
 
-        sslClientCertList: function (location, options, callback) {
+        sslClientCertList: function (location, callback) {
             if (Array.isArray(location)) {
                 return callback(null, location);
             }
@@ -357,15 +394,33 @@ module.exports = function (options, callback) {
     !options.environment && (options.environment = {});
     !options.globals && (options.globals = {});
 
-    let commonOptions = _.pick(options, ['postmanApiKey']);
+    let postmanResources = {};
 
-    async.mapValuesSeries(options, (value, name, cb) => {
-        if (value && _.isFunction(configLoaders[name])) {
-            return configLoaders[name](value, commonOptions, cb);
+    async.waterfall([
+        // get PostmanResource instances corresponding to each option which represents a postman-resource
+        (next) => {
+            return getPostmanResources(options, next);
+        },
+
+        (_postmanResources, next) => {
+            postmanResources = _postmanResources; // store these for future use
+
+            // modify the value of options which represent a postman-resource to corresponding PostmanResource instance
+            _.forEach(postmanResources, (postmanResource, type) => {
+                postmanResource && (options[type] = postmanResource);
+            });
+
+            // finally, load the options from the loaders
+            return async.mapValues(options, (value, name, cb) => {
+                if (value && _.isFunction(configLoaders[name])) {
+                    return configLoaders[name](value, cb);
+                }
+
+                return cb(null, value);
+            }, next);
         }
 
-        return cb(null, value);
-    }, (err, result) => {
+    ], (err, result) => {
         if (err) { return callback(err); }
 
         // mutate globals to add global variables passed from CLI
@@ -378,6 +433,6 @@ module.exports = function (options, callback) {
             variable && (result.environment.set(variable.key, variable.value));
         });
 
-        callback(null, result);
+        return callback(null, result, postmanResources);
     });
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -32,16 +32,6 @@ var fs = require('fs'),
         'ISO-8859-1': 'latin1'
     },
 
-    /**
-     * Map of request-method to name of the process performed
-     *
-     * @type {Object}
-     */
-    PROCESS_MAP = {
-        GET: 'fetch',
-        PUT: 'sync'
-    },
-
     USER_AGENT_VALUE = 'Newman/' + version,
 
     /**
@@ -158,61 +148,10 @@ util = {
     },
 
     /**
-     * Performs an API request with specified request-options and parses the response-body to JSON
-     *
-     * When the response status code is not of the form 2xx, gets suitable error from the response-body
-     *
-     * @param {String} method - The request-method, for eg: 'GET', 'PUT' etc
-     * @param {Object} requestOptions - The options pertaining to the request to be passed to the `request` function
-     * @param {String} [type] - The type of resource to be fetched/updated/deleted with the API request,
-     * for eg: 'collection', 'environment'
-     * @param {Function} callback - The function to be invoked after the process
-     *
-     * @returns {*}
-     */
-    apiRequest: function (method, requestOptions, type, callback) {
-        if (!callback && _.isFunction(type)) {
-            callback = type;
-            type = 'resource';
-        }
-
-        let { url } = requestOptions,
-            process = PROCESS_MAP[method];
-
-        return request[_.lowerCase(method)](requestOptions, (err, response, body) => {
-            if (err) {
-                return callback(_.set(err, 'help', `unable to ${process} data from url "${url}"`));
-            }
-
-            try {
-                _.isString(body) && (body = liquidJSON.parse(body.trim()));
-            }
-            catch (e) {
-                return callback(_.set(e, 'help', `the url "${url}" did not provide valid JSON data`));
-            }
-
-            // if the status code is not in 200s, get the error from the body
-            if (!(/2../).test(response.statusCode)) {
-                var error;
-
-                error = new Error(_.get(body, 'error.message', `Error ${process}ing ${type}, ` +
-                    `the provided URL returned status code: ${response.statusCode}`));
-
-                return callback(_.assign(error, {
-                    name: _.get(body, 'error.name', _.capitalize(type) + _.capitalize(process) + 'Error'),
-                    help: `Error ${process}ing the ${type} from the provided URL. Ensure that the URL is valid.`
-                }));
-            }
-
-            return callback(null, body);
-        });
-    },
-
-    /**
      * Loads JSON data from the given location.
      *
      * @param {String} location - Can be an HTTP URL or a local file path.
-     * @param {String} [type] - The type of data to load, eg: 'collection', 'environment'
+     * @param {String} [type='resource'] - The type of data to load, eg: 'collection', 'environment'
      * @param {Function} callback - The function whose invocation marks the end of the JSON fetch routine.
      * @returns {*}
      */
@@ -225,16 +164,35 @@ util = {
 
         return (/^https?:\/\/.*/).test(location) ?
             // Load from URL
-            this.apiRequest('GET', {
+            request.get({
                 url: location,
-                json: true,
-                // Temporary fix to fetch the collection from https URL on Node v12
-                // @todo find the root cause in postman-request
-                // Refer: https://github.com/postmanlabs/newman/issues/1991
-                agentOptions: {
-                    keepAlive: true
+                json: true
+            }, (err, response, body) => {
+                if (err) {
+                    return callback(_.set(err, 'help', `unable to fetch data from url "${location}"`));
                 }
-            }, type, callback) :
+
+                try {
+                    _.isString(body) && (body = liquidJSON.parse(body.trim()));
+                }
+                catch (e) {
+                    return callback(_.set(e, 'help', `the url "${location}" did not provide valid JSON data`));
+                }
+
+                var error;
+
+                if (response.statusCode !== 200) {
+                    error = new Error(_.get(body, 'error.message',
+                        `Error fetching ${type}, the provided URL returned status code: ${response.statusCode}`));
+
+                    return callback(_.assign(error, {
+                        name: _.get(body, 'error.name', _.capitalize(type) + 'FetchError'),
+                        help: `Error fetching the ${type} from the provided URL. Ensure that the URL is valid.`
+                    }));
+                }
+
+                return callback(null, body);
+            }) :
             fs.readFile(location, function (err, value) {
                 if (err) {
                     return callback(_.set(err, 'help', `unable to read data from file "${location}"`));

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,4 @@
 var fs = require('fs'),
-    url = require('url'),
 
     _ = require('lodash'),
     chardet = require('chardet'),
@@ -43,23 +42,21 @@ var fs = require('fs'),
         PUT: 'sync'
     },
 
-    POSTMAN_API_HOST = 'api.getpostman.com',
-
-    POSTMAN_API_URL = 'https://' + POSTMAN_API_HOST,
+    USER_AGENT_VALUE = 'Newman/' + version,
 
     /**
-     * Map of resource type and its equivalent API pathname.
+     * The message displayed when there is no data related to the Session-API-key
      *
-     * @type {Object}
+     * @type {String}
      */
-    POSTMAN_API_PATH_MAP = {
-        collection: 'collections',
-        environment: 'environments'
-    },
+    NO_AUTHORIZATION_DATA = 'No authorization data found',
 
-    API_KEY_HEADER = 'X-Api-Key',
-
-    USER_AGENT_VALUE = 'Newman/' + version,
+    /**
+     * Regular expression for all Postman-API URLs
+     *
+     * @type {RegExp}
+     */
+    POSTMAN_API_URL_REGEX = /^https?:\/\/api.(get)?postman.com.*/,
 
     /**
      * Regular expression matching valid Postman ID/UID, case insensitive.
@@ -214,73 +211,30 @@ util = {
     /**
      * Loads JSON data from the given location.
      *
-     * @param {String} type - The type of data to load.
-     * @param {String} location - Can be an HTTP URL, a local file path or an UID.
-     * @param {Object=} options - A set of options for JSON data loading.
-     * @param {Object} options.postmanApiKey - API Key used to load the resources via UID from the Postman API.
+     * @param {String} location - Can be an HTTP URL or a local file path.
+     * @param {String} [type] - The type of data to load, eg: 'collection', 'environment'
      * @param {Function} callback - The function whose invocation marks the end of the JSON fetch routine.
      * @returns {*}
      */
 
-    fetchJson: function (type, location, options, callback) {
-        !callback && _.isFunction(options) && (callback = options, options = {});
-
-        var postmanApiKey = _.get(options, 'postmanApiKey'),
-            headers = { 'User-Agent': USER_AGENT_VALUE };
-
-        // build API URL if `location` is a valid UID and api key is provided.
-        // Fetch from file in case a file with valid UID name is present.
-        if (!fs.existsSync(location) && POSTMAN_API_PATH_MAP[type] && postmanApiKey &&
-            POSTMAN_ID_REGEX.test(location)) {
-            location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
-            headers[API_KEY_HEADER] = postmanApiKey;
+    fetchJson: function (location, type, callback) {
+        if (!callback && _.isFunction(type)) {
+            callback = type;
+            type = 'resource';
         }
 
         return (/^https?:\/\/.*/).test(location) ?
             // Load from URL
-            request.get({
+            this.apiRequest('GET', {
                 url: location,
                 json: true,
-                headers: headers,
                 // Temporary fix to fetch the collection from https URL on Node v12
                 // @todo find the root cause in postman-request
                 // Refer: https://github.com/postmanlabs/newman/issues/1991
                 agentOptions: {
                     keepAlive: true
                 }
-            }, (err, response, body) => {
-                if (err) {
-                    return callback(_.set(err, 'help', `unable to fetch data from url "${location}"`));
-                }
-
-                try {
-                    _.isString(body) && (body = liquidJSON.parse(body.trim()));
-                }
-                catch (e) {
-                    return callback(_.set(e, 'help', `the url "${location}" did not provide valid JSON data`));
-                }
-
-                var error,
-                    urlObj,
-                    resource = 'resource';
-
-                if (response.statusCode !== 200) {
-                    urlObj = url.parse(location);
-
-                    (urlObj.hostname === POSTMAN_API_HOST) &&
-                        (resource = _(urlObj.path).split('/').get(1).slice(0, -1) || resource);
-
-                    error = new Error(_.get(body, 'error.message',
-                        `Error fetching ${resource}, the provided URL returned status code: ${response.statusCode}`));
-
-                    return callback(_.assign(error, {
-                        name: _.get(body, 'error.name', _.capitalize(resource) + 'FetchError'),
-                        help: `Error fetching the ${resource} from the provided URL. Ensure that the URL is valid.`
-                    }));
-                }
-
-                return callback(null, body);
-            }) :
+            }, type, callback) :
             fs.readFile(location, function (err, value) {
                 if (err) {
                     return callback(_.set(err, 'help', `unable to read data from file "${location}"`));
@@ -324,6 +278,34 @@ util = {
 
                 return callback(null, value.toString(util.detectEncoding(value)));
             });
+    },
+
+    /**
+     * Extracts the postman-api-key of the session
+     *
+     * @param {String|Object} postmanApiKey - The raw apikey or an object representing an
+     * api-key-alias containing encrypted/encoded apikey
+     * @param {Function} callback - The function to be invoked after the loading
+     */
+    extractPostmanApiKey: function (postmanApiKey, callback) {
+        if (!postmanApiKey) {
+            return callback(NO_AUTHORIZATION_DATA);
+        }
+
+        return callback(null, postmanApiKey);
+
+        // @todo - Get the api-key from its alias if `postmanApiKey` is an object corresponding to it
+    },
+
+    /**
+     * Checks whether a given location represents a Postman Resource
+     *
+     * @param {String} location - The location of the resource
+     * @returns {Boolean} - A boolean result indicating whether or not the passed location is a Postman-resource
+     */
+    isPostmanResource: function (location) {
+        return _.isString(location) && !fs.existsSync(location) &&
+            (POSTMAN_API_URL_REGEX.test(location) || POSTMAN_ID_REGEX.test(location));
     },
 
     /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,6 +33,16 @@ var fs = require('fs'),
         'ISO-8859-1': 'latin1'
     },
 
+    /**
+     * Map of request-method to name of the process performed
+     *
+     * @type {Object}
+     */
+    PROCESS_MAP = {
+        GET: 'fetch',
+        PUT: 'sync'
+    },
+
     POSTMAN_API_HOST = 'api.getpostman.com',
 
     POSTMAN_API_URL = 'https://' + POSTMAN_API_HOST,
@@ -51,9 +61,12 @@ var fs = require('fs'),
 
     USER_AGENT_VALUE = 'Newman/' + version,
 
-    // Matches valid Postman UID, case insensitive.
-    // Same used for validation on the Postman API side.
-    UID_REGEX = /^[0-9A-Z]+-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+    /**
+     * Regular expression matching valid Postman ID/UID, case insensitive.
+     *
+     * @type {RegExp}
+     */
+    POSTMAN_ID_REGEX = /^([0-9A-Z]+-|)[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
 util = {
 
@@ -148,6 +161,57 @@ util = {
     },
 
     /**
+     * Performs an API request with specified request-options and parses the response-body to JSON
+     *
+     * When the response status code is not of the form 2xx, gets suitable error from the response-body
+     *
+     * @param {String} method - The request-method, for eg: 'GET', 'PUT' etc
+     * @param {Object} requestOptions - The options pertaining to the request to be passed to the `request` function
+     * @param {String} [type] - The type of resource to be fetched/updated/deleted with the API request,
+     * for eg: 'collection', 'environment'
+     * @param {Function} callback - The function to be invoked after the process
+     *
+     * @returns {*}
+     */
+    apiRequest: function (method, requestOptions, type, callback) {
+        if (!callback && _.isFunction(type)) {
+            callback = type;
+            type = 'resource';
+        }
+
+        let { url } = requestOptions,
+            process = PROCESS_MAP[method];
+
+        return request[_.lowerCase(method)](requestOptions, (err, response, body) => {
+            if (err) {
+                return callback(_.set(err, 'help', `unable to ${process} data from url "${url}"`));
+            }
+
+            try {
+                _.isString(body) && (body = liquidJSON.parse(body.trim()));
+            }
+            catch (e) {
+                return callback(_.set(e, 'help', `the url "${url}" did not provide valid JSON data`));
+            }
+
+            // if the status code is not in 200s, get the error from the body
+            if (!(/2../).test(response.statusCode)) {
+                var error;
+
+                error = new Error(_.get(body, 'error.message', `Error ${process}ing ${type}, ` +
+                    `the provided URL returned status code: ${response.statusCode}`));
+
+                return callback(_.assign(error, {
+                    name: _.get(body, 'error.name', _.capitalize(type) + _.capitalize(process) + 'Error'),
+                    help: `Error ${process}ing the ${type} from the provided URL. Ensure that the URL is valid.`
+                }));
+            }
+
+            return callback(null, body);
+        });
+    },
+
+    /**
      * Loads JSON data from the given location.
      *
      * @param {String} type - The type of data to load.
@@ -166,7 +230,8 @@ util = {
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
-        if (!fs.existsSync(location) && POSTMAN_API_PATH_MAP[type] && postmanApiKey && UID_REGEX.test(location)) {
+        if (!fs.existsSync(location) && POSTMAN_API_PATH_MAP[type] && postmanApiKey &&
+            POSTMAN_ID_REGEX.test(location)) {
             location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -1,6 +1,8 @@
 const fs = require('fs'),
     nock = require('nock'),
     sinon = require('sinon'),
+    join = require('path').join,
+    sh = require('shelljs'),
     request = require('postman-request'),
     COLLECTION = {
         id: 'C1',
@@ -22,15 +24,15 @@ const fs = require('fs'),
 
 describe('newman.run postmanApiKey', function () {
     before(function () {
-        nock('https://api.getpostman.com')
+        nock('https://api.postman.com')
             .persist()
             .get(/^\/collections/)
-            .reply(200, COLLECTION);
+            .reply(200, { collection: COLLECTION });
 
-        nock('https://api.getpostman.com')
+        nock('https://api.postman.com')
             .persist()
             .get(/^\/environments/)
-            .reply(200, VARIABLE);
+            .reply(200, { environment: VARIABLE });
 
         nock('https://example.com')
             .persist()
@@ -63,7 +65,36 @@ describe('newman.run postmanApiKey', function () {
             expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
 
             expect(requestArg.url)
-                .to.equal('https://api.getpostman.com/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+                .to.equal('https://api.postman.com/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+
+            expect(requestArg.headers).to.be.an('object')
+                .that.has.property('X-Api-Key', '12345678');
+
+            expect(summary).to.be.an('object')
+                .that.has.property('collection').to.be.an('object')
+                .and.include({ id: 'C1', name: 'Collection' });
+
+            expect(summary.run.failures).to.be.empty;
+            expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
+
+            done();
+        });
+    });
+
+    it('should fetch collection via ID', function (done) {
+        newman.run({
+            collection: '588025f9-2497-46f7-b849-47f58b865807',
+            postmanApiKey: '12345678'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            sinon.assert.calledOnce(request.get);
+
+            let requestArg = request.get.firstCall.args[0];
+
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+
+            expect(requestArg.url)
+                .to.equal('https://api.postman.com/collections/588025f9-2497-46f7-b849-47f58b865807');
 
             expect(requestArg.headers).to.be.an('object')
                 .that.has.property('X-Api-Key', '12345678');
@@ -93,7 +124,7 @@ describe('newman.run postmanApiKey', function () {
             expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
 
             expect(requestArg.url)
-                .to.equal('https://api.getpostman.com/environments/1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f');
+                .to.equal('https://api.postman.com/environments/1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f');
 
             expect(requestArg.headers).to.be.an('object')
                 .that.has.property('X-Api-Key', '12345678');
@@ -130,21 +161,42 @@ describe('newman.run postmanApiKey', function () {
         });
     });
 
+    it('should fetch all resources via ID', function (done) {
+        newman.run({
+            collection: '588025f9-2497-46f7-b849-47f58b865807',
+            environment: '931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
+            postmanApiKey: '12345678'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            sinon.assert.calledTwice(request.get);
+
+            expect(summary).to.be.an('object').and.include.keys(['collection', 'environment', 'globals', 'run']);
+
+            expect(summary.collection).to.include({ id: 'C1', name: 'Collection' });
+            expect(summary.environment).to.include({ id: 'E1', name: 'Environment' });
+
+            expect(summary.run.failures).to.be.empty;
+            expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
+
+            done();
+        });
+    });
+
     it('should end with an error if UID is passed without postmanApiKey and no such file exists', function (done) {
         newman.run({
             collection: '1234-588025f9-2497-46f7-b849-47f58b865807'
         }, function (err) {
-            expect(err).to.be.ok.that.match(/no such file or directory/);
+            expect(err).to.be.ok.that.match(/No authorization data found/);
             sinon.assert.notCalled(request.get);
 
             done();
         });
     });
 
-    it('should not pass API Key header for Postman API URLs', function (done) {
+    it('should use API Key from Postman API URL if it contains apikey query-param', function (done) {
         newman.run({
-            collection: 'https://api.getpostman.com/collections?apikey=12345678',
-            postmanApiKey: '12345678'
+            collection: 'https://api.postman.com/collections?apikey=12345678',
+            postmanApiKey: '12345'
         }, function (err, summary) {
             expect(err).to.be.null;
             sinon.assert.calledOnce(request.get);
@@ -153,9 +205,10 @@ describe('newman.run postmanApiKey', function () {
 
             expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
 
-            expect(requestArg.url).to.equal('https://api.getpostman.com/collections?apikey=12345678');
+            expect(requestArg.url).to.equal('https://api.postman.com/collections');
 
-            expect(requestArg.headers).to.not.have.property('X-Api-Key');
+            expect(requestArg.headers).to.be.an('object')
+                .that.has.property('X-Api-Key', '12345678');
 
             expect(summary.run.failures).to.be.empty;
             expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
@@ -174,11 +227,11 @@ describe('newman.run postmanApiKey', function () {
 
             let requestArg = request.get.firstCall.args[0];
 
-            expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'json']);
 
             expect(requestArg.url).to.equal('https://example.com/collection.json');
 
-            expect(requestArg.headers).to.not.have.property('X-Api-Key');
+            expect(requestArg).to.not.have.property('headers');
 
             expect(summary.run.failures).to.be.empty;
             expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
@@ -188,29 +241,45 @@ describe('newman.run postmanApiKey', function () {
     });
 
     describe('read file', function () {
-        const UID = '1234-96771253-046f-4ad7-81f9-a2d3c433492b';
+        let outDir = join(__dirname, '..', '..', 'out'),
+            UID = '1234-96771253-046f-4ad7-81f9-a2d3c433492b',
+            ID = '96771253-046f-4ad7-81f9-a2d3c433492b';
 
-        beforeEach(function (done) {
-            fs.stat(UID, function (err) {
-                if (err) {
-                    return fs.writeFile(UID, JSON.stringify(COLLECTION), done);
-                }
+        beforeEach(function () {
+            sh.test('-d', outDir) && sh.rm('-rf', outDir);
+            sh.mkdir('-p', outDir);
+        });
+
+        afterEach(function () {
+            sh.rm('-rf', outDir);
+        });
+
+        it('should fetch from file having UID name', function (done) {
+            fs.writeFileSync(join(outDir, UID), JSON.stringify(COLLECTION));
+
+            newman.run({
+                collection: join(outDir, UID),
+                postmanApiKey: '12345678'
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                sinon.assert.notCalled(request.get);
+
+                expect(summary).to.be.an('object')
+                    .that.has.property('collection').to.be.an('object')
+                    .and.include({ id: 'C1', name: 'Collection' });
+
+                expect(summary.run.failures).to.be.empty;
+                expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
 
                 done();
             });
         });
 
-        afterEach(function (done) {
-            fs.stat(UID, function (err) {
-                if (err) { return done(); }
+        it('should fetch from file having ID name', function (done) {
+            fs.writeFileSync(join(outDir, ID), JSON.stringify(COLLECTION));
 
-                fs.unlink(UID, done);
-            });
-        });
-
-        it('should fetch from file having UID name', function (done) {
             newman.run({
-                collection: UID,
+                collection: join(outDir, ID),
                 postmanApiKey: '12345678'
             }, function (err, summary) {
                 expect(err).to.be.null;

--- a/test/unit/postman-resource.test.js
+++ b/test/unit/postman-resource.test.js
@@ -1,0 +1,237 @@
+let nock = require('nock'),
+    sinon = require('sinon'),
+    request = require('postman-request'),
+    liquidJSON = require('liquid-json'),
+    PostmanResource = require('../../lib/api').PostmanResource,
+    COLLECTION = {
+        id: 'C1',
+        name: 'Collection',
+        item: [{
+            id: 'ID1',
+            name: 'R1',
+            request: 'https://postman-echo.com/get'
+        }]
+    },
+    ENVIRONMENT = {
+        id: 'E1',
+        name: 'Environment',
+        values: [{
+            key: 'foo',
+            value: 'bar'
+        }]
+    },
+
+    POSTMAN_API_URL = 'https://api.postman.com',
+    SAMPLE_POSTMAN_UID = '1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
+    SAMPLE_POSTMAN_ID = '931c1484-fd1e-4ceb-81d0-2aa102ca8b5f';
+
+describe('PostmanResource class', function () {
+    let request_sandbox = sinon.createSandbox(),
+        responseCode, response;
+
+    before(function () {
+        nock(POSTMAN_API_URL)
+            .persist()
+            .get(/^\/collections\/.*/)
+            .reply(200, { collection: COLLECTION });
+
+        nock(POSTMAN_API_URL)
+            .persist()
+            .get(/^\/environments\/.*/)
+            .reply(() => {
+                return [responseCode, response];
+            });
+
+        nock(POSTMAN_API_URL)
+            .persist()
+            .put(/^\/collections\/.*/)
+            .reply(200, { collection: COLLECTION });
+
+        nock(POSTMAN_API_URL)
+            .persist()
+            .put(/^\/environments\/.*/)
+            .reply(() => {
+                return [responseCode, response];
+            });
+    });
+
+    after(function () {
+        nock.restore();
+    });
+
+    afterEach(function () {
+        request_sandbox.restore();
+    });
+
+    describe('get', function () {
+        beforeEach(function () {
+            // spy the `get` function
+            request_sandbox.spy(request, 'get');
+        });
+
+        it('should fetch a resource from its URL', function (done) {
+            let postmanCollection = new PostmanResource('collection', `${POSTMAN_API_URL}/collections/1234`, '1234');
+
+            postmanCollection.get((err, collection) => {
+                expect(err).to.be.null;
+                expect(collection).to.eql(COLLECTION);
+
+                request_sandbox.assert.calledOnce(request.get);
+
+                let requestArg = request.get.firstCall.args[0];
+
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+                expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/collections/1234`);
+                expect(requestArg.json).to.equal(true);
+                expect(requestArg.headers).to.be.an('object')
+                    .that.has.property('X-Api-Key', '1234');
+                done();
+            });
+        });
+
+        it('should fetch a resource from its ID', function (done) {
+            let postmanEnvironment = new PostmanResource('environment', SAMPLE_POSTMAN_ID, '1234');
+
+            responseCode = 200;
+            response = { environment: ENVIRONMENT };
+
+            postmanEnvironment.get((err, environment) => {
+                expect(err).to.be.null;
+                expect(environment).to.eql(ENVIRONMENT);
+
+                request_sandbox.assert.calledOnce(request.get);
+
+                let requestArg = request.get.firstCall.args[0];
+
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+                expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/environments/${SAMPLE_POSTMAN_ID}`);
+                expect(requestArg.json).to.equal(true);
+                expect(requestArg.headers).to.be.an('object')
+                    .that.has.property('X-Api-Key', '1234');
+                done();
+            });
+        });
+
+        it('should pass the error from response body if the response code is not of the form 2xx', function (done) {
+            let postmanEnvironment = new PostmanResource('environment',
+                `https://api.postman.com/environments/${SAMPLE_POSTMAN_UID}`, '1234');
+
+            responseCode = 401;
+            response = {
+                error: {
+                    message: 'Invalid API Key. Every request requires a valid API Key to be sent.'
+                }
+            };
+
+            postmanEnvironment.get((err) => {
+                expect(err).not.to.be.null;
+                expect(err.message).to.contain(response.error.message);
+                expect(err.help, 'help should contain the type of operation done').to.contain('fetch');
+
+                request_sandbox.assert.calledOnce(request.get);
+
+                let requestArg = request.get.firstCall.args[0];
+
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers', 'json']);
+                expect(requestArg.url).to.equal(`https://api.postman.com/environments/${SAMPLE_POSTMAN_UID}`);
+                expect(requestArg.json).to.equal(true);
+                expect(requestArg.headers).to.be.an('object')
+                    .that.has.property('X-Api-Key', '1234');
+
+                done();
+            });
+        });
+    });
+
+    describe('update', function () {
+        beforeEach(function () {
+            // spy the `put` function
+            request_sandbox.spy(request, 'put');
+        });
+
+        it('should update a resource from its URL', function (done) {
+            let postmanEnvironment = new PostmanResource('environment',
+                `https://api.postman.com/environments/${SAMPLE_POSTMAN_UID}`, '123456');
+
+            responseCode = 200;
+
+            postmanEnvironment.update(ENVIRONMENT, (err) => {
+                expect(err).to.be.null;
+
+                request_sandbox.assert.calledOnce(request.put);
+
+                let requestArg = request.put.firstCall.args[0],
+                    body;
+
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers', 'body']);
+                expect(requestArg.url).to.equal(`https://api.postman.com/environments/${SAMPLE_POSTMAN_UID}`);
+                expect(requestArg.headers).to.be.an('object')
+                    .that.has.property('Content-Type', 'application/json');
+                expect(requestArg.headers['X-Api-Key']).to.equal('123456');
+
+                body = liquidJSON.parse(requestArg.body.trim());
+                expect(body).to.eql({ environment: ENVIRONMENT });
+
+                done();
+            });
+        });
+
+        it('should update a resource from its UID', function (done) {
+            let postmanCollection = new PostmanResource('collection', SAMPLE_POSTMAN_UID, '1234');
+
+            postmanCollection.update(COLLECTION, (err) => {
+                expect(err).to.be.null;
+
+                request_sandbox.assert.calledOnce(request.put);
+
+                let requestArg = request.put.firstCall.args[0],
+                    body;
+
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers', 'body']);
+                expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/collections/${SAMPLE_POSTMAN_UID}`);
+                expect(requestArg.headers).to.be.an('object')
+                    .that.has.property('Content-Type', 'application/json');
+                expect(requestArg.headers['X-Api-Key']).to.equal('1234');
+
+                body = liquidJSON.parse(requestArg.body.trim());
+                expect(body).to.eql({ collection: COLLECTION });
+
+                done();
+            });
+        });
+
+        it('should pass the error from response body if the response code is not of the form 2xx', function (done) {
+            let postmanEnvironment = new PostmanResource('environment',
+                `https://api.postman.com/environments/${SAMPLE_POSTMAN_UID}`, '1234');
+
+            responseCode = 401;
+            response = {
+                error: {
+                    message: 'Invalid API Key. Every request requires a valid API Key to be sent.'
+                }
+            };
+
+            postmanEnvironment.update(ENVIRONMENT, (err) => {
+                expect(err).not.to.be.null;
+                expect(err.message).to.contain(response.error.message);
+                expect(err.help, 'help should contain the type of operation done').to.contain('sync');
+
+                request_sandbox.assert.calledOnce(request.put);
+
+                let requestArg = request.put.firstCall.args[0],
+                    body;
+
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers', 'body']);
+                expect(requestArg.url).to.equal(`https://api.postman.com/environments/${SAMPLE_POSTMAN_UID}`);
+                expect(requestArg.headers).to.be.an('object')
+                    .that.has.property('Content-Type', 'application/json');
+                expect(requestArg.headers['X-Api-Key']).to.equal('1234');
+
+                body = liquidJSON.parse(requestArg.body.trim());
+                expect(body).to.eql({ environment: ENVIRONMENT });
+
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
### What does this PR do?
This PR adds API module to perform different operations using Postman APIs. It consists of a class representing a resource in Postman-Cloud like a collection or an environment. All the operations on a given Postman resource can be then done using member functions of the class like `get()`, `update()` etc.

### Implementation Details
- The module is integrated with `run` to fetch Postman collections and environments. 
- Once initialized before loading run-options, fetching of these resources can be done using the `get()` member function of the corresponding class instance.
- Each class instance also stores authentication details like postman-api-key. This apikey is either the apikey from the query-param of the URL or the session-api-key.

### Testing
- Unit tests for the class are added.
- Library tests on postman-api-key option are updated to address the changes.