### PR TITLE
Newman Command for Single Request

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -85,6 +85,74 @@ program
         });
     });
 
+// The `request` command allows you to run single request with the provided options.
+program
+    .command('request <url>')
+    .description('Run single request with provided options')
+    .usage('<url> [options]')
+    .option('--request, -X <method>', 'Specify request method', 'GET')
+    .option('--header, -H <header>', 'Specify request header', util.cast.memoize,  [])
+    .option('-e, --environment <path>', 'Specify a URL or path to a Postman Environment')
+    .option('-g, --globals <path>', 'Specify a URL or path to a file containing Postman Globals')
+    .option('-r, --reporters [reporters]', 'Specify the reporters to use for this run', util.cast.csvParse, ['cli'])
+    .option('-n, --iteration-count <n>', 'Define the number of iterations to run', util.cast.integer)
+    .option('-d, --iteration-data <path>', 'Specify a data file to use for iterations (either JSON or CSV)')
+    .option('--global-var <value>',
+        'Allows the specification of global variables via the command line, in a key=value format',
+        util.cast.memoizeKeyVal, [])
+    .option('--env-var <value>',
+        'Allows the specification of environment variables via the command line, in a key=value format',
+        util.cast.memoizeKeyVal, [])
+    .option('--export-environment <path>', 'Exports the final environment to a file after completing the run')
+    .option('--export-globals <path>', 'Exports the final globals to a file after completing the run')
+    .option('--export-collection <path>', 'Exports the executed collection to a file after completing the run')
+    .option('--postman-api-key <apiKey>', 'API Key used to load the resources from the Postman API')
+    .option('--bail [modifiers]',
+        'Specify whether or not to gracefully stop a collection run on encountering an error' +
+        ' and whether to end the run with an error based on the optional modifier', util.cast.csvParse)
+    .option('--ignore-redirects', 'Prevents Newman from automatically following 3XX redirect responses')
+    .option('-x , --suppress-exit-code', 'Specify whether or not to override the default exit code for the current run')
+    .option('--silent', 'Prevents Newman from showing output to CLI')
+    .option('--disable-unicode', 'Forces Unicode compliant symbols to be replaced by their plain text equivalents')
+    .option('--color <value>', 'Enable/Disable colored output (auto|on|off)', util.cast.colorOptions, 'auto')
+    .option('--delay-request [n]', 'Specify the extent of delay between requests (milliseconds)', util.cast.integer, 0)
+    .option('--timeout [n]', 'Specify a timeout for collection run (milliseconds)', util.cast.integer, 0)
+    .option('--timeout-request [n]', 'Specify a timeout for requests (milliseconds)', util.cast.integer, 0)
+    .option('--timeout-script [n]', 'Specify a timeout for scripts (milliseconds)', util.cast.integer, 0)
+    .option('--working-dir <path>', 'Specify the path to the working directory')
+    .option('--no-insecure-file-read', 'Prevents reading the files situated outside of the working directory')
+    .option('-k, --insecure', 'Disables SSL validations')
+    .option('--ssl-client-cert-list <path>', 'Specify the path to a client certificates configurations (JSON)')
+    .option('--ssl-client-cert <path>', 'Specify the path to a client certificate (PEM)')
+    .option('--ssl-client-key <path>', 'Specify the path to a client certificate private key')
+    .option('--ssl-client-passphrase <passphrase>', 'Specify the client certificate passphrase (for protected key)')
+    .option('--ssl-extra-ca-certs <path>', 'Specify additionally trusted CA certificates (PEM)')
+    .option('--cookie-jar <path>', 'Specify the path to a custom cookie jar (serialized tough-cookie JSON) ')
+    .option('--export-cookie-jar <path>', 'Exports the cookie jar to a file after completing the run')
+    .option('--verbose', 'Show detailed information of collection run and each request sent')
+    .action((url, command) => {
+        let options = util.commanderToObject(command),
+
+            // parse custom reporter options
+            reporterOptions = util.parseNestedOptions(program._originalArgs, '--reporter-', options.reporters);
+            const curl =  util.createCurl(options, url);
+        // Inject additional properties into the options object
+        options.curl = curl;
+        options.reporterOptions = reporterOptions._generic;
+        options.reporter = _.transform(_.omit(reporterOptions, '_generic'), (acc, value, key) => {
+            acc[key] = _.assignIn(value, reporterOptions._generic); // overrides reporter options with _generic
+        }, {});
+        
+        newman.run(options, function (err, summary) {
+            const runError = err || summary.run.error || summary.run.failures.length;
+
+            if (err) {
+                console.error(`error: ${err.message || err}\n`);
+                err.friendly && console.error(`  ${err.friendly}\n`);
+            }
+            runError && !_.get(options, 'suppressExitCode') && process.exit(1);
+        });
+    });
 program.on('--help', function () {
     console.info('\nTo get available options for a command:');
     console.info('  newman <command> -h');

--- a/bin/util.js
+++ b/bin/util.js
@@ -101,6 +101,31 @@ module.exports = {
         }, {});
     },
 
