### PR TITLE
Feature:Option --exclude-folder added to the options.

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -28,6 +28,9 @@ program
     .option('--folder <path>',
         'Specify the folder to run from a collection. Can be specified multiple times to run multiple folders',
         util.cast.memoize, [])
+    .option('--exclude-folder <path>',
+        'Specify the folder to exclude from a collection. Can be specified multiple times to exclude multiple folders',
+        util.cast.memoize, [])
     .option('--global-var <value>',
         'Allows the specification of global variables via the command line, in a key=value format',
         util.cast.memoizeKeyVal, [])

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -96,6 +96,10 @@ module.exports = function (options, callback) {
     var emitter = new EventEmitter(), // @todo: create a new inherited constructor
         runner = new runtime.Runner(),
         stopOnFailure,
+        items,
+        itemsLength,
+        excludedItems = [],
+        i,
         entrypoint;
 
     // get the configuration from various sources
@@ -141,6 +145,31 @@ module.exports = function (options, callback) {
 
             // uses `multipleIdOrName` lookupStrategy in case of multiple folders.
             _.isArray(entrypoint.execute) && (entrypoint.lookupStrategy = MULTIENTRY_LOOKUP_STRATEGY);
+        }
+
+        // excludes the items which have been specified in options.excludeFolder
+        if (options.excludeFolder) {
+            // Getting all the items to be executed
+            items = options.collection.items.members;
+            itemsLength = options.collection.items.members.length;
+
+            // uses string if only one folder is specified
+            if (_.isString(options.excludeFolder)) {
+                for (i = 0; i < itemsLength; i++) {
+                    // adding the ids of the items to excludedItems specified in options.excludeFolder
+                    if (items[i].name === options.excludeFolder) { excludedItems.push(items[i].id); }
+                }
+            }
+            // uses `multipleIdOrName` lookupStrategy in case of multiple folders.
+            else if (_.isArray(options.excludeFolder)) {
+                for (i = 0; i < itemsLength; i++) {
+                    // adding the ids of the items to excludedItems specified in options.excludeFolder
+                    if (options.excludeFolder.includes(items[i].name)) { excludedItems.push(items[i].id); }
+                }
+            }
+            // Removing the items specified in options.excludeFolder
+            items = items.filter((item) => { return excludedItems.includes(item.id) === false; });
+            options.collection.items.members = items;
         }
 
         // sets stopOnFailure to true in case bail is used without any modifiers or with failure

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -256,6 +256,26 @@ var _ = require('lodash'),
         },
 
         /**
+         * Helper function to sanitize exclude-folder option.
+         *
+         * @param {String[]|String} value - The list of folders to exclude
+         * @param {Object} options - The set of wrapped options.
+         * @param {Function} callback - The callback function invoked to mark the end of the folder load routine.
+         * @returns {*}
+         */
+        excludeFolder: function (value, options, callback) {
+            if (!value.length) {
+                return callback(); // avoids empty string or array
+            }
+
+            if (Array.isArray(value) && value.length === 1) {
+                return callback(null, value[0]); // avoids using multipleIdOrName strategy for a single item array
+            }
+
+            callback(null, value);
+        },
+
+        /**
          * The iterationData loader module, with support for JSON or CSV data files.
          *
          * @param {String|Object[]} location - The path to the iteration data file for the current collection run, or
@@ -373,6 +393,9 @@ var _ = require('lodash'),
 module.exports = function (options, callback) {
     // set newman version used for collection run
     options.newmanVersion = util.version;
+
+    // sets excludeFolder to undefined if not provided
+    if (!options.excludeFolder) { options.excludeFolder = undefined; }
 
     // set working directory if not provided
     options.workingDir = options.workingDir || process.cwd();

--- a/npm/test-cli.js
+++ b/npm/test-cli.js
@@ -45,7 +45,6 @@ module.exports = function (exit) {
         mocha.run(function (err) {
             delete global.expect; // clear references and overrides
             global.exec = _exec;
-
             exit(err || process.exitCode ? 1 : 0);
         });
         mocha = null; // cleanup

--- a/npm/test-unit.js
+++ b/npm/test-unit.js
@@ -10,6 +10,7 @@ require('colors');
 // set directories and files for test and coverage report
 var path = require('path'),
     expect = require('chai').expect,
+    newman = require('../index'),
     recursive = require('recursive-readdir'),
 
     SPEC_SOURCE_DIR = path.join(__dirname, '..', 'test', 'unit');
@@ -35,6 +36,7 @@ module.exports = function (exit) {
         }).forEach(mocha.addFile.bind(mocha));
 
         // start the mocha run
+        global.newman = newman;
         global.expect = expect; // for easy reference
 
         mocha.run(function (runError) {

--- a/test/cli/run-options.test.js
+++ b/test/cli/run-options.test.js
@@ -107,6 +107,15 @@ describe('CLI run options', function () {
         });
     });
 
+    it('should work correctly with --exclude-folder option when specified', function (done) {
+        // eslint-disable-next-line max-len
+        exec('node ./bin/newman.js run test/integration/exclude-folder-variant/exclude-folder-tests.postman_collection.json', function (code, stdout, stderr) {
+            expect(code, 'should have exit code of 0').to.equal(0);
+            expect(stderr).to.equal('');
+            done();
+        });
+    });
+
     describe('script timeouts', function () {
         it('should be handled correctly when breached', function (done) {
             // eslint-disable-next-line max-len

--- a/test/cli/run-options.test.js
+++ b/test/cli/run-options.test.js
@@ -109,7 +109,16 @@ describe('CLI run options', function () {
 
     it('should work correctly with --exclude-folder option when specified', function (done) {
         // eslint-disable-next-line max-len
-        exec('node ./bin/newman.js run test/integration/exclude-folder-variant/exclude-folder-tests.postman_collection.json', function (code, stdout, stderr) {
+        exec('node ./bin/newman.js run test/integration/exclude-folder-variant/exclude-folder-tests.postman_collection.json --exclude-folder R1', function (code, stdout, stderr) {
+            expect(code, 'should have exit code of 0').to.equal(0);
+            expect(stderr).to.equal('');
+            done();
+        });
+    });
+
+    it('should work correctly with --exclude-folder when more than 1 folder is specified', function (done) {
+        // eslint-disable-next-line max-len
+        exec('node ./bin/newman.js run test/integration/exclude-folder-variant/exclude-folder-tests.postman_collection.json --exclude-folder R1 --exclude-folder R2', function (code, stdout, stderr) {
             expect(code, 'should have exit code of 0').to.equal(0);
             expect(stderr).to.equal('');
             done();

--- a/test/integration/exclude-folder-variant/exclude-folder-tests.postman_collection.json
+++ b/test/integration/exclude-folder-variant/exclude-folder-tests.postman_collection.json
@@ -1,0 +1,66 @@
+{
+	"info": {
+		"_postman_id": "ced74a5c-a67c-4141-b7a1-bf2ee8668183",
+		"name": "Sample",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "R1",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://postman-echo.com/get",
+					"protocol": "https",
+					"host": [
+						"postman-echo",
+						"com"
+					],
+					"path": [
+						"get"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "R2",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://postman-echo.com/get",
+					"protocol": "https",
+					"host": [
+						"postman-echo",
+						"com"
+					],
+					"path": [
+						"get"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "R3",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://postman-echo.com/get",
+					"protocol": "https",
+					"host": [
+						"postman-echo",
+						"com"
+					],
+					"path": [
+						"get"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/test/integration/exclude-folder-variant/exclude-folder-tests.postman_config.json
+++ b/test/integration/exclude-folder-variant/exclude-folder-tests.postman_config.json
@@ -1,0 +1,6 @@
+{
+    "run": {
+      "excludeFolder" : ["R1","R3"]
+    }
+}
+  

--- a/test/library/exclude-folder-variants.test.js
+++ b/test/library/exclude-folder-variants.test.js
@@ -1,0 +1,69 @@
+describe('exclude folder variants', function () {
+    var collection = {
+        id: 'C1',
+        name: 'Collection C1',
+        item: [{
+            id: 'ID1',
+            name: 'R1',
+            request: 'https://postman-echo.com/get'
+        }, {
+            id: 'ID2',
+            name: 'R2',
+            request: 'https://postman-echo.com/get'
+        }, {
+            id: 'ID3',
+            name: 'R3',
+            request: 'https://postman-echo.com/get'
+        }]
+    };
+
+    it('should exclude the specified request in case folder name is valid', function (done) {
+        newman.run({
+            collection: collection,
+            excludeFolder: 'R1'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+            expect(summary.run.executions, 'should have 2 executions').to.have.lengthOf(2);
+            expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R2', 'R3']);
+            done();
+        });
+    });
+
+    it('should not affect the collection run in case folder name is invalid', function (done) {
+        newman.run({
+            collection: collection,
+            excludeFolder: 'R123'
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+            expect(summary.run.executions, 'should have 3 executions').to.have.lengthOf(3);
+            done();
+        });
+    });
+
+    it('should exclude the specified requests in case multiple folder names are passed', function (done) {
+        newman.run({
+            collection: collection,
+            excludeFolder: ['R1', 'R3']
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+            expect(summary.run.executions, 'should have 1 executions').to.have.lengthOf(1);
+            expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R2']);
+            done();
+        });
+    });
+    it('should overrule the folder specified by --folder option in case of same arguments passed', function (done) {
+        newman.run({
+            collection: collection,
+            excludeFolder: ['R1', 'R3'],
+            folder: ['R1']
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.stats.iterations.total, 'should have 0 iteration').to.equal(0);
+            expect(summary.run.executions, 'should have 0 executions').to.have.lengthOf(0);
+            done();
+        });
+    });
+});

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -50,6 +50,7 @@ describe('cli parser', function () {
                         delayRequest: 0,
                         globalVar: [],
                         envVar: [],
+                        excludeFolder: [],
                         folder: [],
                         insecureFileRead: true,
                         color: 'auto',
@@ -146,6 +147,7 @@ describe('cli parser', function () {
                 '-g myGlobals.json ' +
                 '-d path/to/csv.csv ' +
                 '--folder myFolder ' +
+                '--exclude-folder myExFolder ' +
                 '--working-dir /Users/postman ' +
                 '--no-insecure-file-read ' +
                 '--cookie-jar myCookie.json ' +
@@ -173,6 +175,7 @@ describe('cli parser', function () {
                 expect(opts.collection).to.equal('myCollection.json');
                 expect(opts.environment).to.equal('myEnv.json');
                 expect(opts.folder).to.eql(['myFolder']);
+                expect(opts.excludeFolder).to.eql(['myExFolder']);
                 expect(opts.workingDir).to.eql('/Users/postman');
                 expect(opts.cookieJar).to.eql('myCookie.json');
                 expect(opts.exportCookieJar).to.eql('exported_cookie.json');
@@ -215,6 +218,7 @@ describe('cli parser', function () {
                 '-d /path/to/csv.csv ' +
                 '--folder myFolder1 ' +
                 '--folder myFolder2 ' +
+                '--exclude-folder myExFolder ' +
                 '--working-dir /Users/postman ' +
                 '--no-insecure-file-read ' +
                 '--disable-unicode ' +
@@ -242,6 +246,7 @@ describe('cli parser', function () {
                 expect(opts.collection).to.equal('myCollection.json');
                 expect(opts.environment).to.equal('myEnv.json');
                 expect(opts.folder).to.eql(['myFolder1', 'myFolder2']);
+                expect(opts.excludeFolder).to.eql(['myExFolder']);
                 expect(opts.workingDir).to.eql('/Users/postman');
                 expect(opts.insecureFileRead).to.be.false;
                 expect(opts.disableUnicode, 'should have disableUnicode to be true').to.equal(true);

--- a/test/unit/options.test.js
+++ b/test/unit/options.test.js
@@ -97,4 +97,73 @@ describe('options', function () {
             done();
         });
     });
+
+    describe('option --exclude-folder', function () {
+        var collection = {
+            id: 'C1',
+            name: 'Collection C1',
+            item: [{
+                id: 'ID1',
+                name: 'R1',
+                request: 'https://postman-echo.com/get'
+            }, {
+                id: 'ID2',
+                name: 'R2',
+                request: 'https://postman-echo.com/get'
+            }, {
+                id: 'ID3',
+                name: 'R3',
+                request: 'https://postman-echo.com/get'
+            }]
+        };
+
+        it('should be undefined by default', function (done) {
+            options({}, function (err, result) {
+                expect(err).to.be.null;
+                expect(result).to.have.property('excludeFolder').to.be.undefined;
+                done();
+            });
+        });
+
+        it('should use string when single folder is passed', function (done) {
+            options({ excludeFolder: 'myFolder' }, function (err, result) {
+                expect(err).to.be.null;
+                expect(result).to.have.property('excludeFolder').to.eql('myFolder');
+                done();
+            });
+        });
+
+        it('should use array when multiple arguments are passed', function (done) {
+            options({ excludeFolder: ['myFolder1', 'myFolder2'] }, function (err, result) {
+                expect(err).to.be.null;
+                expect(result).to.have.property('excludeFolder').to.eql(['myFolder1', 'myFolder2']);
+                done();
+            });
+        });
+
+        it('should exclude the specified requests in case multiple folder names are passed', function (done) {
+            newman.run({
+                collection: collection,
+                excludeFolder: ['R1', 'R3']
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 1 executions').to.have.lengthOf(1);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R2']);
+                done();
+            });
+        });
+        it('should overrule the folder specified by --folder option in case of same arguments passed', function (done) {
+            newman.run({
+                collection: collection,
+                excludeFolder: ['R1', 'R3'],
+                folder: ['R1']
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 0 iteration').to.equal(0);
+                expect(summary.run.executions, 'should have 0 executions').to.have.lengthOf(0);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
**What this PR does?**
This PR adds an option --exclude-folder to the list of options.
This is in response to the feature request #2465 

**What changes have been made?**
- There are changes to the main newman file and the run/options.js file in particular, with --exclude-folder option added.
- Tests have been added to test the option, i.e CLI tests, Unit tests, Integration tests and Library Tests.

**What is the added option --exclude-folder all about?**
- The option --exclude-folder can take in one or more than one folders and it excludes them from items to be executed.
- This option rules supreme in case same folder has been passed using both --folder and --exclude-folder options.