### PR TITLE
Fix do not store memory heavy objects in summary - instead give options

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -60,6 +60,7 @@ program
     .option('--ssl-extra-ca-certs <path>', 'Specify additionally trusted CA certificates (PEM)')
     .option('--cookie-jar <path>', 'Specify the path to a custom cookie jar (serialized tough-cookie JSON) ')
     .option('--export-cookie-jar <path>', 'Exports the cookie jar to a file after completing the run')
+    .option('--skip-execution-response', 'Skips addition of response to the execution report generated')
     .option('--verbose', 'Show detailed information of collection run and each request sent')
     .action((collection, command) => {
         let options = util.commanderToObject(command),

--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -39,6 +39,16 @@ RunSummary = function RunSummary (emitter, options) {
         globals: _.get(options, 'globals'),
 
         /**
+         * Holds information related to the reporters specified.
+         */
+        reporters: _.isString(options.reporters) ? [options.reporters] : options.reporters,
+
+        /**
+         * Holds information related to skip addition of response to the execution report generated.
+         */
+        skipExecutionResponse: _.get(options, 'skipExecutionResponse'),
+
+        /**
          * Holds information related to the run.
          */
         run: {
@@ -223,14 +233,22 @@ _.assign(RunSummary, {
         emitter.on('request', function (err, o) {
             if (!_.get(o, 'cursor.ref')) { return; }
 
-            var execution = cache[o.cursor.ref] = (cache[o.cursor.ref] || {});
+            var execution = cache[o.cursor.ref] = (cache[o.cursor.ref] || {}),
+                executionResponse = {
+                    cursor: o.cursor,
+                    request: o.request,
+                    response: o.response,
+                    id: _.get(o, 'item.id')
+                };
 
-            executions.push(_.assignIn(execution, {
-                cursor: o.cursor,
-                request: o.request,
-                response: o.response,
-                id: _.get(o, 'item.id')
-            }, err && {
+            // check if skipExecutionResponse set in options or if cli is the only reporter specified, we do
+            // not include executionResponse as part of executions summary
+            if (summary.skipExecutionResponse || (_.isArray(summary.reporters) &&
+                summary.reporters.length === 1 && (summary.reporters).includes('cli'))) {
+                executionResponse.response.stream = Buffer.from('');
+            }
+
+            executions.push(_.assignIn(execution, executionResponse, err && {
                 requestError: err || undefined
             }));
         });


### PR DESCRIPTION
We are introducing a new flag `--skip-execution-response` on enabling which the summary response
will not be included in the report.

Also when `cli` is introduced as only reporter in the list of reporters we won't be saving execution responses.
This fix will allow developers using newman to generate the report even for large memory objects, in this case
only the summary response won't be part of the report.

Tested for reporters: `cli, html, json, junit, confluence, csv`