+/**
+     * Extract curl options in the provided options.
+     * Create curl  command from the options.
+     *
+     * @param {Object} options - Commander.Command Instance
+     * @param {String} url - Requested url
+     * @returns {String} - Curl command
+     */
+    createCurl: (options, url) => {
+        const curlOptions = _.reduce(options, (result, value, key) => {
+            // Exclude non curl options
+            const validProp = _.includes(['X', 'H', 'A', 'd'], key);
+
+            validProp && (result[key] = value);
+
+            return result;
+        }, {});
+
+        const headers = _.reduce(curlOptions.H, (result, value)  => {
+            return result + `-H '${value}' `
+        }, '');
+
+        return `curl -X ${curlOptions.X} ${url} ${headers}`;
+    },
+
     /**
      * Remove nested options having the provided prefix from `process.argv`.
      *

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -1,6 +1,7 @@
 var _ = require('lodash'),
     asyncEach = require('async/each'),
     sdk = require('postman-collection'),
+    curl2postman = require('curl-to-postmanv2'),
     runtime = require('postman-runtime'),
     request = require('postman-request'),
     EventEmitter = require('eventemitter3'),
@@ -71,6 +72,7 @@ var _ = require('lodash'),
  *
  * @param {Object} options - The set of wrapped options, passed by the CLI parser.
  * @param {Collection|Object|String} options.collection - A JSON / Collection / String representing the collection.
+ * @param {String} options.curl - Curl command representing a single request.
  * @param {Object|String} options.environment - An environment JSON / file path for the current collection run.
  * @param {Object|String} options.globals - A globals JSON / file path for the current collection run.
  * @param {String} options.workingDir - Path of working directory that contains files needed for the collection run.
@@ -104,8 +106,8 @@ module.exports = function (options, callback) {
             return callback(err);
         }
 
-        // ensure that the collection option is present before starting a run
-        if (!_.isObject(options.collection)) {
+        // ensure that the collection or curl is present before starting a run
+        if (!_.isObject(options.collection) && !_.isString(options.curl)) {
             return callback(new Error('expecting a collection to run'));
         }
 
@@ -113,7 +115,24 @@ module.exports = function (options, callback) {
         // different URLs
         var sslClientCertList = options.sslClientCertList || [],
             // allow providing custom cookieJar
-            cookieJar = options.cookieJar || request.jar();
+            cookieJar = options.cookieJar || request.jar(),
+            collection = options.collection;
+
+
+        // @todo: move this to configLoaders in options.js...
+        // @todo: ...and/or maybe make request function separate from run function
+        if (_.isString(options.curl)) {
+            curl2postman.convert({ type: 'string', data: options.curl }, function (err, result) {
+                if (err) {
+                    return callback(err);
+                }
+                collection = new sdk.Collection();
+                collection.items.add({
+                    name: result.output[0] && result.output[0].data.name,
+                    request: result.output[0] && result.output[0].data
+                });
+            });
+        } 
 
         // if sslClientCert option is set, put it at the end of the list to
         // match all URLs that didn't match in the list
@@ -157,7 +176,7 @@ module.exports = function (options, callback) {
         emitter.exports = [];
 
         // now start the run!
-        runner.run(options.collection, {
+        runner.run(collection, {
             stopOnFailure: stopOnFailure, // LOL, you just got trolled ¯\_(ツ)_/¯
             abortOnFailure: options.abortOnFailure, // used in integration tests, to be considered for a future release
             abortOnError: _.get(options, 'bail.folder'),

--- a/npm/test-lint.js
+++ b/npm/test-lint.js
@@ -32,7 +32,7 @@ module.exports = function (exit) {
          * @returns {*}
          */
         function (next) {
-            next(null, (new ESLintCLIEngine()).executeOnFiles(LINT_SOURCE_DIRS));
+            next(null, (new ESLintCLIEngine({ fix: true })).executeOnFiles(LINT_SOURCE_DIRS));
         },
 
         /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -648,6 +648,26 @@
       "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
       "dev": true
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+    },
+    "array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+    },
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -1294,6 +1314,38 @@
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.14.2.tgz",
       "integrity": "sha512-YE2xlTKtM035/94llhgsp9qFQxGi47EkQJ1pZ+mLT/98GpIsbjkMGAb7Rmu9hNxVfYFOLf10hP+rPVqnoccLgw=="
