### PR TITLE
Update to Warn User for invalid Folder #2791

### DIFF
--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -133,25 +133,32 @@ module.exports = function (options, callback) {
                 result[value] = true;
             }, {});
         }
+        let RequiredFolder = [];
 
+        function checkItems (item) {
+            item.members.forEach((Element) => {
+                if (Element.items) {
+                    RequiredFolder.push(Element.name);
+                    checkItems(Element.items);
+                }
+                else {
+                    RequiredFolder.push(Element.name);
+                }
+            });
+        }
         // sets entrypoint to execute if options.folder is specified.
         if (options.folder) {
             entrypoint = { execute: options.folder };
-
-            let RequiredFolders = [];
-
-            options.collection.items.members.map((e) => {
-                RequiredFolders.push(e.name);
-            });
+            checkItems(options.collection.items);
             if (_.isArray(options.folder)) {
-                options.folder.map((Element) => {
-                    if (!RequiredFolders.includes(Element)) {
-                        console.warn('Folder', Element, 'is not found');
+                options.folder.map((e) => {
+                    if (!RequiredFolder.includes(e)) {
+                        console.warn('Folder ', e, ' is not found');
                     }
                 });
             }
-            else if (!RequiredFolders.includes(options.folder)) {
-                console.warn('Folder', options.folder, 'is not found');
+            else if (!RequiredFolder.includes(options.folder)) {
+                console.warn('Folder ', options.folder, ' is not found');
             }
 
             // uses `multipleIdOrName` lookupStrategy in case of multiple folders.

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -138,6 +138,22 @@ module.exports = function (options, callback) {
         if (options.folder) {
             entrypoint = { execute: options.folder };
 
+            let RequiredFolders = [];
+
+            options.collection.items.members.map((e) => {
+                RequiredFolders.push(e.name);
+            });
+            if (_.isArray(options.folder)) {
+                options.folder.map((Element) => {
+                    if (!RequiredFolders.includes(Element)) {
+                        console.warn('Folder', Element, 'is not found');
+                    }
+                });
+            }
+            else if (!RequiredFolders.includes(options.folder)) {
+                console.warn('Folder', options.folder, 'is not found');
+            }
+
             // uses `multipleIdOrName` lookupStrategy in case of multiple folders.
             _.isArray(entrypoint.execute) && (entrypoint.lookupStrategy = MULTIENTRY_LOOKUP_STRATEGY);
         }


### PR DESCRIPTION
Fixes #2791
Issue ' Warning or Error if `--folder` specified is invalid.'

What changes have been made?
When the user provides the wrong folder, it will warn the user, Folder (`--folder name`) not found, in the console.

Why is this change necessary?
When a user accidentally provides the wrong folder Name, then Newman doesn't show any error or warning in the console. 
To provide a better user experience this feature must be included.
I work on that issue and solved that issue.
Now, if the user passes a wrong folder, then it shows a warning, ' Folder (`--folder name`) not found ' in the console.

when the user provides two or more the wrong folder
<img width="1680" alt="3" src="https://user-images.githubusercontent.com/76155456/133941466-b6c174f8-3609-4faf-ab98-ecb722e80037.png">

when user provide one valid and one invalid folder
<img width="1680" alt="2" src="https://user-images.githubusercontent.com/76155456/133941483-0181b3d9-d767-489b-8c43-a754d1a640d3.png">

when the user provides an invalid folder only
<img width="1680" alt="1" src="https://user-images.githubusercontent.com/76155456/133941489-7705cf95-79b5-4159-b658-e09b9298fe10.png">

What side effects does this change have?
This issue doesn't have any side effects. It passes all the test cases.