### PR TITLE
add file extension based loading

### DIFF
--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -272,7 +272,7 @@ var _ = require('lodash'),
                     return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n  ${err.message || err}`));
                 }
 
-                // Try loading as a JSON, fall-back to CSV. @todo: switch to file extension based loading.
+                // Try loading as a JSON, fall-back to CSV.
                 async.waterfall([
                     (cb) => {
                         try {

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -1,6 +1,6 @@
 var _ = require('lodash'),
     fs = require('fs'),
-    async = require('async'),
+    // async = require('async'),
     Collection = require('postman-collection').Collection,
     VariableScope = require('postman-collection').VariableScope,
     CookieJar = require('tough-cookie').CookieJar,
@@ -271,39 +271,30 @@ var _ = require('lodash'),
                 if (err) {
                     return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n  ${err.message || err}`));
                 }
+                // parse the data according to the file extension
+                try { // check the file extension using the file location
+                    if (location.split(/[#?]/)[0].split('.').pop().trim() === 'json') {
+                        return callback(null, liquidJSON.parse(data.trim()));
+                    } // if file extension is not json then parse csv
+                    parseCsv(data, {
+                        columns: true, // infer the columns names from the first row
+                        escape: '"', // escape character
+                        cast: csvAutoParse, // function to cast values of individual fields
+                        trim: true, // ignore whitespace immediately around the delimiter
+                        relax: true, // allow using quotes without escaping inside unquoted string
+                        relax_column_count: true, // ignore inconsistent columns count
+                        bom: true // strip the byte order mark (BOM) from the input string
+                    }, (err, parsedData) => {
+                        if (err || !parsedData) {
+                            return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n ${err.message || err}`));
+                        }
 
-                // Try loading as a JSON, fall-back to CSV. @todo: switch to file extension based loading.
-                async.waterfall([
-                    (cb) => {
-                        try {
-                            return cb(null, liquidJSON.parse(data.trim()));
-                        }
-                        catch (e) {
-                            return cb(null, undefined); // e masked to avoid displaying JSON parse errors for CSV files
-                        }
-                    },
-                    (json, cb) => {
-                        if (json) {
-                            return cb(null, json);
-                        }
-                        // Wasn't JSON
-                        parseCsv(data, {
-                            columns: true, // infer the columns names from the first row
-                            escape: '"', // escape character
-                            cast: csvAutoParse, // function to cast values of individual fields
-                            trim: true, // ignore whitespace immediately around the delimiter
-                            relax: true, // allow using quotes without escaping inside unquoted string
-                            relax_column_count: true, // ignore inconsistent columns count
-                            bom: true // strip the byte order mark (BOM) from the input string
-                        }, cb);
-                    }
-                ], (err, parsed) => {
-                    if (err) {
-                        return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n ${err.message || err}`));
-                    }
-
-                    callback(null, parsed);
-                });
+                        return callback(null, parsedData);
+                    });
+                }
+                catch (e) {
+                    return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n ${e}`));
+                }
             });
         },
 

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -1,6 +1,6 @@
 var _ = require('lodash'),
     fs = require('fs'),
-    // async = require('async'),
+    async = require('async'),
     Collection = require('postman-collection').Collection,
     VariableScope = require('postman-collection').VariableScope,
     CookieJar = require('tough-cookie').CookieJar,
@@ -271,30 +271,39 @@ var _ = require('lodash'),
                 if (err) {
                     return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n  ${err.message || err}`));
                 }
-                // parse the data according to the file extension
-                try { // check the file extension using the file location
-                    if (location.split(/[#?]/)[0].split('.').pop().trim() === 'json') {
-                        return callback(null, liquidJSON.parse(data.trim()));
-                    } // if file extension is not json then parse csv
-                    parseCsv(data, {
-                        columns: true, // infer the columns names from the first row
-                        escape: '"', // escape character
-                        cast: csvAutoParse, // function to cast values of individual fields
-                        trim: true, // ignore whitespace immediately around the delimiter
-                        relax: true, // allow using quotes without escaping inside unquoted string
-                        relax_column_count: true, // ignore inconsistent columns count
-                        bom: true // strip the byte order mark (BOM) from the input string
-                    }, (err, parsedData) => {
-                        if (err || !parsedData) {
-                            return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n ${err.message || err}`));
-                        }
 
-                        return callback(null, parsedData);
-                    });
-                }
-                catch (e) {
-                    return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n ${e}`));
-                }
+                // Try loading as a JSON, fall-back to CSV. @todo: switch to file extension based loading.
+                async.waterfall([
+                    (cb) => {
+                        try {
+                            return cb(null, liquidJSON.parse(data.trim()));
+                        }
+                        catch (e) {
+                            return cb(null, undefined); // e masked to avoid displaying JSON parse errors for CSV files
+                        }
+                    },
+                    (json, cb) => {
+                        if (json) {
+                            return cb(null, json);
+                        }
+                        // Wasn't JSON
+                        parseCsv(data, {
+                            columns: true, // infer the columns names from the first row
+                            escape: '"', // escape character
+                            cast: csvAutoParse, // function to cast values of individual fields
+                            trim: true, // ignore whitespace immediately around the delimiter
+                            relax: true, // allow using quotes without escaping inside unquoted string
+                            relax_column_count: true, // ignore inconsistent columns count
+                            bom: true // strip the byte order mark (BOM) from the input string
+                        }, cb);
+                    }
+                ], (err, parsed) => {
+                    if (err) {
+                        return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n ${err.message || err}`));
+                    }
+
+                    callback(null, parsed);
+                });
             });
         },
 


### PR DESCRIPTION
Going through the code base there was a todo marked at the `lib\run\options.js` in `iterationData` function to change the loading of iteration data to extension based loading. Following changes have been made in the file.

- remove `async.waterfall` function
- getting the file extension from the file location
- parsing the file according to the extension
- remove the import of `async` as it was no longer required