### PR TITLE
This exposes the `runner` on newman and the runtime `run` object in start event

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  new features:
+    - >-
+      GH-2806 Exposed the runner on newman and the runtime run object in start
+      event
+
 5.2.4:
   date: 2021-06-24
   chores:

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -226,10 +226,9 @@ module.exports = function (options, callback) {
                  * @returns {*}
                  */
                 start (err, cursor) {
-                    emitter.emit('start', null, {
+                    emitter.emit('start', err, {
                         cursor: cursor,
-                        run: run,
-                        error: err
+                        run: run
                     });
                 },
 

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -17,7 +17,6 @@ var _ = require('lodash'),
      * @type {Object}
      */
     runtimeEvents = {
-        start: [],
         beforeIteration: [],
         beforeItem: ['item'],
         beforePrerequest: ['events', 'item'],
@@ -156,6 +155,9 @@ module.exports = function (options, callback) {
         // to store the exported content from reporters
         emitter.exports = [];
 
+        // expose the runner object for reporter and programmatic use
+        emitter.runner = runner;
+
         // now start the run!
         runner.run(options.collection, {
             stopOnFailure: stopOnFailure, // LOL, you just got trolled ¯\_(ツ)_/¯
@@ -214,6 +216,22 @@ module.exports = function (options, callback) {
 
             // add non generic callback handling
             _.assignIn(callbacks, {
+
+                /**
+                 * Emits event for start of the run. It injects/exposes additional objects useful for
+                 * programmatic usage and reporters
+                 *
+                 * @param {?Error} err - An Error instance / null object.
+                 * @param {Object} cursor - The run cursor instance.
+                 * @returns {*}
+                 */
+                start (err, cursor) {
+                    emitter.emit('start', null, {
+                        cursor: cursor,
+                        run: run,
+                        error: err
+                    });
+                },
 
                 /**
                  * Bubbles up console messages.

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -227,8 +227,8 @@ module.exports = function (options, callback) {
                  */
                 start (err, cursor) {
                     emitter.emit('start', err, {
-                        cursor: cursor,
-                        run: run
+                        cursor,
+                        run
                     });
                 },
 


### PR DESCRIPTION
The change is tiny and the code-diff would be self explanatory.

This cannot be documented as of yet, since runtime itself does not have enough documentation to leverage extensibility. However, it is a start and in a few iterations, the documentation can be improved.

For now, with this change, powerful reporters such as GIF attached below can be built.
![Aug-03-2021 23-38-06](https://user-images.githubusercontent.com/232373/128065525-e73d9013-d49f-4cb7-a95b-9bc5adc518b4.gif)
