### PR TITLE
Publish types from DefinitelyTyped with newman package

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,0 +1,206 @@
+// Type definitions for newman 5.1
+// Project: https://github.com/postmanlabs/newman
+// Definitions by: Leonid Logvinov <https://github.com/LogvinovLeon>
+//                 Graham McGregor <https://github.com/Graham42>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import * as http from 'http';
+import { EventEmitter } from "events";
+import {
+    Collection,
+    VariableScope,
+} from "postman-collection";
+
+export interface NewmanRunOptions {
+    /** A JSON / Collection / String representing the collection. */
+    collection: Collection | Collection.definition | string;
+    /** An environment JSON / file path for the current collection run. */
+    environment?: VariableScope | VariableScope.definition | string;
+    /** A globals JSON / file path for the current collection run. */
+    globals?: VariableScope | VariableScope.definition | string;
+    /** The relative path to export the globals file from the current run to  */
+    exportGlobals?: string;
+    /** The relative path to export the environment file from the current run to */
+    exportEnvironment?: string;
+    /** The relative path to export the collection from the current run to */
+    exportCollection?: string;
+    /**
+     * Specify the number of iterations to run on the collection. This is
+     * usually accompanied by providing a data file reference as
+     * iterationData
+     */
+    iterationCount?: number;
+    /**
+     * Path to the JSON or CSV file or URL to be used as data source when
+     * running multiple iterations on a collection.
+     */
+    iterationData?: any;
+    /**
+     * The name or ID of the folder (ItemGroup) in the collection which would
+     * be run instead of the entire collection.
+     */
+    folder?: string | string[];
+    /**
+     * The path of the directory to be used as working directory.
+     */
+    workingDir?: string;
+    /**
+     * Allow reading files outside of working directory.
+     */
+    insecureFileRead?: boolean;
+    /**
+     * Specify the time (in milliseconds) to wait for the entire collection run
+     * to complete execution.
+     *
+     * Default value: Infinity
+     */
+    timeout?: number;
+    /**
+     * Specify the time (in milliseconds) to wait for requests to return a
+     * response.
+     *
+     * Default value: Infinity
+     */
+    timeoutRequest?: number;
+    /**
+     * Specify the time (in milliseconds) to wait for scripts to return a
+     * response.
+     *
+     * Default value: Infinity
+     */
+    timeoutScript?: number;
+    /**
+     * Specify the time (in milliseconds) to wait for between subsequent
+     * requests.
+     *
+     * Default value: 0
+     */
+    delayRequest?: number;
+    /**
+     * This specifies whether newman would automatically follow 3xx responses
+     * from servers.
+     *
+     * Default value: false
+     */
+    ignoreRedirects?: boolean;
+    /**
+     * Disables SSL verification checks and allows self-signed SSL certificates.
+     *
+     * Default value: false
+     */
+    insecure?: boolean;
+    /**
+     * Specify whether or not to stop a collection run on encountering the
+     * first test script error.
+     *
+     * "folder" allows you to skip the entire collection run in case an invalid
+     * folder was specified using the `folder` option or an error was
+     * encountered in general.
+     *
+     * "failure" would gracefully stop a collection run after completing the
+     * current test script.
+     *
+     * Default value: false
+     */
+    bail?: boolean | ["folder"] | ["failure"];
+    /**
+     * If present, allows overriding the default exit code from the current
+     * collection run, useful for bypassing collection result failures.
+     *
+     * Default value: false
+     */
+    suppressExitCode?: boolean;
+    /** Available reporters: cli, json, html and junit. */
+    reporters?: string | string[];
+    /**
+     * Specify options for the reporter(s) declared in options.reporters.
+     */
+    reporter?: any;
+    /**
+     * Enable or Disable colored CLI output.
+     *
+     * Default value: auto
+     */
+    color?: "on" | "off" | "auto";
+    /**
+     * The path to the public client certificate file.
+     */
+    sslClientCert?: string;
+    /**
+     * The path to the private client key file.
+     */
+    sslClientKey?: string;
+    /**
+     * The secret client key passphrase.
+     */
+    sslClientPassphrase?: string;
+    /**
+     * Custom HTTP(S) agents which will be used for making the requests. This allows for use of various proxies (e.g. socks)
+     */
+    requestAgents?: {
+        http?: http.Agent;
+        https?: http.Agent;
+    };
+}
+
+export interface NewmanRunSummary {
+    error?: any;
+    collection: any;
+    environment: any;
+    globals: any;
+    run: NewmanRun;
+}
+export interface NewmanRun {
+    stats: {
+        iterations: NewmanRunStat;
+        items: NewmanRunStat;
+        scripts: NewmanRunStat;
+        prerequests: NewmanRunStat;
+        requests: NewmanRunStat;
+        tests: NewmanRunStat;
+        assertions: NewmanRunStat;
+        testScripts: NewmanRunStat;
+        prerequestScripts: NewmanRunStat;
+    };
+    failures: NewmanRunFailure[];
+    executions: NewmanRunExecution[];
+}
+export interface NewmanRunStat {
+    total?: number;
+    failed?: number;
+    pending?: number;
+}
+export interface NewmanRunExecution {
+    item: NewmanRunExecutionItem;
+    assertions: NewmanRunExecutionAssertion[];
+}
+export interface NewmanRunExecutionItem {
+    name: string;
+}
+export interface NewmanRunExecutionAssertion {
+    assertion: string;
+    error: NewmanRunExecutionAssertionError;
+}
+export interface NewmanRunExecutionAssertionError {
+    name: string;
+    index: number;
+    test: string;
+    message: string;
+    stack: string;
+}
+export interface NewmanRunFailure {
+    error: NewmanRunExecutionAssertionError;
+    /** The event where the failure occurred */
+    at: string;
+    source: NewmanRunExecutionItem | undefined;
+    parent: any;
+    cursor: { ref: string } | {};
+}
+export function run(
+    options: NewmanRunOptions,
+    callback?: (err: Error | null, summary: NewmanRunSummary) => void
+): EventEmitter;
+export function run(
+    callback: (err: Error | null, summary: NewmanRunSummary) => void
+): EventEmitter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,9 +1534,9 @@
       },
       "dependencies": {
         "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
         },
         "entities": {
           "version": "2.0.3",
@@ -3932,9 +3932,9 @@
       }
     },
     "postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+      "version": "7.0.34",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
