### PR TITLE
Converted the deprecated `apikey` parameter in Postman API urls to `x-api-key` header

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+    chores:
+      - >-
+        GH-3258 Converted the deprecated `apikey` parameter in Postman API urls
+        to `x-api-key` header
+
 6.1.3:
   date: 2024-06-10
   chores:

--- a/lib/util.js
+++ b/lib/util.js
@@ -161,6 +161,21 @@ util = {
             location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }
+        // if location contains the apikey query param, remove it and add it to headers
+        else if (location.includes('apikey=')) {
+            try {
+                // eslint-disable-next-line one-var
+                var url = new URL(location),
+                    apiKey = url.searchParams.get('apikey');
+
+                url.searchParams.delete('apikey');
+                headers[API_KEY_HEADER] = apiKey;
+                location = url.toString();
+            }
+            catch (e) {
+                // if not a valid url, ignore
+            }
+        }
 
         return (/^https?:\/\/.*/).test(location) ?
             // Load from URL

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,5 @@
 var fs = require('fs'),
-    { URL } = require('url'),
+    { Url } = require('postman-collection'),
 
     _ = require('lodash'),
     chardet = require('chardet'),
@@ -33,9 +33,12 @@ var fs = require('fs'),
         'ISO-8859-1': 'latin1'
     },
 
-    POSTMAN_API_HOST = 'api.getpostman.com',
+    POSTMAN_API_HOSTS = {
+        'api.postman.com': true,
+        'api.getpostman.com': true
+    },
 
-    POSTMAN_API_URL = 'https://' + POSTMAN_API_HOST,
+    POSTMAN_API_URL = 'https://api.postman.com',
 
     /**
      * Map of resource type and its equivalent API pathname.
@@ -152,8 +155,10 @@ util = {
     fetchJson: function (type, location, options, callback) {
         !callback && _.isFunction(options) && (callback = options, options = {});
 
-        var postmanApiKey = _.get(options, 'postmanApiKey'),
-            headers = { 'User-Agent': USER_AGENT_VALUE };
+        const postmanApiKey = _.get(options, 'postmanApiKey'),
+            headers = { 'User-Agent': USER_AGENT_VALUE },
+            urlObj = new Url(location),
+            isPostmanHost = urlObj && POSTMAN_API_HOSTS[urlObj.getHost().toLowerCase()];
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
@@ -161,34 +166,21 @@ util = {
             location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }
-        // if location contains the apikey query param, remove it and add it to headers
-        else if (location.includes('apikey=')) {
-            try {
-                // eslint-disable-next-line one-var
-                var url = new URL(location),
-                    apiKey = url.searchParams.get('apikey');
 
-                url.searchParams.delete('apikey');
-                headers[API_KEY_HEADER] = apiKey;
-                location = url.toString();
-            }
-            catch (e) {
-                // if not a valid url, ignore
-            }
+        if (isPostmanHost) {
+            const apikey = urlObj.query.get('apikey') || postmanApiKey;
+
+            apikey && (headers[API_KEY_HEADER] = apikey);
+
+            urlObj.query.remove('apikey');
+            location = urlObj.toString();
         }
 
         return (/^https?:\/\/.*/).test(location) ?
-            // Load from URL
             request.get({
                 url: location,
                 json: true,
-                headers: headers,
-                // Temporary fix to fetch the collection from https URL on Node v12
-                // @todo find the root cause in postman-request
-                // Refer: https://github.com/postmanlabs/newman/issues/1991
-                agentOptions: {
-                    keepAlive: true
-                }
+                headers: headers
             }, (err, response, body) => {
                 if (err) {
                     return callback(_.set(err, 'help', `unable to fetch data from url "${location}"`));
@@ -201,18 +193,11 @@ util = {
                     return callback(_.set(e, 'help', `the url "${location}" did not provide valid JSON data`));
                 }
 
-                var error,
-                    urlObj,
-                    resource = 'resource';
-
                 if (response.statusCode !== 200) {
-                    urlObj = new URL(location);
-
-                    (urlObj.hostname === POSTMAN_API_HOST) &&
-                        (resource = _(urlObj.pathname).split('/').get(1).slice(0, -1) || resource);
-
-                    error = new Error(_.get(body, 'error.message',
-                        `Error fetching ${resource}, the provided URL returned status code: ${response.statusCode}`));
+                    const resource = isPostmanHost ? _(urlObj.getPath()).split('/').get(1).slice(0, -1) : 'resource',
+                        error = new Error(_.get(body, 'error.message',
+                            // eslint-disable-next-line max-len
+                            `Error fetching ${resource}, the provided URL returned status code: ${response.statusCode}`));
 
                     return callback(_.assign(error, {
                         name: _.get(body, 'error.name', _.capitalize(resource) + 'FetchError'),

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -145,10 +145,9 @@ describe('newman.run postmanApiKey', function () {
         });
     });
 
-    it('should not pass API Key header for Postman API URLs', function (done) {
+    it('should pass API Key header for Postman API URLs instead of apikey query parameter', function (done) {
         newman.run({
-            collection: 'https://api.getpostman.com/collections?apikey=12345678',
-            postmanApiKey: '12345678'
+            collection: 'https://api.getpostman.com/collections?apikey=12345678'
         }, function (err, summary) {
             expect(err).to.be.null;
             sinon.assert.calledOnce(request.get);
@@ -157,9 +156,9 @@ describe('newman.run postmanApiKey', function () {
 
             expect(requestArg).to.be.an('object').and.include.keys(['url', 'json', 'headers']);
 
-            expect(requestArg.url).to.equal('https://api.getpostman.com/collections?apikey=12345678');
+            expect(requestArg.url).to.equal('https://api.getpostman.com/collections');
 
-            expect(requestArg.headers).to.not.have.property('X-Api-Key');
+            expect(requestArg.headers).to.have.property('X-Api-Key');
 
             expect(summary.run.failures).to.be.empty;
             expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);


### PR DESCRIPTION
The `apikey` query parameter is a deprecated way to authenticate requests on Postman API. This pull requests converts the query parameter in the url passed by the user, to the `x-api-key` header, before executing the request to Postman API