### PR TITLE
feat: Adds envinfo command to list required information for submitting bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@ This issue reporting template should guide you to effectively report issues for 
 Version and environment information:
 -->
  1. Newman Version (can be found via `newman -v`):
- 2. OS details (type, version, and architecture):
+ 2. Please paste the output of `newman envinfo`:
  3. Are you using Newman as a library, or via the CLI?
  3. Did you encounter this recently, or has this bug always been there:
  4. Expected behaviour:

--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ For more details on [Reporters](#reporters) and writing your own [External Repor
 - `--verbose`<br />
   Show detailed information of collection run and each request sent.
 
+### `newman envinfo`
+Displays all system and envnironment related information required for submitting bug reports.
+
+
 ### SSL
 
 #### Client Certificates
@@ -347,7 +351,7 @@ newman.run({
         "_postman_exported_at": "2016-10-17T14:31:26.200Z",
         "_postman_exported_using": "Postman/4.8.0"
     },
-    globalVar: [ 
+    globalVar: [
         { "key":"glboalSecret", "value":"globalSecretValue" },
         { "key":"globalAnotherSecret", "value":`${process.env.GLOBAL_ANOTHER_SECRET}`}
     ],
@@ -367,7 +371,7 @@ newman.run({
         "_postman_exported_at": "2016-10-17T14:26:34.940Z",
         "_postman_exported_using": "Postman/4.8.0"
     },
-    envVar: [ 
+    envVar: [
         { "key":"secret", "value":"secretValue" },
         { "key":"anotherSecret", "value":`${process.env.ANOTHER_SECRET}`}
     ],

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -85,6 +85,14 @@ program
         });
     });
 
+// The `envinfo` command allows you to print system information required while reporting issues
+program.command('envinfo')
+    .description('Prints system and environment information required for reporting issues')
+    .action(() => {
+        newman.envinfo();
+    });
+
+
 program.on('--help', function () {
     console.info('\nTo get available options for a command:');
     console.info('  newman <command> -h');

--- a/lib/envinfo/index.js
+++ b/lib/envinfo/index.js
@@ -1,0 +1,30 @@
+var envinfo = require('envinfo'),
+    colors = require('colors/safe'),
+
+    print = require('../print');
+
+// sets theme for colors for console logging
+colors.setTheme({
+    log: 'white'
+});
+
+/**
+ * Module whose job is to print system and environment related information onto the terminal.
+ *
+ * @returns {*}
+ */
+
+module.exports = function () {
+    print.lf(colors.log('%s:'), 'Environment Info');
+
+    envinfo.run({
+        System: ['OS', 'CPU'],
+        Binaries: ['Node', 'Yarn', 'npm'],
+        Browsers: ['Chrome', 'Firefox', 'Safari'],
+        npmGlobalPackages: ['newman']
+    },
+    { json: false, showNotFound: true })
+        .then((env) => { return print.lf(colors.log(env)); })
+        .catch((err) => { return print.lf(colors.error(err)); });
+};
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-    run: require('./run')
+    run: require('./run'),
+    envinfo: require('./envinfo')
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1631,6 +1631,11 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
+    "envinfo": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
+      "integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA=="
+    },
     "es-abstract": {
       "version": "1.17.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "colors": "1.4.0",
     "commander": "6.1.0",
     "csv-parse": "4.12.0",
+    "envinfo": "^7.7.3",
     "eventemitter3": "4.0.7",
     "filesize": "6.1.0",
     "lodash": "4.17.20",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "colors": "1.4.0",
     "commander": "6.1.0",
     "csv-parse": "4.12.0",
-    "envinfo": "^7.7.3",
+    "envinfo": "7.7.3",
     "eventemitter3": "4.0.7",
     "filesize": "6.1.0",
     "lodash": "4.17.20",


### PR DESCRIPTION
resolves #2134 

This command will allow users to get all system and environment-related information onto the terminal. Then the user can copy-paste this info while raising the issue.