### PR TITLE
fix: JSON Collection Unwrapping Consistency in Programmatic Interface

### DIFF
--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -52,12 +52,21 @@ var _ = require('lodash'),
      */
     extractModel = function (source, type) {
         source = source[type] || source; // extract object that holds variable. these usually come from cloud API
+
+        if (_.isObject(source) && !source.values) {
+            // Check if the source is an object and doesn't have a "values" property
+            // If it's an object, unwrap it if needed
+            source = source.collection || source;
+        }
+
         if (!_.isObject(source)) {
             return undefined;
         }
 
         // ensure we un-box the JSON if it comes from cloud-api or similar sources
-        !source.values && _.isObject(source[type]) && (source = source[type]);
+        if (!source.values && _.isObject(source[type])) {
+            source = source[type];
+        }
 
         // we ensure that environment passed as array is converted to plain object. runtime does this too, but we do it
         // here for consistency of options passed to reporters


### PR DESCRIPTION
This pull request addresses an inconsistency in the programmatic interface of Newman related to the handling of JSON collections as described in #3179. When a collection is passed directly as JSON, there was unexpected behaviour compared to loading it from an external file, especially when unwrapping was required.

Changes Made:
- Modified the extractModel function in `newman/lib/run/options.js` to ensure consistent unwrapping behaviour for JSON collections.
- Added checks for the presence of the "values" property to distinguish between variables and other objects.