### PR TITLE
added support for proxy definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ Newman can also be configured to work with proxy settings via the following envi
 
 For more details on using these variables, [refer here](https://github.com/postmanlabs/postman-request/blob/master/README.md#controlling-proxy-behaviour-using-environment-variables).
 
+#### Using Proxy configuration file
+
+- `--proxy-config-list`<br/>
+The path to the Proxy configuration file (JSON format). See [examples/proxy-config-list.json](https://github.com/postmanlabs/newman/blob/develop/examples/proxy-config-list.json).
+
+This option takes precedence over `HTTP_PROXY` / `http_proxy`, `HTTPS_PROXY` / `https_proxy` and `NO_PROXY` / `no_proxy` environment variables. If there is no match for the URL in the list, these environment variables are used as fallback.
+
 [back to top](#table-of-contents)
 
 ## API Reference
@@ -303,6 +310,7 @@ return of the `newman.run` function is a run instance, which emits run events th
 | options.sslExtraCaCerts   | The path to the file, that holds one or more trusted CA certificates in PEM format.<br /><br />_Optional_<br />Type: `string` |
 | options.requestAgents     | Specify the custom requesting agents to be used when performing HTTP and HTTPS requests respectively. Example: [Using Socks Proxy](#using-socks-proxy)<br /><br />_Optional_<br />Type: `object` |
 | options.cookieJar     | One can optionally pass a CookieJar file path as `string` to this property and that will be deserialized using [`tough-cookie`](https://github.com/salesforce/tough-cookie). This property also accepts a `tough-cookie` CookieJar instance.<br /><br />_Optional_<br />Type: `object\|string` |
+| options.proxyConfigList | The path to the proxy configuration list file. This option takes precedence over  `HTTP_PROXY` / `http_proxy`, `HTTPS_PROXY` / `https_proxy` and `NO_PROXY` / `no_proxy` environment variables. When there is no match in this configuration list, these environment variables are used as fallback.<br /><br />_Optional_<br />Type: `string\|array` |
 | options.newmanVersion     | The Newman version used for the collection run.<br /><br />_This will be set by Newman_ |
 | callback                  | Upon completion of the run, this callback is executed with the `error`, `summary` argument.<br /><br />_Required_<br />Type: `function` |
 

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -61,6 +61,7 @@ program
     .option('--cookie-jar <path>', 'Specify the path to a custom cookie jar (serialized tough-cookie JSON) ')
     .option('--export-cookie-jar <path>', 'Exports the cookie jar to a file after completing the run')
     .option('--verbose', 'Show detailed information of collection run and each request sent')
+    .option('--proxy-config-list <path>', 'Specify the path to a proxy configurations (JSON)')
     .action((collection, command) => {
         let options = util.commanderToObject(command),
 

--- a/examples/proxy-config-list.json
+++ b/examples/proxy-config-list.json
@@ -1,0 +1,22 @@
+[
+    {
+        "match": "https://example.com/*",
+        "host": "proxy.com", 
+        "port": "8080",
+        "tunnel": true
+    },
+    {
+        "match": "http+https://example2.com/*",
+        "host": "proxy2.com"
+    },
+    {
+        "match": "http+https://example3.com/*",
+        "host": "proxy3.com",
+        "port": "8080",
+        "tunnel": true,
+        "disabled": false,
+        "authenticate": true,
+        "username": "proxy_username",
+        "password": "proxy_password"
+    }
+]

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -112,7 +112,9 @@ module.exports = function (options, callback) {
         // different URLs
         var sslClientCertList = options.sslClientCertList || [],
             // allow providing custom cookieJar
-            cookieJar = options.cookieJar || request.jar();
+            cookieJar = options.cookieJar || request.jar(),
+            proxyConfigList = options.proxyConfigList || [];
+
 
         // if sslClientCert option is set, put it at the end of the list to
         // match all URLs that didn't match in the list
@@ -166,6 +168,7 @@ module.exports = function (options, callback) {
             iterationCount: options.iterationCount,
             environment: options.environment,
             globals: options.globals,
+            proxies: proxyConfigList.length && new sdk.ProxyConfigList({}, proxyConfigList),
             entrypoint: entrypoint,
             data: options.iterationData,
             delay: {

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -360,7 +360,38 @@ var _ = require('lodash'),
 
                 return callback(null, value);
             });
+        },
+
+        proxyConfigList: function (location, options, callback) {
+            if (Array.isArray(location)) {
+                return callback(null, location);
+            }
+
+            if (typeof location !== 'string') {
+                return callback(new Error('path for proxy configuration list file must be a string'));
+            }
+
+            fs.readFile(location, function (err, value) {
+                if (err) {
+                    return callback(new Error(`unable to read the proxy configuration file "${location}"`));
+                }
+
+                try {
+                    value = liquidJSON.parse(value.toString(util.detectEncoding(value)).trim());
+                }
+                catch (e) {
+                    return callback(new Error(`the file at ${location} does not contain valid JSON data.`));
+                }
+
+                // ensure that `proxyConfigList` is an array
+                if (!Array.isArray(value)) {
+                    return callback(new Error('expected proxy configuration  list to be an array.'));
+                }
+
+                return callback(null, value);
+            });
         }
+
     };
 
 /**


### PR DESCRIPTION
This PR can close #1701 which was opened as a feature request by @shamasis .
- [x] Feature
- [x] Update docs
- [ ] Add tests

Not sure about which proxy server  should be used for writing tests , should we need to create a proxy server using 
`http-proxy` or something else need to be done ?

Any suggestions/changes in this PR which leads to closing the above issue are welcome.