### PR TITLE
Draft: Exploring a headless mode in Newman to reduce things that take up memory

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -61,6 +61,7 @@ program
     .option('--cookie-jar <path>', 'Specify the path to a custom cookie jar (serialized tough-cookie JSON) ')
     .option('--export-cookie-jar <path>', 'Exports the cookie jar to a file after completing the run')
     .option('--verbose', 'Show detailed information of collection run and each request sent')
+    .option('--headless', 'headless mode')
     .action((collection, command) => {
         let options = util.commanderToObject(command),
 

--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -199,14 +199,14 @@ RunSummary = function RunSummary (emitter, options) {
     RunSummary.attachRequestTracker(this, emitter);
 
     // accumulate errors (failures) from all events
-    RunSummary.attachFailureTrackers(this, emitter);
+    RunSummary.attachFailureTrackers(this, emitter, !options.headless);
 
     // accumulate all execution specific data in collection
-    RunSummary.attachReportingTrackers(this, emitter);
+    RunSummary.attachReportingTrackers(this, emitter, !options.headless);
 };
 
 _.assign(RunSummary, {
-    attachReportingTrackers (summary, emitter) {
+    attachReportingTrackers (summary, emitter, detailedExecutions) {
         var cache = {},
             executions = summary.run.executions;
 
@@ -225,14 +225,24 @@ _.assign(RunSummary, {
 
             var execution = cache[o.cursor.ref] = (cache[o.cursor.ref] || {});
 
-            executions.push(_.assignIn(execution, {
-                cursor: o.cursor,
-                request: o.request,
-                response: o.response,
-                id: _.get(o, 'item.id')
-            }, err && {
-                requestError: err || undefined
-            }));
+            if (detailedExecutions) {
+                executions.push(_.assignIn(execution, {
+                    cursor: o.cursor,
+                    request: o.request,
+                    response: o.response,
+                    id: _.get(o, 'item.id')
+                }, err && {
+                    requestError: err || undefined
+                }));
+            }
+            else {
+                executions.push(_.assignIn(execution, {
+                    cursor: o.cursor,
+                    id: _.get(o, 'item.id')
+                }, err && {
+                    requestError: err || undefined
+                }));
+            }
         });
 
         // save all script execution errors in each execution
@@ -319,11 +329,11 @@ _.assign(RunSummary, {
             timings = timings && timings.timings;
             timingPhases = timings && sdk.Response.timingPhases(timings);
 
-            (timingPhases || time) && _.forEach([
+            (timingPhases || time) && [
                 'dns',
                 'firstByte',
                 'response'
-            ], (value) => {
+            ].forEach((value) => {
                 var currentValue = (value === 'response') ? time : (timingPhases && timingPhases[value]),
                     previousAverage = summary.run.timings[`${value}Average`],
                     previousVariance = Math.pow(summary.run.timings[`${value}Sd`], 2),
@@ -359,7 +369,7 @@ _.assign(RunSummary, {
         });
     },
 
-    attachFailureTrackers (summary, emitter) {
+    attachFailureTrackers (summary, emitter, traceParent) {
         var eventsToTrack = ['beforeIteration', 'iteration', 'beforeItem', 'item', 'beforeScript', 'script',
             'beforePrerequest', 'prerequest', 'beforeRequest', 'request', 'beforeTest', 'test', 'beforeAssertion',
             'assertion'];
@@ -397,7 +407,8 @@ _.assign(RunSummary, {
                     error: err,
                     at: source,
                     source: item || undefined,
-                    parent: item && item.__parent && item.__parent.__parent || undefined,
+                    parent: traceParent ?
+                        (item && item.__parent && item.__parent.__parent || undefined) : undefined,
                     cursor: o.cursor || {}
                 });
             });


### PR DESCRIPTION
This option allows user to give clear intent that they want to run newman in a mode where they're unlikely to work interactively. 

Along with the same, it also sets expectations for reporters to adhere to some guidelines. In headless mode I also intent to make summary object NOT available to reporters at all.