### PR TITLE
Feature: Running Single Request from a folder in a Collection

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+
 require('../lib/node-version-check'); // @note that this should not respect CLI --silent
 
 const _ = require('lodash'),
@@ -95,6 +96,15 @@ program.on('command:*', (command) => {
     console.error(`error: invalid command \`${command}\`\n`);
     program.help();
 });
+
+program
+    .command('run-request <url>')
+    .usage('<url> [options]')
+    .option('-m,--method', 'Method of the request', 'GET')
+    .action((url, command) => {
+        console.info(url);
+        console.info(command);
+    });
 
 /**
  * Starts the script execution.

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -29,6 +29,8 @@ program
     .option('--folder <path>',
         'Specify the folder to run from a collection. Can be specified multiple times to run multiple folders',
         util.cast.memoize, [])
+    .option('--item-from-folder <path>', 'Specify the item and its parent folder',
+        util.cast.memoize, [])
     .option('--global-var <value>',
         'Allows the specification of global variables via the command line, in a key=value format',
         util.cast.memoizeKeyVal, [])

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -136,13 +136,19 @@ module.exports = function (options, callback) {
         }
 
         // sets entrypoint to execute if options.folder is specified.
-        if (options.folder) {
+        if (options.folder && !options.itemFromFolder) {
             entrypoint = { execute: options.folder };
 
             // uses `multipleIdOrName` lookupStrategy in case of multiple folders.
             _.isArray(entrypoint.execute) && (entrypoint.lookupStrategy = MULTIENTRY_LOOKUP_STRATEGY);
         }
 
+        if (options.itemFromFolder) {
+            if (options.collection.items) {
+                options.collection.items.members = util.parseItemFromFolder(String(options.itemFromFolder),
+                    options.collection.items.members);
+            }
+        }
         // sets stopOnFailure to true in case bail is used without any modifiers or with failure
         // --bail => stopOnFailure = true
         // --bail failure => stopOnFailure = true

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -256,6 +256,26 @@ var _ = require('lodash'),
         },
 
         /**
+         * Helper function to sanitize folder option.
+         *
+         * @param {String[]|String} value - The list of folders to execute
+         * @param {Object} options - The set of wrapped options.
+         * @param {Function} callback - The callback function invoked to mark the end of the folder load routine.
+         * @returns {*}
+         */
+        itemFromFolder: function (value, options, callback) {
+            if (!value.length) {
+                return callback(); // avoids empty string or array
+            }
+
+            if (Array.isArray(value) && value.length === 1) {
+                return callback(null, value[0]); // avoids using multipleIdOrName strategy for a single item array
+            }
+
+            callback(null, value);
+        },
+
+        /**
          * The iterationData loader module, with support for JSON or CSV data files.
          *
          * @param {String|Object[]} location - The path to the iteration data file for the current collection run, or

--- a/lib/util.js
+++ b/lib/util.js
@@ -252,6 +252,69 @@ util = {
             });
     },
 
+
+    /**
+     * Finds an item or item group based on id or name.
+     *
+     * @param {Object} itemGroup - The group of items to be searched within.
+     * @param {?String} match - The string name of the item to be compared against.
+     *
+     * @returns {Object} - The item we searched for.
+     */
+    findItemOrGroup: function (itemGroup, match) {
+        if (!itemGroup) { return; }
+
+        var matched,
+            flag = 1,
+            x;
+
+        // lookup match on own children
+        for (x = 0; x < itemGroup.length && flag; x++) {
+            if (itemGroup[x].id === match || itemGroup[x].name === match) {
+                matched = itemGroup[x];
+                flag = 0;
+            }
+        }
+
+        // if there is no match on own children, start lookup on grand children
+        if (flag) {
+            for (x = 0; x < itemGroup.length && flag; x++) {
+                matched = util.findItemOrGroup(itemGroup[x], match);
+                if (matched) { flag = 0; }
+            }
+        }
+
+        if (flag) {
+            // eslint-disable-next-line consistent-return
+            return null;
+        }
+
+        // eslint-disable-next-line consistent-return
+        return matched;
+    },
+
+    /**
+     * Parses the input string and returns the item to be executed.
+     *
+     * @param {String} folderString - The string input by user for --item-from-folder option
+     * @param {Object} collection - The Collection Object
+     * @returns {Object} - A collection result containing the item to be executed.
+     */
+    parseItemFromFolder: function (folderString, collection) {
+        const folderStrings = folderString.split('/');
+        var parentFolder,
+            childFolder,
+            result = [];
+
+        if (folderStrings.length === 2) {
+            parentFolder = util.findItemOrGroup(collection, folderStrings[0]);
+            childFolder = util.findItemOrGroup(parentFolder.items.members, folderStrings[1]);
+            childFolder && result.push(childFolder);
+        }
+
+        return result;
+    },
+
     /**
      * Checks whether the given object is a v1 collection
      *

--- a/test/integration/parsing-folder-paths/parsing-folder-paths.postman_collection.json
+++ b/test/integration/parsing-folder-paths/parsing-folder-paths.postman_collection.json
@@ -1,0 +1,71 @@
+{
+	"info": {
+		"_postman_id": "592004d7-14da-4a88-80e8-a00979d1a423",
+		"name": "parsing-folder-files",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "firstpost",
+			"item": [
+				{
+					"name": "first",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://postman-echo.com/get",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"get"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "second",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://postman-echo.com/get",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"get"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "post",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://postman-echo.com/get",
+					"protocol": "https",
+					"host": [
+						"postman-echo",
+						"com"
+					],
+					"path": [
+						"get"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/test/integration/parsing-folder-paths/parsing-folder-paths.postman_config.json
+++ b/test/integration/parsing-folder-paths/parsing-folder-paths.postman_config.json
@@ -1,0 +1,6 @@
+{
+    "run": {
+        "itemFromFolder": "firstpost/first"
+    }
+}
+  

--- a/test/library/run-options.test.js
+++ b/test/library/run-options.test.js
@@ -239,4 +239,40 @@ describe('Newman run options', function () {
             });
         });
     });
+
+    describe('Option --item-from-folder', function () {
+        it('should work correctly when path is correct', function (done) {
+            newman.run({
+                collection: 'test/integration/parsing-folder-paths/parsing-folder-paths.postman_collection.json',
+                itemFromFolder: 'firstpost/first'
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary).to.be.ok;
+                done();
+            });
+        });
+
+        it('should work correctly when path is incorrect', function (done) {
+            newman.run({
+                collection: 'test/integration/parsing-folder-paths/parsing-folder-paths.postman_collection.json',
+                itemFromFolder: 'firstpost/third'
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary).to.be.ok;
+                done();
+            });
+        });
+
+        it('should work override folder option when both are specified', function (done) {
+            newman.run({
+                collection: 'test/integration/parsing-folder-paths/parsing-folder-paths.postman_collection.json',
+                itemFromFolder: 'firstpost/third',
+                folder: 'post'
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary).to.be.ok;
+                done();
+            });
+        });
+    });
 });

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -1,3 +1,5 @@
+const { expect } = require('chai');
+
 describe('cli parser', function () {
     var _ = require('lodash'),
         sinon = require('sinon'),
@@ -51,6 +53,7 @@ describe('cli parser', function () {
                         globalVar: [],
                         envVar: [],
                         folder: [],
+                        itemFromFolder: [],
                         insecureFileRead: true,
                         color: 'auto',
                         timeout: 0,
@@ -146,6 +149,7 @@ describe('cli parser', function () {
                 '-g myGlobals.json ' +
                 '-d path/to/csv.csv ' +
                 '--folder myFolder ' +
+                '--item-from-folder myFolder/myRequest ' +
                 '--working-dir /Users/postman ' +
                 '--no-insecure-file-read ' +
                 '--cookie-jar myCookie.json ' +
@@ -173,6 +177,7 @@ describe('cli parser', function () {
                 expect(opts.collection).to.equal('myCollection.json');
                 expect(opts.environment).to.equal('myEnv.json');
                 expect(opts.folder).to.eql(['myFolder']);
+                expect(opts.itemFromFolder).to.eql(['myFolder/myRequest']);
                 expect(opts.workingDir).to.eql('/Users/postman');
                 expect(opts.cookieJar).to.eql('myCookie.json');
                 expect(opts.exportCookieJar).to.eql('exported_cookie.json');
@@ -215,6 +220,7 @@ describe('cli parser', function () {
                 '-d /path/to/csv.csv ' +
                 '--folder myFolder1 ' +
                 '--folder myFolder2 ' +
+                '--item-from-folder myFolder/myRequest ' +
                 '--working-dir /Users/postman ' +
                 '--no-insecure-file-read ' +
                 '--disable-unicode ' +
@@ -242,6 +248,7 @@ describe('cli parser', function () {
                 expect(opts.collection).to.equal('myCollection.json');
                 expect(opts.environment).to.equal('myEnv.json');
                 expect(opts.folder).to.eql(['myFolder1', 'myFolder2']);
+                expect(opts.itemFromFolder).to.eql(['myFolder/myRequest']);
                 expect(opts.workingDir).to.eql('/Users/postman');
                 expect(opts.insecureFileRead).to.be.false;
                 expect(opts.disableUnicode, 'should have disableUnicode to be true').to.equal(true);

--- a/test/unit/options.test.js
+++ b/test/unit/options.test.js
@@ -1,3 +1,4 @@
+const { expect } = require('chai');
 var _ = require('lodash'),
     options = require('../../lib/run/options');
 
@@ -98,3 +99,30 @@ describe('options', function () {
         });
     });
 });
+
+describe('Option --item-from-folder', function () {
+    it('should be undefined by default', function (done) {
+        options({}, function (err, result) {
+            expect(err).to.be.null;
+            expect(result.itemFromFolder).to.be.undefined;
+            done();
+        });
+    });
+
+    it('should handle options.itemFromFolder passed as string correctly', function (done) {
+        options({ itemFromFolder: 'f1' }, function (err, result) {
+            expect(err).to.be.null;
+            expect(result.itemFromFolder).to.eql('f1');
+            done();
+        });
+    });
+
+    it('should use multipleIdOrName strategy if options.itemFromFolder is passed as an array', function (done) {
+        options({ itemFromFolder: ['f1', 'f2'] }, function (err, result) {
+            expect(err).to.be.null;
+            expect(result.itemFromFolder).to.eql(['f1', 'f2']);
+            done();
+        });
+    });
+});
+


### PR DESCRIPTION
Fixes #2566.

**What does this PR do?**
This PR is a follow-up to the feature request mentioned under the above cited issue.
It allows the user to specify a path to an item which doesn't have unique name in the collection and runs the item at the specified path.

**What changes have been made?**
- An extra option --item-from-folder has been added.
- It can have one or more than one arguments.
- It uses string for one argument and array for more than one arguments.
- It overrides folder option if both are specified.
- It halts the run if the path specified is invalid.
- Unit, Library and Integration Tests have been added.

**What things are still expected?**
Since I am still working on it, there will be following changes:
- Currently, only paths of depth 2 are supported, i.e myFolder/myRequest. Functionality for deeper paths is being implemented.
- Functionality for more than one arguments is being implemented.
- Some more unit tests will be added.
- CLI tests will be added.
P.S. Coverage may not be appropriate right now but will increase surely once remaining CLI and Unit tests are added.