+      "integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -3952,9 +3952,9 @@
       }
     },
     "postman-collection": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.6.6.tgz",
-      "integrity": "sha512-fm9AGKHbL2coSzD5nw+F07JrX7jzqu2doGIXevPPrwlpTZyTM6yagEdENeO/Na8rSUrI1+tKPj+TgAFiLvtF4w==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.6.7.tgz",
+      "integrity": "sha512-tJnlqMZHSI0kZS9/bqZ5DJTA9pP++QgfPhOKXUDu6XR7s3Xbk5hSm9svPUG6Tw55Q0xw5UxrWKYb0ogdPXr7zQ==",
       "requires": {
         "escape-html": "1.0.3",
         "faker": "5.1.0",
@@ -4100,6 +4100,45 @@
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
             "lodash": "^4.17.14"
+          }
+        },
+        "marked": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
+          "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
+        },
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+        },
+        "mime-types": {
+          "version": "2.1.27",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+          "requires": {
+            "mime-db": "1.44.0"
+          }
+        },
+        "postman-collection": {
+          "version": "3.6.6",
+          "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.6.6.tgz",
+          "integrity": "sha512-fm9AGKHbL2coSzD5nw+F07JrX7jzqu2doGIXevPPrwlpTZyTM6yagEdENeO/Na8rSUrI1+tKPj+TgAFiLvtF4w==",
+          "requires": {
+            "escape-html": "1.0.3",
+            "faker": "5.1.0",
+            "file-type": "3.9.0",
+            "http-reasons": "0.1.0",
+            "iconv-lite": "0.6.2",
+            "liquid-json": "0.3.1",
+            "lodash": "4.17.20",
+            "marked": "1.1.1",
+            "mime-format": "2.0.0",
+            "mime-types": "2.1.27",
+            "postman-url-encoder": "2.1.3",
+            "sanitize-html": "1.20.1",
+            "semver": "7.3.2",
+            "uuid": "3.4.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "filesize": "6.1.0",
     "lodash": "4.17.20",
     "mkdirp": "1.0.4",
-    "postman-collection": "3.6.6",
+    "postman-collection": "3.6.7",
     "postman-collection-transformer": "3.3.3",
     "postman-request": "2.88.1-postman.24",
     "postman-runtime": "7.26.5",
@@ -85,6 +85,7 @@
     "sinon": "9.0.3",
     "xml2js": "0.4.23"
   },
+  "types": "lib/types/index.d.ts",
   "engines": {
     "node": ">=10"
   }


### PR DESCRIPTION
I recently ran into a couple of problems when updating `newman` and `postman-collection` to their latest versions along with the latest versions of [@types/newman](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/newman) and [@types/postman-collection](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/postman-collection).

The first problem was that [@types/postman-collection](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/postman-collection) is no longer compatible with `postman-collection`.  For example, `VariableScopeDefinition` is now `VariableScope.definition`.  It appears that the type information is no longer being maintained in the DefinitelyTyped repo and has instead been moved inside the `postman-collection` repo [here](https://github.com/postmanlabs/postman-collection/blob/develop/types/index.d.ts).

The second problem was that `newman` does not publish types in its repo, so the only way to get them currently is from DefinitelyTyped.  However, the `newman` types in the DefinitelyTyped repo [depend](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/newman/index.d.ts#L10-L15) on the outdated `postman-collection` types in DefinitelyTyped, so they can't be used.

The only way to use the most recent versions of `newman` and `postman-collection` right now is to remove both `@types/newman` and `@types/postman-collection` from your project.  After doing this the `postman-collection` type information will be available directly from that project, but it is not possible to get `newman` types such as `NewmanRunSummary`.

In this PR I've taken the types from [@types/newman](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/newman) and added them to the `newman` repo in the same way as the `postman-collection` repo.  I did also try to replicate how `postman-collection` automatically generates these types with `npm/build-types.js`, but it looks like the many of the JSDocs need to be updated for compatibility with tsd-jsdoc.  So for now `lib/types/index.d.ts` comes directly from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/newman/index.d.ts) with some minor changes for compatibility with `postman-collection` 3.6.7.  I've confirmed that with these changes I can access the `newman` types in my code.

I'm not sure what the strategy is for the postman/newman team regarding TypeScript, but if the goal is to publish types along with their respective packages (which I think is a good idea) then hopefully this PR might help move in the right direction.  Alternatively, if type support is already in progress in `newman` I could submit both the `newman` and `postman-collection` type changes to the DefinitelyTyped repo in the meantime.
