### PR TITLE
Fix:Timing Details added for each request(#2601)

### DIFF
--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -267,7 +267,11 @@ _.assign(RunSummary, {
     attachTimingTrackers (summary, emitter) {
         // mark the point when the run started
         // also mark the point when run completed and also store error if needed
-        emitter.on('start', function () { summary.run.timings.started = Date.now(); });
+        // initialise a requestWise timings array
+        emitter.on('start', function () {
+            summary.run.timings.started = Date.now();
+            summary.run.timings.requestWise = [];
+        });
         emitter.on('beforeDone', function () {
             summary.run.timings.completed = Date.now();
         });
@@ -319,6 +323,11 @@ _.assign(RunSummary, {
             timings = timings && timings.timings;
             timingPhases = timings && sdk.Response.timingPhases(timings);
 
+            // Push the timing stats of the current request to the summary
+            summary.run.timings.requestWise && summary.run.timings.requestWise.push(timingPhases);
+
+            // Computing the timing stats for the whole run
+            // eslint-disable-next-line lodash/collection-method-value
             (timingPhases || time) && _.forEach([
                 'dns',
                 'firstByte',
@@ -326,7 +335,7 @@ _.assign(RunSummary, {
             ], (value) => {
                 var currentValue = (value === 'response') ? time : (timingPhases && timingPhases[value]),
                     previousAverage = summary.run.timings[`${value}Average`],
-                    previousVariance = Math.pow(summary.run.timings[`${value}Sd`], 2),
+                    previousVariance = summary.run.timings[`${value}Sd`],
                     delta1 = currentValue - previousAverage,
                     delta2,
                     currentVariance;

--- a/npm/test-unit.js
+++ b/npm/test-unit.js
@@ -21,6 +21,7 @@ module.exports = function (exit) {
     var Mocha = require('mocha');
 
     // add all spec files to mocha
+    // eslint-disable-next-line consistent-return
     recursive(SPEC_SOURCE_DIR, function (err, files) {
         if (err) {
             console.error(err);


### PR DESCRIPTION
Output timing details( like dns, firstBytes,..) for each request are now, there in the report using JSON reporter and verbose option.
Fixes #2601 

The fix details are as follows:
1. A separate attribute requestWise has been added to timings attribute of summary.run .
2. Timing details like dns, firstByte, wait, prepare, etc have been added for each request, whenever verbose option is set.

Background of the issue:
Actually, CLI reporter gives all the details using the verbose option but JSON reporter only publishes the overall timing details in the report.
