### PR TITLE
fix: error handling for parsing iteration data files

### DIFF
--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -267,24 +267,21 @@ var _ = require('lodash'),
         iterationData: function (location, options, callback) {
             if (_.isArray(location)) { return callback(null, location); }
 
-            util.fetch(location, function (err, data) {
+            util.fetch(location, function (err, data, fileType) {
                 if (err) {
                     return callback(new Error(ITERATION_DATA_LOAD_ERROR_MESSAGE + `\n  ${err.message || err}`));
                 }
 
-                // Try loading as a JSON, fall-back to CSV.
+                // Check if the file is JSON else parse as CSV
                 async.waterfall([
                     (cb) => {
-                        try {
-                            return cb(null, liquidJSON.parse(data.trim()));
-                        }
-                        catch (e) {
-                            return cb(null, undefined); // e masked to avoid displaying JSON parse errors for CSV files
-                        }
-                    },
-                    (json, cb) => {
-                        if (json) {
-                            return cb(null, json);
+                        if (fileType === '.json') {
+                            try {
+                                return cb(null, liquidJSON.parse(data.trim()));
+                            }
+                            catch (e) {
+                                return cb(e, undefined);
+                            }
                         }
                         // Wasn't JSON
                         parseCsv(data, {

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -283,16 +283,21 @@ var _ = require('lodash'),
                                 return cb(e, undefined);
                             }
                         }
-                        // Wasn't JSON
-                        parseCsv(data, {
-                            columns: true, // infer the columns names from the first row
-                            escape: '"', // escape character
-                            cast: csvAutoParse, // function to cast values of individual fields
-                            trim: true, // ignore whitespace immediately around the delimiter
-                            relax: true, // allow using quotes without escaping inside unquoted string
-                            relax_column_count: true, // ignore inconsistent columns count
-                            bom: true // strip the byte order mark (BOM) from the input string
-                        }, cb);
+                        else if (fileType === '.csv') {
+                            // Wasn't JSON
+                            parseCsv(data, {
+                                columns: true, // infer the columns names from the first row
+                                escape: '"', // escape character
+                                cast: csvAutoParse, // function to cast values of individual fields
+                                trim: true, // ignore whitespace immediately around the delimiter
+                                relax: true, // allow using quotes without escaping inside unquoted string
+                                relax_column_count: true, // ignore inconsistent columns count
+                                bom: true // strip the byte order mark (BOM) from the input string
+                            }, cb);
+                        }
+                        else {
+                            return cb('Invalid file for iteration data. Only use .json/.csv files', undefined);
+                        }
                     }
                 ], (err, parsed) => {
                     if (err) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,6 @@
 var fs = require('fs'),
     { URL } = require('url'),
+    path = require('path'),
 
     _ = require('lodash'),
     chardet = require('chardet'),
@@ -248,7 +249,7 @@ util = {
                     return callback(err);
                 }
 
-                return callback(null, value.toString(util.detectEncoding(value)));
+                return callback(null, value.toString(util.detectEncoding(value)), path.extname(location));
             });
     },
 


### PR DESCRIPTION
This PR separately handles https://github.com/postmanlabs/newman/pull/2688#issuecomment-810547757 

1. Uses the ```path.extname``` method for getting the extension of the file being used for providing iteration data ```-d```
2. If the filetype is ```.json``` -> ```liquidJSON``` is used to parse and report any errors.
3. If the filetype is ```.csv``` -> ```parseCSV``` is used to parse and report any errors.
4. If none, the fallback informs the user to use only ```.json/.csv``` files.