### PR TITLE
Feature: Add start and end times of each iteration to JSON report.

### DIFF
--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -18,7 +18,7 @@ var _ = require('lodash'),
      */
     runtimeEvents = {
         start: [],
-        beforeIteration: [],
+        beforeIteration: ['item', 'executions'],
         beforeItem: ['item'],
         beforePrerequest: ['events', 'item'],
         prerequest: ['executions', 'item'],
@@ -27,7 +27,7 @@ var _ = require('lodash'),
         beforeTest: ['events', 'item'],
         test: ['executions', 'item'],
         item: ['item'],
-        iteration: [],
+        iteration: ['item', 'executions'],
         beforeScript: ['script', 'event', 'item'],
         script: ['execution', 'script', 'event', 'item']
     },

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -18,7 +18,7 @@ var _ = require('lodash'),
      */
     runtimeEvents = {
         start: [],
-        beforeIteration: ['item', 'executions'],
+        beforeIteration: [],
         beforeItem: ['item'],
         beforePrerequest: ['events', 'item'],
         prerequest: ['executions', 'item'],
@@ -27,7 +27,7 @@ var _ = require('lodash'),
         beforeTest: ['events', 'item'],
         test: ['executions', 'item'],
         item: ['item'],
-        iteration: ['item', 'executions'],
+        iteration: [],
         beforeScript: ['script', 'event', 'item'],
         script: ['execution', 'script', 'event', 'item']
     },

--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -267,6 +267,8 @@ _.assign(RunSummary, {
     attachTimingTrackers (summary, emitter) {
         // mark the point when the run started
         // also mark the point when run completed and also store error if needed
+        var x = 0;
+
         emitter.on('start', function () {
             summary.run.timings.started = Date.now();
             summary.run.timings.iterationData = [];
@@ -277,11 +279,15 @@ _.assign(RunSummary, {
         emitter.on('done', function (err) {
             err && (summary.error = err);
         });
-        emitter.on('beforeIteration', function(cursor) {
-            // console.log(summary.run.executions);
+        emitter.on('beforeIteration', function () {
+            summary.run.timings.iterationData && summary.run.timings.iterationData.push({
+                iteration: x + 1, started: Date.now() });
         });
         emitter.on('iteration', function () {
-             console.log(summary.run);
+            if (summary.run.timings.iterationData) {
+                summary.run.timings.iterationData[x].completed = Date.now();
+            }
+            x++;
         });
     },
     attachStatisticTrackers (summary, emitter) {

--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -267,12 +267,21 @@ _.assign(RunSummary, {
     attachTimingTrackers (summary, emitter) {
         // mark the point when the run started
         // also mark the point when run completed and also store error if needed
-        emitter.on('start', function () { summary.run.timings.started = Date.now(); });
+        emitter.on('start', function () {
+            summary.run.timings.started = Date.now();
+            summary.run.timings.iterationData = [];
+        });
         emitter.on('beforeDone', function () {
             summary.run.timings.completed = Date.now();
         });
         emitter.on('done', function (err) {
             err && (summary.error = err);
+        });
+        emitter.on('beforeIteration', function(cursor) {
+            // console.log(summary.run.executions);
+        });
+        emitter.on('iteration', function () {
+             console.log(summary.run);
         });
     },
     attachStatisticTrackers (summary, emitter) {


### PR DESCRIPTION
Fixes #2655 

**What does this PR do?**
This PR is an enhancement and adds start times and end times of each iteration to the JSON report.

**What changes have been made?**
- A timing tracker has been attached to the iteration event.
- Start time is recorded when ' beforeIteration '  event is fired.
- End time is recorded when ' iteration ' event is fired.
- The timing details contain an attribute iterationData which consists of start time and end time.