### PR TITLE
Fixed "CLI Options"'s table which was messed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,6 @@ such a scenario.
 | CLI Option  | Description       |
 |-------------|-------------------|
 | `--reporter-cli-silent`         | The CLI reporter is internally disabled and you see no output to terminal. |
-
 | `--reporter-cli-show-timestamps` | This prints the local time for each request made. | 
 | `--reporter-cli-no-summary`     | The statistical summary table is not shown. |
 | `--reporter-cli-no-failures`    | This prevents the run failures from being separately printed. |


### PR DESCRIPTION
The content in "CLI Options" table was not shown properly, since extra line was added between children of table.