+    },
+    "curl": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/curl/-/curl-0.1.4.tgz",
+      "integrity": "sha1-xPX744swOaa1VbzC+ISjsDNCfiM=",
+      "requires": {
+        "request": ">=0.1.0",
+        "router": ">=0.3.0"
+      }
+    },
+    "curl-to-postmanv2": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/curl-to-postmanv2/-/curl-to-postmanv2-0.5.1.tgz",
+      "integrity": "sha512-XzS4EfUX8a6ZindDwLM6yN+yLtAJGQGRGghsHj4Yp7xZ4Mz7nK+7qZXnHVF4e7hARKhP+kYsLjc+ZsODUVUb4A==",
+      "requires": {
+        "commander": "2.15.1",
+        "lodash": "^4.17.11",
+        "shell-quote": "1.6.1",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+        }
+      }
     },
     "cycle": {
       "version": "1.0.3",
@@ -2031,6 +2083,16 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fromentries": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
@@ -2755,6 +2817,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -3046,6 +3113,11 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime-db": {
       "version": "1.45.0",
@@ -3623,6 +3695,11 @@
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
       "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4132,6 +4209,54 @@
         "es6-error": "^4.0.1"
       }
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4186,6 +4311,40 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "router": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/router/-/router-1.3.5.tgz",
+      "integrity": "sha512-kozCJZUhuSJ5VcLhSb3F8fsmGXy+8HaDbKCAerR1G6tq3mnMZFMuSohbFvGv1c5oMFipijDjRZuuN/Sq5nMf3g==",
+      "requires": {
+        "array-flatten": "3.0.0",
+        "debug": "2.6.9",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "setprototypeof": "1.2.0",
+        "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        }
       }
     },
     "safe-buffer": {
@@ -4291,6 +4450,11 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4305,6 +4469,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "requires": {
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
+      }
     },
     "shelljs": {
       "version": "0.8.4",
@@ -4819,6 +4994,14 @@
         "punycode": "^2.1.1"
       }
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -4912,6 +5095,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "colors": "1.4.0",
     "commander": "6.2.1",
     "csv-parse": "4.14.2",
+    "curl": "^0.1.4",
+    "curl-to-postmanv2": "0.5.1",
     "eventemitter3": "4.0.7",
     "filesize": "6.1.0",
     "lodash": "4.17.20",


### PR DESCRIPTION
Proof of concept to create `newman request` according to following expected output:

1. Users can send a single request with Newman and show the request/response using a reporter of their choice.
2. Replacing curl with newman request in a curl command should run the send the request using Newman.

Supported commands (The following commands show expected output in POC)

```
newman request -X GET http://www.google.com -r cli,json

newman request -X POST  https://postman-echo.com/post -H 'Content-Type: text/plain'  -r progress

```