### PR TITLE
Add support for `preserveOrder` option

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -28,6 +28,7 @@ program
     .option('--folder <path>',
         'Specify the folder to run from a collection. Can be specified multiple times to run multiple folders',
         util.cast.memoize, [])
+    .option('--preserve-order', 'When running multiple folders, preserve the order given on the command line')
     .option('--global-var <value>',
         'Allows the specification of global variables via the command line, in a key=value format',
         util.cast.memoizeKeyVal, [])

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -138,8 +138,12 @@ module.exports = function (options, callback) {
         if (options.folder) {
             entrypoint = { execute: options.folder };
 
-            // uses `multipleIdOrName` lookupStrategy in case of multiple folders.
-            _.isArray(entrypoint.execute) && (entrypoint.lookupStrategy = MULTIENTRY_LOOKUP_STRATEGY);
+            if (_.isArray(entrypoint.execute)) {
+                // uses `multipleIdOrName` lookupStrategy in case of multiple folders.
+                entrypoint.lookupStrategy = MULTIENTRY_LOOKUP_STRATEGY;
+                // preserve order of given folders, if requested
+                options.preserveOrder && (entrypoint.preserveOrder = true);
+            }
         }
 
         // sets stopOnFailure to true in case bail is used without any modifiers or with failure

--- a/test/library/folder-variants.test.js
+++ b/test/library/folder-variants.test.js
@@ -59,6 +59,33 @@ describe('folder variants', function () {
         });
     });
 
+    it('should run the specified requests in collection order in case preserveOrder is not true', function (done) {
+        newman.run({
+            collection: collection,
+            folder: ['R3', 'R1']
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+            expect(summary.run.executions, 'should have 2 executions').to.have.lengthOf(2);
+            expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1', 'R3']);
+            done();
+        });
+    });
+
+    it('should run the specified requests in given order in case preserveOrder is true', function (done) {
+        newman.run({
+            collection: collection,
+            folder: ['R3', 'R1'],
+            preserveOrder: true
+        }, function (err, summary) {
+            expect(err).to.be.null;
+            expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+            expect(summary.run.executions, 'should have 2 executions').to.have.lengthOf(2);
+            expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R3', 'R1']);
+            done();
+        });
+    });
+
     it('should skip the collection run in case any of the folder name is invalid', function (done) {
         newman.run({
             collection: collection,

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -147,6 +147,7 @@ describe('cli parser', function () {
                 '-g myGlobals.json ' +
                 '-d path/to/csv.csv ' +
                 '--folder myFolder ' +
+                '--preserve-order ' +
                 '--working-dir /Users/postman ' +
                 '--no-insecure-file-read ' +
                 '--cookie-jar myCookie.json ' +
@@ -174,6 +175,7 @@ describe('cli parser', function () {
                 expect(opts.collection).to.equal('myCollection.json');
                 expect(opts.environment).to.equal('myEnv.json');
                 expect(opts.folder).to.eql(['myFolder']);
+                expect(opts.preserveOrder, 'should have preserveOrder to be true').to.equal(true);
                 expect(opts.workingDir).to.eql('/Users/postman');
                 expect(opts.cookieJar).to.eql('myCookie.json');
                 expect(opts.exportCookieJar).to.eql('exported_cookie.json');


### PR DESCRIPTION
Introduce a new CLI option, `--preserve-order`, to maintain the execution order of folders as specified on the command line. Updated relevant tests to validate proper behavior for cases both with and without the flag enabled.

Feature Request: #3310