### PR TITLE
Fixed failed iterations count is always zero - even if an iteration had assertion errors #1600

### DIFF
--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -390,6 +390,9 @@ _.assign(RunSummary, {
 
                 // if this is a plain error, convert it to serialised error
                 if (err.stack && !err.stacktrace) {
+                    if (err.name === 'AssertionError') {
+                        summary.run.stats.iterations.failed += 1;
+                    }
                     err = new SerialiseError(err, true);
                 }
 


### PR DESCRIPTION
Fix #1600 

### About Issue

When assertions within an iteration fail, the iteration fail count doesn't increase, it remains at 0.

### Fixed Solution 

Now, `summary.run.stats.iterations.failed` increase the value to 1  for the Assertion error.

### Code change ScreenShot

<img width="1335" alt="Screenshot 2021-10-26 at 4 36 24 PM" src="https://user-images.githubusercontent.com/76155456/138865907-3d098769-f09f-4151-9ab0-be1bf83d7a3a.png">


### Cli Report changes 

additionally, the CLI report of test iterations displays this behavior (see attached screenshot): Now the failed iteration count value is increased to 1 rather than showing 0.

<img width="862" alt="Screenshot 2021-10-26 at 4 21 06 PM" src="https://user-images.githubusercontent.com/76155456/138866380-881e1abd-f1c3-47c1-9534-f38cee5d50bc.png">


What side effects does this change have?
This issue doesn't have any side effects. It passes all the test cases.


#### Please provide me with appropriate feedback/review so that I can continue working on this.



