### PR TITLE
Fix Formatting of CLI Reporter Options Table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,6 @@ such a scenario.
 | CLI Option  | Description       |
 |-------------|-------------------|
 | `--reporter-cli-silent`         | The CLI reporter is internally disabled and you see no output to terminal. |
-
 | `--reporter-cli-show-timestamps` | This prints the local time for each request made. | 
 | `--reporter-cli-no-summary`     | The statistical summary table is not shown. |
 | `--reporter-cli-no-failures`    | This prevents the run failures from being separately printed. |


### PR DESCRIPTION
There is a redundant newline in the READMEs CLI reporter options table. This newline causes the table formatting to break. The table is not displayed as a table at the moment.

This patch does remove the newline. If it is applied the table formatting will be ok again.