### PR TITLE
Fix `--color off` not being respected in summary table

### DIFF
--- a/lib/reporters/cli/index.js
+++ b/lib/reporters/cli/index.js
@@ -426,12 +426,17 @@ _.assignIn(PostmanCLIReporter, {
      * @returns {Table} - The constructed collection run statistics table.
      */
     parseStatistics (stats, timings, transfers, options) {
-        var summaryTable;
+        var summaryTable,
+            style = { head: [] };
+
+        if (cliUtils.noTTY(options.color)) {
+            style.border = [];
+        }
 
         // create the summary table
         summaryTable = new Table({
             chars: options.disableUnicode && cliUtils.cliTableTemplateFallback,
-            style: { head: [] },
+            style: style,
             head: [E, 'executed', '  failed'],
             colAligns: ['right', 'right', 'right'],
             colWidths: [25]

--- a/test/cli/color-tty.test.js
+++ b/test/cli/color-tty.test.js
@@ -3,7 +3,7 @@ const fs = require('fs'),
 
 describe('CLI output', function () {
     // eslint-disable-next-line no-control-regex
-    const coloredOutput = /^[\u001b[0m]+newman/;
+    const coloredOutput = /\u001b/;
 
     describe('TTY', function () {
         // @todo: Change to assert colored output after https://github.com/shelljs/shelljs/pull/524 is released


### PR DESCRIPTION
We have to pass `border: []` to disable colors on the table.

- Fixes https://github.com/postmanlabs/newman/issues/3169