### PR TITLE
Enhancement: Preserve order of Folders when specified.

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -28,6 +28,8 @@ program
     .option('--folder <path>',
         'Specify the folder to run from a collection. Can be specified multiple times to run multiple folders',
         util.cast.memoize, [])
+    .option('--preserve-order',
+        'Specify if the order of folder arguments in the command line should be preserved.', false)
     .option('--global-var <value>',
         'Allows the specification of global variables via the command line, in a key=value format',
         util.cast.memoizeKeyVal, [])

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -137,10 +137,12 @@ module.exports = function (options, callback) {
 
         // sets entrypoint to execute if options.folder is specified.
         if (options.folder) {
+            // specify of the order should be preserved or not.
             entrypoint = { execute: options.folder };
 
             // uses `multipleIdOrName` lookupStrategy in case of multiple folders.
             _.isArray(entrypoint.execute) && (entrypoint.lookupStrategy = MULTIENTRY_LOOKUP_STRATEGY);
+            entrypoint.preserveOrder = options.preserveOrder;
         }
 
         // sets stopOnFailure to true in case bail is used without any modifiers or with failure

--- a/test/library/folder-variants.test.js
+++ b/test/library/folder-variants.test.js
@@ -30,6 +30,31 @@ describe('folder variants', function () {
         });
     });
 
+    it('should not preserve the order if not specified', function (done) {
+        newman.run({
+            collection: collection,
+            folder: ['R3', 'R1'],
+            preserveOrder: false
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1', 'R3']);
+            done();
+        });
+    });
+
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip('should preserve the order if specified', function (done) {
+        newman.run({
+            collection: collection,
+            folder: ['R3', 'R1'],
+            preserveOrder: true
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R3', 'R1']);
+            done();
+        });
+    });
+
     it('should skip the collection run in case folder name is invalid', function (done) {
         newman.run({
             collection: collection,

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -49,6 +49,7 @@ describe('cli parser', function () {
                         globalVar: [],
                         envVar: [],
                         folder: [],
+                        preserveOrder: false,
                         insecureFileRead: true,
                         color: 'auto',
                         timeout: 0,

--- a/test/unit/run.test.js
+++ b/test/unit/run.test.js
@@ -282,25 +282,26 @@ describe('run module', function () {
             });
 
             it('should handle options.folder passed as string correctly', function (done) {
-                run({ collection: {}, folder: 'f1' }, function (options) {
-                    expect(options).to.have.deep.property('entrypoint', { execute: 'f1' });
+                run({ collection: {}, folder: 'f1', preserveOrder: false }, function (options) {
+                    expect(options).to.have.deep.property('entrypoint', { execute: 'f1', preserveOrder: false });
                     done();
                 });
             });
 
             it('should use multipleIdOrName strategy if options.folder is passed as an array', function (done) {
-                run({ collection: {}, folder: ['f1', 'f2'] }, function (options) {
+                run({ collection: {}, folder: ['f1', 'f2'], preserveOrder: true }, function (options) {
                     expect(options).to.have.deep.property('entrypoint', {
                         execute: ['f1', 'f2'],
-                        lookupStrategy: 'multipleIdOrName'
+                        lookupStrategy: 'multipleIdOrName',
+                        preserveOrder: true
                     });
                     done();
                 });
             });
 
             it('should not use multipleIdOrName strategy if options.folder is a single item array', function (done) {
-                run({ collection: {}, folder: ['f1'] }, function (options) {
-                    expect(options).to.have.property('entrypoint').to.eql({ execute: 'f1' });
+                run({ collection: {}, folder: ['f1'], preserveOrder: false }, function (options) {
+                    expect(options).to.have.property('entrypoint').to.eql({ execute: 'f1', preserveOrder: false });
                     done();
                 });
             });


### PR DESCRIPTION
Fixes #2085 
**What does this PR do?**
This PR introduces an option --preserve-order which defaults to false.
This option preserves the order in which the arguments are passed to folder option.
**For example:** 
Consider ' newman run test/collection.json --folder R2 --folder R1  --preserve-order' to be run.
Then R2 will be run before R1 even if R1 is ahead in the original collection.

**What changes have been made?**
- An option --preserve-order has been introduced.
- This defaults to false.
- When set true, it preserves the order of the folders, as specified in the command line.
- Library and Unit tests have been added.

**Important:**
These changes depend on the changes proposed under [#1137](https://github.com/postmanlabs/postman-runtime/pull/1137)
in the postman-runtime by me.
Hence, the functionality may not be working but it has been tested locally.
