### PR TITLE
Add docker image for Qase reporter using alpine image

### DIFF
--- a/docker/images/qase-alpine/Dockerfile
+++ b/docker/images/qase-alpine/Dockerfile
@@ -1,0 +1,3 @@
+FROM postman/newman:alpine
+
+RUN npm install --global newman-reporter-qase

--- a/docker/images/qase-alpine/README.md
+++ b/docker/images/qase-alpine/README.md
@@ -1,0 +1,30 @@
+# newman:qase-alpine
+
+This image runs newman on node v16 on Alpine with a Qase reporter installed. 
+
+Build the image:
+
+```terminal
+docker build -t postman/newman:qase-alpine --build-arg NEWMAN_VERSION="full semver version" .
+```
+
+Or get it from [Docker Hub](https://registry.hub.docker.com/u/postman/newman/):
+
+```terminal
+docker pull postman/newman:qase-alpine
+```
+
+Then run it:
+
+```terminal
+docker --volume="/home/postman/collections:/etc/newman" -t postman/newman:qase-alpine run JSONBlobCoreAPI.json.postman_collection  -r qase \ # Enable Qase logger
+    --reporter-qase-logging \ # Use reporter logger (like debug)
+    --reporter-qase-projectCode PRJCODE \ # Specify Project Code
+    --reporter-qase-apiToken <api token> \ # Specify API token
+    --reporter-qase-runId 34 \ # Specify Run ID using CLI parameters
+    --reporter-qase-runName "..." \ # Specify Run name using CLI parameters
+    --reporter-qase-runDescription "..." \ # Specify Run description using CLI parameters
+    -x # WA for issue https://github.com/postmanlabs/newman/issues/2148#issuecomment-665229759
+```
+
+Visit the [GitHub](https://github.com/qase-tms/qase-javascript/tree/master/qase-newman) repository of newman-reporter-qase for full details on how to use this reporter.


### PR DESCRIPTION
# What kind of change does this PR introduce?
Introduce docker file for building an image that uses the base alpine newman image, but with the Qase reporter installed. This enables the use of the newman container with Qase inside a kubernetes cluster, without the need to create separate node services or custom docker images in private repositories.

A similar approach could be used for other reporters.

# Does this PR introduce a breaking change?
No

# Other Information:
This image needs to be built and pushed to the dockerHub with the tag postman/newman:qase-alpine