### PR TITLE
Improve login user experience

### DIFF
--- a/.nycrc.js
+++ b/.nycrc.js
@@ -8,10 +8,10 @@ function configOverrides (testType) {
     switch (testType) {
         case 'cli':
             return {
-                statements: 80,
-                branches: 65,
-                functions: 85,
-                lines: 80
+                statements: 82,
+                branches: 67,
+                functions: 86,
+                lines: 83
             };
         case 'integration':
             return {
@@ -19,23 +19,24 @@ function configOverrides (testType) {
                 branches: 20,
                 functions: 35,
                 lines: 35,
+                // since integration tests only test collection-runs
                 exclude: ['lib/crypt.js', 'lib/login', 'lib/config', 'lib/logout']
             };
         case 'library':
             return {
-                statements: 55,
+                statements: 57,
                 branches: 40,
-                functions: 54,
-                lines: 55,
+                functions: 56,
+                lines: 57,
+                // since these features are only for cli-run
                 exclude: ['lib/crypt.js', 'lib/login', 'lib/config', 'lib/logout']
             };
         case 'unit':
             return {
-                statements: 70,
-                branches: 55,
-                functions: 75,
-                lines: 75,
-                exclude: ['lib/logout']
+                statements: 72,
+                branches: 56,
+                functions: 74,
+                lines: 73
             };
         default:
             return {}

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -14,6 +14,7 @@ const _ = require('lodash'),
     logout = require('../lib/logout'),
 
     LOGIN_SUCCESS_MESSAGE = 'API Key added successfully.',
+    LOGOUT_SUCCESS_MESSAGE = 'API Key deleted successfully.',
     RUN_COMMAND = 'run';
 
 program
@@ -132,7 +133,7 @@ program
     });
 
 program.command('logout')
-    .description('Dereference an API-Key from its alias.')
+    .description('Delete a stored Postman API Key.')
     .action(() => {
         logout((err) => {
             if (err) {
@@ -140,6 +141,8 @@ program.command('logout')
                 err.help && console.error(err.help);
                 process.exit(1);
             }
+
+            console.info(LOGOUT_SUCCESS_MESSAGE);
         });
     });
 

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -13,6 +13,7 @@ const _ = require('lodash'),
     config = require('../lib/config'),
     logout = require('../lib/logout'),
 
+    LOGIN_SUCCESS_MESSAGE = 'API Key added successfully.',
     RUN_COMMAND = 'run';
 
 program
@@ -117,7 +118,7 @@ program
 
 program
     .command('login')
-    .description('Store the API-Key along with an alias to it, to reference it in the following commands.')
+    .description('Store Postman API Key to access Postman-Cloud resources in the following commands.')
     .action(() => {
         login((err) => {
             if (err) {
@@ -125,6 +126,8 @@ program
                 err.help && console.error(err.help);
                 process.exit(1);
             }
+
+            console.info(LOGIN_SUCCESS_MESSAGE);
         });
     });
 

--- a/lib/login/index.js
+++ b/lib/login/index.js
@@ -2,9 +2,13 @@ const _ = require('lodash'),
     waterfall = require('async/waterfall'),
     prompts = require('prompts'),
     rcfile = require('../config/rc-file'),
+    print = require('../print'),
     util = require('../util'),
     crypt = require('../crypt'),
 
+    DEFAULT = 'default',
+
+    USER_ACTION = 'userAction',
     ALIAS = 'alias',
     OVERRIDE_PERMISSION = 'overridePermission',
     POSTMAN_API_KEY = 'postmanApiKey',
@@ -12,14 +16,24 @@ const _ = require('lodash'),
     PASSKEY = 'passkey',
 
     INPUT_PROMPTS = {
+        userAction: 'Default authentication details already exist.\nChoose an option to continue',
+        userActionChoices: [
+            { title: 'Override it', value: 'override' },
+            { title: 'Store as an alias', value: 'new_alias' },
+            { title: 'Abort', value: 'abort' }
+        ],
         alias: 'Alias',
         overridePermission: 'The alias already exists.\nDo you want to override it?',
-        postmanApiKey: 'Postman API-Key',
+        postmanApiKey: 'Postman API Key',
         encrypted: 'Do you want to have a passkey for authentication?',
         passkey: 'Passkey'
     },
 
-    SUCCESS_MESSAGE = 'API-Key added successfully.',
+    // Regular expression for Postman API Key in different versions
+    V1_API_KEY_REGEX = /^[a-f0-9]{32}$/,
+    V2_API_KEY_REGEX = /^(PMAK-[a-f0-9]{24}-[a-f0-9]{34})$/,
+
+    INVALID_API_KEY = 'Invalid Postman API Key.',
     ABORT_MESSAGE = 'Login aborted.',
     INVALID_INPUT = 'Invalid input.';
 
@@ -40,6 +54,7 @@ module.exports = (callback) => {
          * @param {Object} opts - Options related to the input
          * @param {Boolean} opts.type - The type of the input
          * @param {Boolean} opts.boolean - Indicates if the input field is boolean
+         * @param {String[]} opts.choices - Input choices to be displayed
          * @param {String} opts.initial - Default value of the field, if any
          * @param {Function} cb - The callback to be invoked after storing the input
          */
@@ -47,7 +62,8 @@ module.exports = (callback) => {
             let promptOptions = {
                 type: opts.type,
                 name: 'response',
-                message: INPUT_PROMPTS[field]
+                hint: ' ', // if not specified, the prompt shows the default hint
+                message: (INPUT_PROMPTS[field])
             };
 
             if (opts.boolean) {
@@ -58,20 +74,36 @@ module.exports = (callback) => {
                 };
             }
 
-            opts.initial && (promptOptions.initial = opts.initial);
+            if (opts.choices) {
+                promptOptions = {
+                    ...promptOptions,
+                    choices: opts.choices
+                };
+            }
+
+            !_.isUndefined(opts.initial) && (promptOptions.initial = opts.initial);
 
             util.signal(field); // signal the parent process(if any) for input
-            const { response } = await prompts(promptOptions);
+            var { response } = await prompts(promptOptions);
+
+            if (_.isString(response) && field !== PASSKEY) {
+                // trim all the string inputs except for the passkey
+                response = response.trim();
+            }
 
             _.set(options, field, response);
 
-            // exit the program if the user-input was empty
+            // exit the program if Ctrl-C is pressed
             if (_.isUndefined(options[field])) {
-                console.error(INVALID_INPUT);
                 process.exit(1);
             }
 
-            cb();
+            // pass the error if the input is empty
+            if (options[field] === '') {
+                return cb(INVALID_INPUT);
+            }
+
+            return cb(null);
         };
 
     waterfall([
@@ -79,19 +111,53 @@ module.exports = (callback) => {
         // this is done in the beginning to prevent errors caused by file-load in between the login-process
         rcfile.load,
 
-        // get the api-key-alias
+        // determine the action to be performed
         (data, next) => {
             fileData = data; // store the file-data for future use
 
-            return getData(ALIAS, { type: 'text', initial: 'default' }, next);
+            let defaultAliasDetails = _.has(fileData, 'login._profiles') &&
+                _.filter(fileData.login._profiles, [ALIAS, DEFAULT]); // get the data related to `default` alias
+
+            // store the input details under 'default' alias if no data is already present under it
+            if (_.isEmpty(defaultAliasDetails)) {
+                options.alias = DEFAULT;
+
+                return next(null);
+            }
+
+            // if the `default` alias already exists, determine the action to be performed
+            return getData(USER_ACTION,
+                { type: 'select', choices: INPUT_PROMPTS.userActionChoices }, () => {
+                    if (options.userAction === 'abort') {
+                        process.exit(1);
+                    }
+
+                    print('\n');
+
+                    if (options.userAction === 'override') {
+                        options.alias = DEFAULT;
+
+                        // delete the old data related to the alias
+                        fileData.login._profiles = _.reject(fileData.login._profiles, [ALIAS, DEFAULT]);
+                    }
+
+                    return next(null);
+                });
+        },
+
+        // get the api-key-alias, if not set already
+        (next) => {
+            if (options.alias) {
+                return next(null);
+            }
+
+            return getData(ALIAS, { type: 'text' }, next);
         },
 
         // delete the existing data about the alias(if any) with user consent
         (next) => {
-            let previousData;
-
-            _.has(fileData, 'login._profiles') &&
-                (previousData = _.filter(fileData.login._profiles, [ALIAS, options.alias]));
+            let previousData = _.has(fileData, 'login._profiles') &&
+                _.filter(fileData.login._profiles, [ALIAS, options.alias]);
 
             if (_.isEmpty(previousData)) {
                 return next(null);
@@ -111,7 +177,18 @@ module.exports = (callback) => {
         },
 
         // get the postman-api-key
-        (next) => { return getData(POSTMAN_API_KEY, { type: 'text' }, next); },
+        (next) => {
+            return getData(POSTMAN_API_KEY, { type: 'text' }, (err) => {
+                if (err) { return next(err); }
+
+                // validate the API Key format
+                if (!V1_API_KEY_REGEX.test(options.postmanApiKey) && !V2_API_KEY_REGEX.test(options.postmanApiKey)) {
+                    return next(INVALID_API_KEY);
+                }
+
+                return next(null);
+            });
+        },
 
         // get the `encrypted` option
         (next) => { return getData(ENCRYPTED, { type: 'toggle', boolean: true, initial: false }, next); },
@@ -120,7 +197,7 @@ module.exports = (callback) => {
         (next) => {
             if (!options.encrypted) { return next(null); }
 
-            return getData(PASSKEY, { type: 'invisible' }, next);
+            return getData(PASSKEY, { type: 'password' }, next);
         },
 
         // encrypt/encode the API-Key and push the necessary fields into the `fileData`
@@ -140,13 +217,5 @@ module.exports = (callback) => {
         // update the data in the config file
         rcfile.store
 
-    ], (err) => {
-        if (err) {
-            return callback(err);
-        }
-
-        console.info(SUCCESS_MESSAGE);
-
-        return callback(null);
-    });
+    ], callback);
 };

--- a/lib/logout/index.js
+++ b/lib/logout/index.js
@@ -3,12 +3,21 @@ const _ = require('lodash'),
     prompts = require('prompts'),
     rcfile = require('../config/rc-file'),
     env = require('../config/process-env'),
+    util = require('../util'),
 
     ALIAS = 'alias',
+    DEFAULT = 'default',
+    USER_PERMISSION = 'userPermission',
+
+    LOGOUT_CONFIRMATION = (alias) => {
+        return alias === DEFAULT ? 'Are you sure you want to delete the default API Key?' :
+            `Are you sure you want to delete API Key with alias \`${alias}\`?`;
+    },
 
     ALIAS_INPUT_PROMPT = 'Select the alias',
-    NO_ALIAS_AVAILABLE = 'No aliases are available.',
-    SUCCESS_MESSAGE = (alias) => { return `${alias} logged out successfully.`; },
+    ABORT_MESSAGE = 'Logout aborted.',
+    NO_APIKEY_AVAILABLE = 'No API Key available.' +
+        '\n   Use the login command to store an API Key.',
     ALIAS_NOT_PRESENT = 'Alias not present.';
 
 /**
@@ -46,7 +55,7 @@ module.exports = (callback) => {
             fileData.login && (profiles = fileData.login._profiles);
 
             if (_.isEmpty(profiles)) {
-                return next(NO_ALIAS_AVAILABLE);
+                return next(NO_APIKEY_AVAILABLE);
             }
 
             if (profiles.length === 1) {
@@ -67,6 +76,7 @@ module.exports = (callback) => {
             [initialProfile] = _.filter(profiles, [ALIAS, sessionAlias]);
             initialProfile && (promptOptions.initial = initialProfile.alias);
 
+            util.signal(ALIAS);
             prompts(promptOptions)
                 .then((response) => {
                     // on pressing ctrl-c
@@ -86,6 +96,33 @@ module.exports = (callback) => {
                 .catch(next);
         },
 
+        (next) => {
+            let promptOptions = {
+                type: 'toggle',
+                name: USER_PERMISSION,
+                message: LOGOUT_CONFIRMATION(alias),
+                active: 'Yes',
+                inactive: 'No',
+                initial: true
+            };
+
+            util.signal(USER_PERMISSION);
+            prompts(promptOptions)
+                .then((response) => {
+                    // on pressing ctrl-c
+                    if (!_.has(response, USER_PERMISSION)) {
+                        process.exit(1);
+                    }
+
+                    if (!response.userPermission) {
+                        return next(ABORT_MESSAGE);
+                    }
+
+                    return next(null);
+                })
+                .catch(next);
+        },
+
         // delete the data related to the alias selected
         (next) => {
             fileData.login._profiles = _.reject(fileData.login._profiles, [ALIAS, alias]);
@@ -96,13 +133,5 @@ module.exports = (callback) => {
         // write the edited file data back
         rcfile.store
 
-    ], (err) => {
-        if (err) {
-            return callback(err);
-        }
-
-        console.info(SUCCESS_MESSAGE(alias));
-
-        return callback(null);
-    });
+    ], callback);
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,6 +6,8 @@ var fs = require('fs'),
     prettyms = require('pretty-ms'),
     liquidJSON = require('liquid-json'),
     request = require('postman-request'),
+    colors = require('colors/safe'),
+    print = require('./print'),
     prompts = require('prompts'),
 
     util,
@@ -282,21 +284,25 @@ util = {
             return callback(null, postmanApiKey);
         }
 
-        console.info(`Using alias: ${postmanApiKey.alias}`);
+        print(colors.gray('\nAuthenticating using stored API Key' +
+            (postmanApiKey.alias === 'default' ? '\n' : ` with alias \`${postmanApiKey.alias}\`\n`)));
 
         // decode the API-Key if it is stored after encoding
         if (!postmanApiKey.encrypted) {
             postmanApiKey = crypt.decode(postmanApiKey.postmanApiKey);
+            print('\n'); // pad the earlier message
 
             return callback(null, postmanApiKey);
         }
 
         // prompt the user for a passkey to decrypt the API Key using it
         var { passkey } = await prompts({
-            type: 'invisible',
+            type: 'password',
             name: 'passkey',
             message: PASSKEY_INPUT_PROMPT
         });
+
+        print('\n');
 
         if (!passkey) {
             return callback(INVALID_INPUT);

--- a/test/cli/logout.test.js
+++ b/test/cli/logout.test.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-process-env */
 const fs = require('fs'),
+    // eslint-disable-next-line security/detect-child-process
+    child = require('child_process'),
     liquidJSON = require('liquid-json'),
     sh = require('shelljs'),
     join = require('path').join,
@@ -7,34 +9,61 @@ const fs = require('fs'),
     DEFAULT = 'default',
     TEST_ALIAS = 'testalias',
 
-    DOWN_ARROW = '\u001b[B',
     CARRIAGE_RETURN = '\r',
+    LEFT_ARROW = '\u001b[D',
 
+    SUCCESS_MESSAGE = 'API Key deleted successfully.',
     ALIAS_INPUT_PROMPT = 'Select the alias',
-    SUCCESS_MESSAGE = (alias) => { return `${alias} logged out successfully.`; },
-    NO_ALIAS_AVAILABLE = 'No aliases are available.';
+    ABORT_MESSAGE = 'Logout aborted.',
+    NO_APIKEY_AVAILABLE = 'No API Key available.' +
+        '\n   Use the login command to store an API Key.';
 
 describe('Logout command', function () {
     let outDir = join(__dirname, '..', '..', 'out'),
         configDir = join(outDir, '.postman'),
         rcFile = join(configDir, 'newmanrc'),
-        isWin = (/^win/).test(process.platform),
-        homeDir = process.env[isWin ? 'userprofile' : 'HOME'],
-        proc;
+        proc,
+        stdout,
+        stderr,
 
-    before(function () {
-        // change the home directory to alter the location of the rc file
-        process.env[isWin ? 'userprofile' : 'HOME'] = outDir;
-    });
+        spawn = (responses) => {
+            let n_responses = 0; // the number of responses fed to the program
 
-    after(function () {
-        // update the home directory back to its original value
-        process.env[isWin ? 'userprofile' : 'HOME'] = homeDir;
-    });
+            proc = child.spawn('node', ['./bin/newman.js', 'logout'], {
+                stdio: ['pipe', 'pipe', 'pipe', 'ipc'] // to enable inter process communication through messages
+            });
+
+            proc.stdout.setEncoding('utf-8');
+            proc.stderr.setEncoding('utf-8');
+
+            // listen to prompt messages and feed the answers to the queries
+            proc.on('message', (prompt) => {
+                expect(responses).to.have.property(prompt);
+                proc.stdin.write(responses[prompt] + CARRIAGE_RETURN);
+
+                n_responses++;
+
+                // if the number of responses fed equals total number of responses specified, end the stream
+                // else the program doesn't exit
+                if (n_responses === Object.keys(responses).length) { proc.stdin.end(); }
+            });
+
+            proc.stdout.on('data', (data) => {
+                stdout += data;
+            });
+
+            proc.stderr.on('data', (data) => {
+                stderr += data;
+            });
+        };
 
     beforeEach(function () {
+        // clean up `outDir` which will be used to save the config file
         sh.test('-d', outDir) && sh.rm('-rf', outDir);
         sh.mkdir('-p', outDir);
+
+        stdout = '';
+        stderr = '';
     });
 
     afterEach(function () {
@@ -62,6 +91,9 @@ describe('Logout command', function () {
                     ]
                 }
             },
+            responses = {
+                userPermission: ''
+            },
             finalData = {
                 login: {
                     _profiles: []
@@ -71,10 +103,14 @@ describe('Logout command', function () {
         fs.mkdirSync(configDir);
         fs.writeFileSync(rcFile, JSON.stringify(initialData, null, 2), { mode: 0o600 });
 
-        proc = exec('node ./bin/newman.js logout', function (code, stdout, stderr) {
+        spawn(responses);
+
+        proc.on('close', (code) => {
             expect(code, 'should have exit code of 0').to.equal(0);
-            expect(stdout, 'should indicate the deleted alias').to.contain(SUCCESS_MESSAGE(TEST_ALIAS));
             expect(stderr).to.be.empty;
+            expect(stdout, 'should contain the confirmation message').to
+                .contain('Are you sure you want to delete API Key with alias `testalias`?');
+            expect(stdout, 'should contain the success message').to.contain(SUCCESS_MESSAGE);
 
             fs.readFile(rcFile, (err, data) => {
                 expect(err).to.be.null;
@@ -85,7 +121,40 @@ describe('Logout command', function () {
         });
     });
 
-    it('should show all the choices if there are more than one available', function (done) {
+    it('should not log out the alias if user doesn\'t give the confirmation', function (done) {
+        let initialData = {
+                login: {
+                    _profiles: [
+                        { alias: TEST_ALIAS }
+                    ]
+                }
+            },
+            responses = {
+                userPermission: LEFT_ARROW
+            },
+            finalData = initialData;
+
+        fs.mkdirSync(configDir);
+        fs.writeFileSync(rcFile, JSON.stringify(initialData, null, 2), { mode: 0o600 });
+
+        spawn(responses);
+
+        proc.on('close', (code) => {
+            expect(code, 'should have exit code of 1').to.equal(1);
+            expect(stderr).to.contain(ABORT_MESSAGE);
+            expect(stdout, 'should contain the confirmation message').to
+                .contain('Are you sure you want to delete API Key with alias `testalias`?');
+
+            fs.readFile(rcFile, (err, data) => {
+                expect(err).to.be.null;
+                data = liquidJSON.parse(data.toString());
+                expect(data).to.eql(finalData);
+                done();
+            });
+        });
+    });
+
+    it('should show all the choices if there are more than one aliases available', function (done) {
         let initialData = {
                 login: {
                     _profiles: [
@@ -94,10 +163,14 @@ describe('Logout command', function () {
                     ]
                 }
             },
+            responses = {
+                alias: DEFAULT,
+                userPermission: ''
+            },
             finalData = {
                 login: {
                     _profiles: [
-                        { alias: DEFAULT }
+                        { alias: TEST_ALIAS }
                     ]
                 }
             };
@@ -105,13 +178,16 @@ describe('Logout command', function () {
         fs.mkdirSync(configDir);
         fs.writeFileSync(rcFile, JSON.stringify(initialData, null, 2), { mode: 0o600 });
 
-        proc = exec('node ./bin/newman.js logout', function (code, stdout, stderr) {
+        spawn(responses);
+
+        proc.on('close', (code) => {
             expect(code, 'should have exit code of 0').to.equal(0);
             expect(stderr).to.be.empty;
             expect(stdout, 'should contain the prompt for alias input').to.contain(ALIAS_INPUT_PROMPT);
-            expect(stdout, 'should highlight the chosen option').to.contain(TEST_ALIAS);
-            expect(stdout, 'should not include \'default\' alias').to.contain(DEFAULT);
-            expect(stdout, 'should contain the success message').to.contain(SUCCESS_MESSAGE(TEST_ALIAS));
+            expect(stdout, 'should contain the chosen option').to.contain(DEFAULT);
+            expect(stdout, 'should contain the confirmation message').to
+                .contain('Are you sure you want to delete the default API Key?');
+            expect(stdout, 'should contain the success message').to.contain(SUCCESS_MESSAGE);
 
             fs.readFile(rcFile, (err, data) => {
                 expect(err).to.be.null;
@@ -120,16 +196,12 @@ describe('Logout command', function () {
                 done();
             });
         });
-
-        // go to the next option and press enter
-        proc.stdin.write(DOWN_ARROW + CARRIAGE_RETURN);
-        proc.stdin.end();
     });
 
-    it('should print an error if no aliases exist', function (done) {
+    it('should print an error if there are no stored API keys', function (done) {
         proc = exec('node ./bin/newman.js logout', function (code, _stdout, stderr) {
             expect(code, 'should have exit code of 1').to.equal(1);
-            expect(stderr, 'should display the error message').to.contain(NO_ALIAS_AVAILABLE);
+            expect(stderr, 'should display the error message').to.contain(NO_APIKEY_AVAILABLE);
             done();
         });
     });

--- a/test/cli/postman-api-key-alias.test.js
+++ b/test/cli/postman-api-key-alias.test.js
@@ -178,7 +178,8 @@ describe('postman-api-key-alias option and environment variable', function () {
             (code, stdout, stderr) => {
                 expect(code, 'should have exit code of 0').to.equal(0);
                 expect(stderr).to.be.empty;
-                expect((stdout.match(/default/g) || []).length, 'should indicate the alias only once').to.equal(1);
+                expect((stdout.match(/Authenticating using stored API Key/g) || []).length,
+                    'should indicate the API Key used').to.equal(1);
                 expect(stdout, 'should prompt for the passkey').to.contain(PASSKEY_PROMPT);
                 expect(stdout, 'should not include the passkey provided').to.not.contain(PASSKEY);
                 expect(stdout, 'should contain the name of the collection').to.contain(TEST_COLLECTION);
@@ -230,7 +231,8 @@ describe('postman-api-key-alias option and environment variable', function () {
                 (code, stdout, stderr) => {
                     expect(code, 'should have exit code of 0').to.equal(0);
                     expect(stderr).to.be.empty;
-                    expect(stdout, 'should indicate the alias used').to.contain(DEFAULT_ALIAS);
+                    expect(stdout, 'should indicate that the stored API Key is used')
+                        .to.contain('Authenticating using stored API Key');
                     expect(stdout, 'should contain the name of the collection').to.contain(TEST_COLLECTION);
                     done();
                 });


### PR DESCRIPTION
### What does this PR do?
This PR improves the user experience in dealing with stored API Keys. 

### Major Changes
1. The login command now assumes that the alias is `default` if there is no data regarding it already stored. This way the user doesn't have to bother about the internal workings of the command.
<img src="https://user-images.githubusercontent.com/43881774/91520415-df1b1a80-e912-11ea-8503-093af90e1ae3.gif" width="600">

2. If the `default` API Key already exists, the command will allow the user to either override it or create a new alias.
<img src="https://user-images.githubusercontent.com/43881774/91520359-ba26a780-e912-11ea-95a1-77e62110b19e.gif" width="600">

3. The logout command now gets user confirmation before deleting the API Key.
<img src="https://user-images.githubusercontent.com/43881774/91484295-9fc6dc80-e8c6-11ea-89e9-bec31d29acf7.gif" width="500">

### Minor Changes
1. Better messages and prompts.
2. Improvement in the coloring of prompt messages.
3. Validation of the input for API Key

### Testing
The CLI tests of the `login` command, `logout` command and `postman-api-key-alias` commands are updated.