### PR TITLE
chore: replaced `substr()` with `substring()`

### DIFF
--- a/npm/publish-wiki.js
+++ b/npm/publish-wiki.js
@@ -51,7 +51,7 @@ module.exports = function (exit) {
             sidebar = source.replace(/<a name="Collection"><\/a>[\s\S]+/g, '');
 
             // remove sidebar data from home
-            home = source.substr(sidebar.length);
+            home = source.substring(sidebar.length);
 
             // add timestamp to sidebar
             sidebar += '\n\n ' + (new Date()).toUTCString();

--- a/npm/server.js
+++ b/npm/server.js
@@ -93,7 +93,7 @@ function createRedirectServer () {
         }
         // path: /status/<responseCode>
         else if ((/^\/status\/(\d{3})$/).test(req.url)) {
-            res.writeHead(parseInt(req.url.substr(-3), 10), { location: '/' });
+            res.writeHead(parseInt(req.url.substring(req.url.length - 3), 10), { location: '/' });
 
             return res.end();
         }

--- a/npm/test-cli.js
+++ b/npm/test-cli.js
@@ -31,7 +31,7 @@ module.exports = function (exit) {
         var _exec = global.exec; // need to restore it later
 
         files.filter(function (file) {
-            return (file.substr(-8) === '.test.js');
+            return (file.substring(file.length - 8) === '.test.js');
         }).forEach(function (file) {
             mocha.addFile(file);
         });

--- a/npm/test-library.js
+++ b/npm/test-library.js
@@ -28,7 +28,7 @@ module.exports = function (exit) {
         }
 
         files.filter(function (file) {
-            return (file.substr(-8) === '.test.js');
+            return (file.substring(file.length - 8) === '.test.js');
         }).forEach(function (file) {
             mocha.addFile(file);
         });

--- a/npm/test-system.js
+++ b/npm/test-system.js
@@ -51,7 +51,7 @@ module.exports = function (exit) {
                 }
 
                 files.filter(function (file) {
-                    return (file.substr(-8) === '.test.js');
+                    return (file.substring(file.length - 8) === '.test.js');
                 }).forEach(function (file) {
                     mocha.addFile(file);
                 });

--- a/npm/test-unit.js
+++ b/npm/test-unit.js
@@ -31,7 +31,7 @@ module.exports = function (exit) {
         var mocha = new Mocha({ timeout: 1000 * 60 });
 
         files.filter(function (file) { // extract all test files
-            return (file.substr(-8) === '.test.js');
+            return (file.substring(file.length - 8) === '.test.js');
         }).forEach(mocha.addFile.bind(mocha));
 
         // start the mocha run


### PR DESCRIPTION
I think we should try to avoid using [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) functions, just added a small fix for that in this PR.
