### PR TITLE
Add sync-environment option for run command

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -38,6 +38,8 @@ program
         util.cast.csvParse)
     .option('-n, --iteration-count <n>', 'Define the number of iterations to run.', util.cast.integer)
     .option('-d, --iteration-data <path>', 'Specify a data file to use for iterations (either json or csv).')
+    .option('--sync-environment', 'Update the corresponding environment in Postman-Cloud with the ' +
+        'resultant environment')
     .option('--export-environment <path>', 'Exports the environment to a file after completing the run.')
     .option('--export-globals <path>', 'Specify an output file to dump Globals before exiting.')
     .option('--export-collection <path>', 'Specify an output file to save the executed collection')

--- a/lib/api/postman-resource.js
+++ b/lib/api/postman-resource.js
@@ -59,9 +59,8 @@ let _ = require('lodash'),
                 'X-Api-Key': apikey
             },
             requestOptions = {
-                url: url,
-                headers: headers,
-                json: true
+                url,
+                headers
             },
             requestMethod = REQUEST_METHOD_MAP[operation];
 

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -1,5 +1,5 @@
 var _ = require('lodash'),
-    asyncEach = require('async/each'),
+    async = require('async'),
     sdk = require('postman-collection'),
     runtime = require('postman-runtime'),
     request = require('postman-request'),
@@ -64,7 +64,15 @@ var _ = require('lodash'),
      * @private
      * @type {String}
      */
