### PR TITLE
Fix missing dependency which blocks Yarn PNP usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "csv-parse": "4.16.3",
     "eventemitter3": "4.0.7",
     "filesize": "8.0.7",
+    "liquid-json": "0.3.1",
     "lodash": "4.17.21",
     "mkdirp": "1.0.4",
     "postman-collection": "4.1.1",


### PR DESCRIPTION
This PR addresses Issue #3000

Due to missing dependencies in package.json newman cannot be used with Yarn PNP mode.