### PR TITLE
Changed xmlbuilder-js attributes for attribs on JUnit reporter

### DIFF
--- a/lib/reporters/junit/index.js
+++ b/lib/reporters/junit/index.js
@@ -126,7 +126,7 @@ JunitReporter = function (newman, reporterOptions) {
                 testcase.att('time', executionTime.toFixed(3));
 
                 // Set the same classname for all the tests
-                testcase.att('classname', _.get(testcase.up(), 'attributes.name.value',
+                testcase.att('classname', _.get(testcase.up(), 'attribs.name.value',
                     classname));
 
                 if (failures && failures.length) {


### PR DESCRIPTION
Fixes #3230. 

According to [xmlbuilder-js CHANGELOG](https://github.com/oozcitak/xmlbuilder-js/blob/master/CHANGELOG.md), they

> Renamed `attributes` property to `attribs` to prevent name clash with DOM property with the same name.

This PR contains only this change.