### PR TITLE
Change the sequence to use object destructuring

### DIFF
--- a/lib/run/export-file.js
+++ b/lib/run/export-file.js
@@ -5,10 +5,7 @@ var fs = require('fs'),
     async = require('async'),
     mkdirp = require('mkdirp'),
 
-    // @todo: ES6: Change the sequence below to use object destructuring when Node v4 support is dropped
-    joinPath = nodePath.join,
-    parsePath = nodePath.parse,
-    resolvePath = nodePath.resolve,
+    { join: joinPath, parse: parsePath, resolve: resolvePath } = nodePath,
 
     /**
      * The root path specifier


### PR DESCRIPTION
As I was going through the codebase, I came across this comment
```
    // @todo: ES6: Change the sequence below to use object destructuring when Node v4 support is dropped
   joinPath = nodePath.join,
   parsePath = nodePath.parse,
   resolvePath = nodePath.resolve,
```
As `Node v4` support has been dropped, I think it's safe to use Object destructing instead.