### PR TITLE
Feature: Ignore iterations from start.

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -34,6 +34,8 @@ program
     .option('--env-var <value>',
         'Allows the specification of environment variables via the command line, in a key=value format',
         util.cast.memoizeKeyVal, [])
+    .option('-s,--skip-iteration <value>',
+        'Option to specify the no. of iterations that must be skipped in the data file from the start.')
     .option('--export-environment <path>', 'Exports the final environment to a file after completing the run')
     .option('--export-globals <path>', 'Exports the final globals to a file after completing the run')
     .option('--export-collection <path>', 'Exports the executed collection to a file after completing the run')

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -34,8 +34,8 @@ program
     .option('--env-var <value>',
         'Allows the specification of environment variables via the command line, in a key=value format',
         util.cast.memoizeKeyVal, [])
-    .option('-s,--skip-iteration <value>',
-        'Option to specify the no. of iterations that must be skipped in the data file from the start.')
+    .option('--ignore-iteration <n>',
+        'Option to specify the no. of iterations that must be ignored in the data file from the start.')
     .option('--export-environment <path>', 'Exports the final environment to a file after completing the run')
     .option('--export-globals <path>', 'Exports the final globals to a file after completing the run')
     .option('--export-collection <path>', 'Exports the executed collection to a file after completing the run')

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -96,7 +96,8 @@ module.exports = function (options, callback) {
     var emitter = new EventEmitter(), // @todo: create a new inherited constructor
         runner = new runtime.Runner(),
         stopOnFailure,
-        entrypoint;
+        entrypoint,
+        iterationDataLength;
 
     // get the configuration from various sources
     getOptions(options, function (err, options) {
@@ -149,6 +150,16 @@ module.exports = function (options, callback) {
         (typeof options.bail !== 'undefined' &&
             (options.bail === true || (_.isObject(options.bail) && options.bail.failure))) ?
             stopOnFailure = true : stopOnFailure = false;
+
+        if (options.skipIteration) {
+            iterationDataLength = options.iterationData.length;
+            let n = options.skipIteration;
+
+            n = n > 0 && n < iterationDataLength ? n : 0;
+            if (n) {
+                options.iterationData = options.iterationData.slice(n - 1, iterationDataLength - 1);
+            }
+        }
 
         // store summary object and other relevant information inside the emitter
         emitter.summary = new RunSummary(emitter, options);

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -97,6 +97,7 @@ module.exports = function (options, callback) {
         runner = new runtime.Runner(),
         stopOnFailure,
         entrypoint,
+        ignoreIteration,
         iterationDataLength;
 
     // get the configuration from various sources
@@ -151,14 +152,10 @@ module.exports = function (options, callback) {
             (options.bail === true || (_.isObject(options.bail) && options.bail.failure))) ?
             stopOnFailure = true : stopOnFailure = false;
 
-        if (options.skipIteration) {
-            iterationDataLength = options.iterationData.length;
-            let n = options.skipIteration;
-
-            n = n > 0 && n < iterationDataLength ? n : 0;
-            if (n) {
-                options.iterationData = options.iterationData.slice(n - 1, iterationDataLength);
-            }
+        ignoreIteration = options.ignoreIteration;
+        if (options.iterationData) { iterationDataLength = options.iterationData.length; }
+        if (iterationDataLength && ignoreIteration > 0 && ignoreIteration < iterationDataLength) {
+            options.iterationData = options.iterationData.slice(ignoreIteration - 1, iterationDataLength);
         }
 
         // store summary object and other relevant information inside the emitter

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -155,9 +155,8 @@ module.exports = function (options, callback) {
         ignoreIteration = options.ignoreIteration;
         if (options.iterationData) { iterationDataLength = options.iterationData.length; }
         if (iterationDataLength && ignoreIteration > 0 && ignoreIteration < iterationDataLength) {
-            options.iterationData = options.iterationData.slice(ignoreIteration - 1, iterationDataLength);
+            options.iterationData = options.iterationData.slice(ignoreIteration, iterationDataLength);
         }
-
         // store summary object and other relevant information inside the emitter
         emitter.summary = new RunSummary(emitter, options);
 

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -157,7 +157,7 @@ module.exports = function (options, callback) {
 
             n = n > 0 && n < iterationDataLength ? n : 0;
             if (n) {
-                options.iterationData = options.iterationData.slice(n - 1, iterationDataLength - 1);
+                options.iterationData = options.iterationData.slice(n - 1, iterationDataLength);
             }
         }
 
@@ -333,7 +333,6 @@ module.exports = function (options, callback) {
                                     .value()
                         });
                     });
-
                     asyncEach(emitter.exports, exportFile, function (err) {
                         // we now trigger actual done event which we had overridden
                         emitter.emit('done', err, emitter.summary);

--- a/test/cli/run-options.test.js
+++ b/test/cli/run-options.test.js
@@ -125,4 +125,15 @@ describe('CLI run options', function () {
             });
         });
     });
+
+    describe('Option --ignore-iteration ', function () {
+        it('should work correctly when specified', function (done) {
+            // eslint-disable-next-line max-len
+            exec('node ./bin/newman.js run test/integration/steph/steph.postman_collection.json -d test/integration/steph/steph.postman_data.json --ignore-iteration 1', function (code, stdout, stderr) {
+                expect(code, 'should have zero exit code').to.equal(0);
+                expect(stderr).to.be.empty;
+                done();
+            });
+        });
+    });
 });

