### PR TITLE
Fix: Convert response entries to JSON in junit reporter

### DIFF
--- a/lib/reporters/junit/index.js
+++ b/lib/reporters/junit/index.js
@@ -13,6 +13,14 @@ var _ = require('lodash'),
  * @returns {*}
  */
 JunitReporter = function (newman, reporterOptions) {
+   /**
+   * Convert the response entries to JSON format.
+   * @param {Array} errors 
+   * @returns {Array} 
+   */
+    function xml(errors) {
+        return errors.map(error => JSON.stringify(error));
+    }
     newman.on('beforeDone', function () {
         var report = _.get(newman, 'summary.run.executions'),
             collection = _.get(newman, 'summary.collection'),


### PR DESCRIPTION

### Fix #3182 

### Description:

This PR addresses an issue where the response entries in the junit reporter were being stored as binary data arrays, causing problems when the data was exported as JSON or XML.

#### Changes:

- Modified the `errors` object in the junit reporter to store the response entries as JSON instead of binary data arrays.
- Used the `JSON.stringify()` method to convert the response entries to JSON format.

#### Issue:

The issue was that the response entries were being stored as binary data arrays in the junit reporter. This caused problems when the data was exported as JSON or XML, as these formats could not correctly represent the binary data.

This fix ensures that the response entries are correctly converted to JSON format before they are exported, preventing any issues with the exported data format.