### PR TITLE
chore: update to WHATWG url api

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -194,7 +194,7 @@ util = {
                     urlObj = new URL(location);
 
                     (urlObj.hostname === POSTMAN_API_HOST) &&
-                        (resource = _(urlObj.path).split('/').get(1).slice(0, -1) || resource);
+                        (resource = _(urlObj.pathname).split('/').get(1).slice(0, -1) || resource);
 
                     error = new Error(_.get(body, 'error.message',
                         `Error fetching ${resource}, the provided URL returned status code: ${response.statusCode}`));

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,5 @@
 var fs = require('fs'),
-    url = require('url'),
+    { URL } = require('url'),
 
     _ = require('lodash'),
     chardet = require('chardet'),
@@ -191,7 +191,7 @@ util = {
                     resource = 'resource';
 
                 if (response.statusCode !== 200) {
-                    urlObj = url.parse(location);
+                    urlObj = new URL(location);
 
                     (urlObj.hostname === POSTMAN_API_HOST) &&
                         (resource = _(urlObj.path).split('/').get(1).slice(0, -1) || resource);


### PR DESCRIPTION
NodeJS has deprecated the [Legacy URL API](https://nodejs.org/api/deprecations.html#deprecations_dep0116_legacy_url_api) which was being used in ```utils.js``` and recommends moving to the [WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api).

I don't believe this change can fix https://github.com/postmanlabs/newman/issues/1991 but I'll be happy to look into it deeper.