--- a/test/library/run-options.test.js
+++ b/test/library/run-options.test.js
@@ -1,5 +1,7 @@
 var _ = require('lodash'),
-    runtimeVersion = require('../../package.json').dependencies['postman-runtime'];
+    runtimeVersion = require('../../package.json').dependencies['postman-runtime'],
+    path = require('path'),
+    fs = require('fs');
 
 describe('Newman run options', function () {
     var collection = 'test/fixtures/run/single-get-request.json';
@@ -235,6 +237,31 @@ describe('Newman run options', function () {
             }, function (err, summary) {
                 expect(err).to.be.null;
                 expect(summary).to.be.ok;
+                done();
+            });
+        });
+    });
+
+    describe('Option --ignore-iteration ', function () {
+        var iterationProperty = 'run.stats.iterations.total',
+            collectionRunPath = path.join(__dirname, '..', '..', 'out', 'iteration-count-test.json');
+
+        it('should work correctly when specified', function (done) {
+            newman.run({
+                collection: 'test/integration/steph/steph.postman_collection.json',
+                iterationData: 'test/integration/steph/steph.postman_data.json',
+                reporters: ['json'],
+                reporter: { json: { export: collectionRunPath } },
+                ignoreIteration: 1
+            }, function (err) {
+                if (err) { return done(err); }
+
+                var collectionRun;
+
+                try { collectionRun = JSON.parse(fs.readFileSync(collectionRunPath).toString()); }
+                catch (e) { console.error(e); }
+
+                expect(_.get(collectionRun, iterationProperty), 'should have 1 iterations').to.equal(1);
                 done();
             });
         });

--- a/test/unit/options.test.js
+++ b/test/unit/options.test.js
@@ -97,4 +97,27 @@ describe('options', function () {
             done();
         });
     });
+
+    describe('Option --ignore-iteration ', function () {
+        it('should be undefined by default', function (done) {
+            options({
+                iterationData: './test/fixtures/run/spaces/data.json'
+            }, function (err, result) {
+                expect(err).to.be.null;
+                expect(result.igonoreiteration).to.be.undefined;
+                done();
+            });
+        });
+
+        it('should work correctly when specified', function (done) {
+            options({
+                iterationData: './test/fixtures/run/spaces/data.json',
+                ignoreiteration: 1
+            }, function (err, result) {
+                expect(err).to.be.null;
+                expect(result.ignoreiteration).to.equal(1);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Fixes #2168 

**What does this PR do?**
This PR is in response to the feature request received under the above mentioned issue.
Functionality to skip iterations in case of csv files has been added.

**What changes have been made?**
- An option --skip-iteration has been added.
- User can skip some specified no. of iterations from the start.
- There is a lower bound and an upper bound on the no. of iterations skipped.

P.S. Tests are coming soon.