### PR TITLE
Feature: Option --reporter-cli-only-dots added.

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -61,6 +61,7 @@ program
     .option('--cookie-jar <path>', 'Specify the path to a custom cookie jar (serialized tough-cookie JSON) ')
     .option('--export-cookie-jar <path>', 'Exports the cookie jar to a file after completing the run')
     .option('--verbose', 'Show detailed information of collection run and each request sent')
+    .option('--reporter-cli-only-dots', 'Print one dot for every request.')
     .action((collection, command) => {
         let options = util.commanderToObject(command),
 

--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -118,7 +118,7 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
         }
         var snr = extractSNR(o.executions);
 
-        if (snr) {
+        if (snr && !reporterOptions.onlyDots) {
             print.lf(LF + colors.gray('Attempting to set next request to', snr));
         }
     });
@@ -147,16 +147,22 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
     emitter.on('beforeRequest', function (err, o) {
         if (err || !o.request) { return; }
 
-        print('  %s %s ', colors.gray(o.request.method), colors.gray(o.request.url.toString()));
-
+        if (!reporterOptions.onlyDots) {
+            print('  %s %s ', colors.gray(o.request.method), colors.gray(o.request.url.toString()));
+        }
         !options.disableUnicode && print().wait(colors.gray);
     });
 
     // output the response code, reason and time
     emitter.on('request', function (err, o) {
         if (err) {
-            print.lf(colors.red('[errored]'));
-            print.lf(colors.red('     %s'), err.message);
+            if (!reporterOptions.onlyDots) {
+                print.lf(colors.red('[errored]'));
+                print.lf(colors.red('     %s'), err.message);
+            }
+            else {
+                print.lf(colors.red('%s'), cliUtils.symbols().error);
+            }
 
             return;
         }
@@ -179,8 +185,13 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
 
         size = size && (size.header || 0) + (size.body || 0) || 0;
 
-        print.lf(colors.gray('[%d %s, %s, %s]'), o.response.code, o.response.reason(),
-            util.filesize(size), util.prettyms(o.response.responseTime));
+        if (reporterOptions.onlyDots) {
+            print.lf(colors.green('%s'), cliUtils.symbols().ok);
+        }
+        else {
+            print.lf(colors.gray('[%d %s, %s, %s]'), o.response.code, o.response.reason(),
+                util.filesize(size), util.prettyms(o.response.responseTime));
+        }
 
         // if there are redirects, get timings for the last request sent
         timings = _.last(_.get(o, 'history.execution.data'));
@@ -223,7 +234,7 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
         var passed = !err;
 
         // handle skipped test display
-        if (o.skipped && !reporterOptions.noSuccessAssertions) {
+        if (o.skipped && !reporterOptions.noSuccessAssertions && !reporterOptions.onlyDots) {
             print.lf('%s %s', colors.cyan('  - '), colors.cyan('[skipped] ' + o.assertion));
 
             return;
@@ -234,9 +245,11 @@ PostmanCLIReporter = function (emitter, reporterOptions, options) {
         }
 
         // print each test assertions
-        print.lf('%s %s', passed ? colors.green(`  ${symbols.ok} `) :
-            colors.red.bold(pad(this.summary.run.failures.length, 3, SPC) + symbols.dot), passed ?
-            colors.gray(o.assertion) : colors.red.bold(o.assertion));
+        if (!reporterOptions.onlyDots) {
+            print.lf('%s %s', passed ? colors.green(`  ${symbols.ok} `) :
+                colors.red.bold(pad(this.summary.run.failures.length, 3, SPC) + symbols.dot), passed ?
+                colors.gray(o.assertion) : colors.red.bold(o.assertion));
+        }
     });
 
     // show user console logs in a neatly formatted way (provided user has not disabled the same)

--- a/test/cli/cli-reporter-only-dots.test.js
+++ b/test/cli/cli-reporter-only-dots.test.js
@@ -1,0 +1,10 @@
+describe('CLI reporter only dots', function () {
+    it('should produce normal output', function (done) {
+        exec('node ./bin/newman.js run test/fixtures/run/single-get-request.json --reporter-cli-only-dots',
+            function (code, stdout, stderr) {
+                expect(code, 'should have exit code of 0').to.equal(0);
+                expect(stderr).to.be.empty;
+                done(code);
+            });
+    });
+});

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -1,3 +1,5 @@
+const { expect } = require('chai');
+
 describe('cli parser', function () {
     var _ = require('lodash'),
         sinon = require('sinon'),
@@ -235,9 +237,9 @@ describe('cli parser', function () {
                 '--bail folder,failure ' +
                 '--global-var foo=bar --global-var alpha==beta= ' +
                 '--reporter-json-output ./omg.txt ' +
-                '--reporter-use everything').split(' '), 'run', function (err, opts) {
+                '--reporter-use everything ' +
+                '--reporter-cli-only-dots').split(' '), 'run', function (err, opts) {
                 expect(err).to.be.null;
-
                 expect(opts).to.be.ok;
                 expect(opts.collection).to.equal('myCollection.json');
                 expect(opts.environment).to.equal('myEnv.json');
@@ -273,6 +275,8 @@ describe('cli parser', function () {
                 expect(opts.reporters).to.contain('json');
                 expect(opts.reporters).to.not.contain('verbose');
                 expect(opts.reporters).to.not.contain('junit');
+                expect(opts.reporter.json.cliOnlyDots).to.equal(true);
+                expect(opts.reporterOptions.cliOnlyDots).to.equal(true);
 
                 // Generic reporter options
                 expect(opts.reporterOptions).to.be.ok;
@@ -298,6 +302,16 @@ describe('cli parser', function () {
                     expect(err).to.be.null;
                     expect(opts).to.be.ok;
                     expect(opts.reporter.cli.noBanner, 'should have noBanner to be true').to.equal(true);
+
+                    done();
+                });
+        });
+        it('should print one character for each request if --reporter-cli-only-dots is set', function (done) {
+            cli('node newman.js run myCollection.json --reporter-cli-only-dots'.split(' '), 'run',
+                function (err, opts) {
+                    expect(err).to.be.null;
+                    expect(opts).to.be.ok;
+                    expect(opts.reporter.cli.onlyDots, 'should have onlyDots to be true').to.equal(true);
 
                     done();
                 });


### PR DESCRIPTION
Fixes #2596 
**What does this PR do?**
This PR is in response to the feature request under #2596.
The option --reporter-cli-only-dots has been added.

**What things have been added?**
The following things have been added/updated:
- The option --reporter-cli-only-dots has been added.
- The option turns off the information related to the request like method, status code, etc to be printed on the console.
- The option prints a green tick if request succeeded and a red cross if it failed.
- The other information related to assertion is also turned off.
- This option has lower precedence than other options like verbose.