-    MULTIENTRY_LOOKUP_STRATEGY = 'multipleIdOrName';
+    MULTIENTRY_LOOKUP_STRATEGY = 'multipleIdOrName',
+
+    /**
+     * The message displayed when the specified environment could not be synced
+     *
+     * @private
+     * @type {String}
+     */
+    ENVIRONMENT_SYNC_ERROR_MESSAGE = 'could not sync environment';
 
 /**
  * Runs the collection, with all the provided options, returning an EventEmitter.
@@ -80,6 +88,8 @@ var _ = require('lodash'),
  * @param {String} options.exportGlobals - The relative path to export the globals file from the current run to.
  * @param {String} options.exportEnvironment - The relative path to export the environment file from the current run to.
  * @param {String} options.exportCollection - The relative path to export the collection from the current run to.
+ * @param {Boolean} options.syncEnvironment - Indicates if the corresponding environment in the Cloud has to be updated
+ * after the run.
  * @param {String} options.postmanApiKey - The Postman API Key for fetching/updating remote resources.
  * @param {Function} callback - The callback function invoked to mark the end of the collection run.
  * @returns {EventEmitter} - An EventEmitter instance with done and error event attachments.
@@ -98,7 +108,7 @@ module.exports = function (options, callback) {
         entrypoint;
 
     // get the configuration from various sources
-    getOptions(options, function (err, options) {
+    getOptions(options, function (err, options, postmanResources) {
         if (err) {
             return callback(err);
         }
@@ -318,7 +328,34 @@ module.exports = function (options, callback) {
                         });
                     });
 
-                    asyncEach(emitter.exports, exportFile, function (err) {
+                    // run all the file-exports and cloud-syncs parallelly
+                    async.parallel([
+                        (next) => {
+                            async.each(emitter.exports, exportFile, next);
+                        },
+
+                        // sync the environment in the cloud if chosen to
+                        (next) => {
+                            if (!options.syncEnvironment) { return next(null); }
+
+                            if (!postmanResources.environment) {
+                                return callback(ENVIRONMENT_SYNC_ERROR_MESSAGE +
+                                    '\n   the environment is not a Postman Resource');
+                            }
+
+                            return postmanResources.environment.update(emitter.summary.environment, (err) => {
+                                if (err) {
+                                    // format the error to indicate its origin
+                                    err = ENVIRONMENT_SYNC_ERROR_MESSAGE +
+                                        (err.help ? `\n  ${err.help}` : '') +
+                                        `\n  ${err.message || err}`;
+                                }
+
+                                return next(err);
+                            });
+                        }
+
+                    ], (err) => {
                         // we now trigger actual done event which we had overridden
                         emitter.emit('done', err, emitter.summary);
                         callback(err, emitter.summary);

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -41,7 +41,7 @@ describe('newman.run postmanApiKey', function () {
     });
 
     after(function () {
-        nock.restore();
+        nock.cleanAll();
     });
 
     beforeEach(function () {
@@ -62,7 +62,7 @@ describe('newman.run postmanApiKey', function () {
 
             let requestArg = request.get.firstCall.args[0];
 
-            expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
 
             expect(requestArg.url)
                 .to.equal('https://api.postman.com/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
@@ -91,7 +91,7 @@ describe('newman.run postmanApiKey', function () {
 
             let requestArg = request.get.firstCall.args[0];
 
-            expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
 
             expect(requestArg.url)
                 .to.equal('https://api.postman.com/collections/588025f9-2497-46f7-b849-47f58b865807');
@@ -121,7 +121,7 @@ describe('newman.run postmanApiKey', function () {
 
             let requestArg = request.get.firstCall.args[0];
 
-            expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
 
             expect(requestArg.url)
                 .to.equal('https://api.postman.com/environments/1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f');
@@ -203,7 +203,7 @@ describe('newman.run postmanApiKey', function () {
 
             let requestArg = request.get.firstCall.args[0];
 
-            expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
 
             expect(requestArg.url).to.equal('https://api.postman.com/collections');
 

--- a/test/library/sync-environment.test.js
+++ b/test/library/sync-environment.test.js
@@ -1,0 +1,163 @@
+let nock = require('nock'),
+    sinon = require('sinon'),
+    liquidJSON = require('liquid-json'),
+    request = require('postman-request'),
+    POSTMAN_API_URL = 'https://api.postman.com',
+
+    SAMPLE_ENVIRONMENT_UID = '1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
+    SAMPLE_ENVIRONMENT_ID = '931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
+
+    SAMPLE_ENVIRONMENT_URL =
+        'https://api.postman.com/environments/931c1484-fd1e-4ceb-81d0-2aa102ca8b5f?apikey=1234',
+
+    SAMPLE_ENVIRONMENT = {
+        id: '1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
+        name: 'Environment',
+        values: [{
+            key: 'foo',
+            type: 'any',
+            value: 'bar'
+        }]
+    },
+
+    SAMPLE_COLLECTION = {
+        id: 'C1',
+        name: 'Collection C1',
+        item: []
+    };
+
+describe('sync-environment', function () {
+    before(function () {
+        nock('https://api.postman.com')
+            .persist()
+            .put(/^\/environments/)
+            .query(true)
+            .reply(200, { environment: SAMPLE_ENVIRONMENT });
+
+        nock('https://api.postman.com')
+            .persist()
+            .get(/^\/environments/)
+            .query(true)
+            .reply(200, { environment: SAMPLE_ENVIRONMENT });
+    });
+
+    after(function () {
+        nock.cleanAll();
+    });
+
+    beforeEach(function () {
+        // spy the `put` function
+        sinon.spy(request, 'put');
+    });
+
+    afterEach(function () {
+        request.put.restore();
+    });
+
+    it('should work with an URL with apikey query param', function (done) {
+        newman.run({
+            collection: SAMPLE_COLLECTION,
+            environment: SAMPLE_ENVIRONMENT_URL,
+            postmanApiKey: '123456',
+            syncEnvironment: true
+        }, (err) => {
+            expect(err).to.be.null;
+            sinon.assert.calledOnce(request.put);
+
+            let requestArg = request.put.firstCall.args[0],
+                body;
+
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers', 'body']);
+            expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/environments/931c1484-fd1e-4ceb-81d0-2aa102ca8b5f`);
+            expect(requestArg.headers).to.be.an('object')
+                .that.has.property('Content-Type', 'application/json');
+            expect(requestArg.headers['X-Api-Key']).to.equal('1234');
+
+            body = liquidJSON.parse(requestArg.body.trim());
+            expect(body).to.eql({ environment: SAMPLE_ENVIRONMENT });
+
+            done();
+        });
+    });
+
+    it('should work with environment ID', function (done) {
+        newman.run({
+            collection: SAMPLE_COLLECTION,
+            environment: SAMPLE_ENVIRONMENT_ID,
+            postmanApiKey: '123456',
+            syncEnvironment: true
+        }, (err) => {
+            expect(err).to.be.null;
+            sinon.assert.calledOnce(request.put);
+
+            let requestArg = request.put.firstCall.args[0],
+                body;
+
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers', 'body']);
+            expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/environments/${SAMPLE_ENVIRONMENT_ID}`);
+            expect(requestArg.headers).to.be.an('object')
+                .that.has.property('Content-Type', 'application/json');
+            expect(requestArg.headers['X-Api-Key']).to.equal('123456');
+
+            body = liquidJSON.parse(requestArg.body.trim());
+            expect(body).to.eql({ environment: SAMPLE_ENVIRONMENT });
+
+            done();
+        });
+    });
+
+    it('should work with environment UID', function (done) {
+        newman.run({
+            collection: SAMPLE_COLLECTION,
+            environment: SAMPLE_ENVIRONMENT_UID,
+            postmanApiKey: '123456',
+            syncEnvironment: true
+        }, (err) => {
+            expect(err).to.be.null;
+            sinon.assert.calledOnce(request.put);
+
+            let requestArg = request.put.firstCall.args[0],
+                body;
+
+            expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers', 'body']);
+            expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/environments/${SAMPLE_ENVIRONMENT_UID}`);
+            expect(requestArg.headers).to.be.an('object')
+                .that.has.property('Content-Type', 'application/json');
+            expect(requestArg.headers['X-Api-Key']).to.equal('123456');
+
+            body = liquidJSON.parse(requestArg.body.trim());
+            expect(body).to.eql({ environment: SAMPLE_ENVIRONMENT });
+
+            done();
+        });
+    });
+
+    it('should not sync the environment by default', function (done) {
+        newman.run({
+            collection: SAMPLE_COLLECTION,
+            environment: SAMPLE_ENVIRONMENT_UID,
+            postmanApiKey: '123456'
+        }, (err) => {
+            expect(err).to.be.null;
+            sinon.assert.notCalled(request.put);
+
+            done();
+        });
+    });
+
+    it('should return an error if the environment doesn\'t represent a Postman resource', function (done) {
+        newman.run({
+            collection: SAMPLE_COLLECTION,
+            environment: SAMPLE_ENVIRONMENT,
+            postmanApiKey: '123456',
+            syncEnvironment: true
+        }, (err) => {
+            expect(err).to.not.be.null;
+            expect(err, 'should indicate the cause of error').to.contain('could not sync environment');
+
+            sinon.assert.notCalled(request.put);
+
+            done();
+        });
+    });
+});

--- a/test/unit/postman-resource.test.js
+++ b/test/unit/postman-resource.test.js
@@ -85,9 +85,8 @@ describe('PostmanResource class', function () {
 
                 let requestArg = request.get.firstCall.args[0];
 
-                expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
                 expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/collections/1234`);
-                expect(requestArg.json).to.equal(true);
                 expect(requestArg.headers).to.be.an('object')
                     .that.has.property('X-Api-Key', '1234');
                 done();
@@ -108,9 +107,8 @@ describe('PostmanResource class', function () {
 
                 let requestArg = request.get.firstCall.args[0];
 
-                expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
                 expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/environments/${SAMPLE_POSTMAN_ID}`);
-                expect(requestArg.json).to.equal(true);
                 expect(requestArg.headers).to.be.an('object')
                     .that.has.property('X-Api-Key', '1234');
                 done();
@@ -137,9 +135,8 @@ describe('PostmanResource class', function () {
 
                 let requestArg = request.get.firstCall.args[0];
 
-                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers', 'json']);
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
                 expect(requestArg.url).to.equal(`https://api.postman.com/environments/${SAMPLE_POSTMAN_UID}`);
-                expect(requestArg.json).to.equal(true);
                 expect(requestArg.headers).to.be.an('object')
                     .that.has.property('X-Api-Key', '1234');
 
@@ -158,9 +155,8 @@ describe('PostmanResource class', function () {
 
                 let requestArg = request.get.firstCall.args[0];
 
-                expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
                 expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/collections/1234`);
-                expect(requestArg.json).to.equal(true);
                 expect(requestArg.headers).to.be.an('object')
                     .that.has.property('X-Api-Key', '1234');
 
@@ -285,9 +281,8 @@ describe('PostmanResource class', function () {
 
                 let requestArg = request.delete.firstCall.args[0];
 
-                expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
+                expect(requestArg).to.be.an('object').and.include.keys(['url', 'headers']);
                 expect(requestArg.url).to.equal(`${POSTMAN_API_URL}/collections/${SAMPLE_POSTMAN_ID}`);
-                expect(requestArg.json).to.equal(true);
                 expect(requestArg.headers).to.be.an('object')
                     .that.has.property('X-Api-Key', '1234');
                 done();


### PR DESCRIPTION
### What does this PR do?
This PR adds an option named `sync-environment` for the run command. The option is used to update the environment in Postman-Cloud with the resultant environment of the run, given it represents a Postman Cloud resource. The option can also be used with the library run function.

### Usage
``` console
$ newman run test_collection -e test_environment --sync-environment
```
Here the `test_environment` should either be a Postman API URL, a Postman-UID, or a Postman-ID of the environment.

### Implementation
The update is done using the `update` method of the PostmanResource Class.

### Testing
The library tests for the option are added.