### PR TITLE
docker: improve NEWMAN_VERSION check in Dockerfiles

### DIFF
--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -6,9 +6,10 @@ ARG NEWMAN_VERSION
 # Set environment variables
 ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8" ALPINE_NODE_REPO="oznu/alpine-node"
 
-# Bail out early if NODE_VERSION is not provided
-RUN if [ ! $(echo $NEWMAN_VERSION | grep -oE "^[0-9]+\.[0-9]+\.[0-9]+$") ]; then \
-        echo "\033[0;31mA valid semver Newman version is required in the NEWMAN_VERSION build-arg\033[0m"; \
+# Bail out early if NEWMAN_VERSION is not provided
+RUN if ! echo "v$NEWMAN_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then \
+        printf '\e[0;31m%s\e[0m\n' \
+               "A valid semver is required in --build-arg NEWMAN_VERSION='$NEWMAN_VERSION'"; \
         exit 1; \
     fi && \
     # Install Newman globally

--- a/docker/images/ubuntu/Dockerfile
+++ b/docker/images/ubuntu/Dockerfile
@@ -4,9 +4,10 @@ LABEL maintainer="Postman Labs <help@postman.com>"
 ARG NODE_VERSION=10
 ARG NEWMAN_VERSION
 
-# Bail out early if NODE_VERSION is not provided
-RUN if [ ! $(echo $NEWMAN_VERSION | grep -oE "^[0-9]+\.[0-9]+\.[0-9]+$") ]; then \
-        echo "\033[0;31mA valid semver Newman version is required in the NEWMAN_VERSION build-arg\033[0m"; \
+# Bail out early if NEWMAN_VERSION is not provided
+RUN if ! echo "v$NEWMAN_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then \
+        printf '\e[0;31m%s\e[0m\n' \
+               "A valid semver is required in --build-arg NEWMAN_VERSION='$NEWMAN_VERSION'"; \
         exit 1; \
     fi
 


### PR DESCRIPTION
There were a few issues with the check (plus a typo in comment).

`echo $NEWMAN_VERSION` wasn't quoted, so if it started with whitespace, the check would pass. Later the `npm install` would of course fail, but if there's a sanity check, it should catch corner cases as well.

The `if` condition had unnecessary square brackets (`test`). Replaced with direct use of `grep -q` result.

On Alpine, `echo` by default doesn't interpret escape sequences, so the error message didn't show up red, but surrounded with garbage. Replaced with `printf`.

I didn't touch the Dockerfiles in deprecated alpine33 and ubuntu1404, assuming it's not worth fixing those.
