### PR TITLE
Fixed the documentation link used for generating a postman api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ $ newman run file-upload.postman_collection.json
 
 ## Using Newman with the Postman API
 
-1 [Generate an API key](https://app.getpostman.com/dashboard/integrations)<br/>
+1 [Generate an API key](https://learning.postman.com/docs/developer/intro-api/#generating-a-postman-api-key)<br/>
 2 Fetch a list of your collections from: `https://api.getpostman.com/collections?apikey=$apiKey`<br/>
 3 Get the collection link via it's `uid`: `https://api.getpostman.com/collections/$uid?apikey=$apiKey`<br/>
 4 Obtain the environment URI from: `https://api.getpostman.com/environments?apikey=$apiKey`<br/>


### PR DESCRIPTION
- The `/dashboard/integration` is an old link - integrations used to be within workspaces earlier, but has now moved to their own section in the app.
- Updated the link to point learning center docs for generating a postman API key