### PR TITLE
add: expose control commands for reporters

### DIFF
--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -29,7 +29,10 @@ var _ = require('lodash'),
         item: ['item'],
         iteration: [],
         beforeScript: ['script', 'event', 'item'],
-        script: ['execution', 'script', 'event', 'item']
+        script: ['execution', 'script', 'event', 'item'],
+        pause: [],
+        resume: [],
+        abort: []
     },
 
     /**
@@ -341,6 +344,13 @@ module.exports = function (options, callback) {
                 o && o.event && emitter.emit(_.camelCase('before-' + o.event.listen + 'Script'), err, o);
             });
 
+            // expose run control commands for reporters
+            const commands = {
+                pause: () => { return run.pause(); },
+                abort: () => { return run.abort(); },
+                resume: () => { return run.resume(); }
+            };
+
             // initialise all the reporters
             !emitter.reporters && (emitter.reporters = {});
             _.isArray(reporters) && _.forEach(reporters, function (reporterName) {
@@ -387,7 +397,7 @@ module.exports = function (options, callback) {
                     // we could have checked _.isFunction(Reporter), here, but we do not do that so that the nature of
                     // reporter error can be bubbled up
                     Reporter && (emitter.reporters[reporterName] = new Reporter(emitter,
-                        _.get(options, ['reporter', reporterName], {}), options));
+                        _.get(options, ['reporter', reporterName], {}), options, commands));
                 }
                 catch (error) {
                     // if the reporter errored out during initialisation, we should not stop the run simply log


### PR DESCRIPTION
This PR exposes the control commands to `pause`, `abort` or `resume` a Newman run to the reporters. This would enable the [newman-dashboard](https://github.com/elit-altum/newman-dashboard) and other reporters to control the Newman run.

1. Adds listeners on runtime for  `pause`, `abort` and `resume`.
2. The function exported to the reporters now has another argument `commands` which exposes all the control methods
     - `run.pause()`
     - `run.resume()`
     - `run.abort()`