### PR TITLE
Fixes "CLI Reporter" table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,6 @@ such a scenario.
 | CLI Option  | Description       |
 |-------------|-------------------|
 | `--reporter-cli-silent`         | The CLI reporter is internally disabled and you see no output to terminal. |
-
 | `--reporter-cli-show-timestamps` | This prints the local time for each request made. |
 | `--reporter-cli-no-summary`     | The statistical summary table is not shown. |
 | `--reporter-cli-no-failures`    | This prevents the run failures from being separately printed. |


### PR DESCRIPTION
Currently looks like:

![image](https://github.com/user-attachments/assets/40a47f30-2244-4341-aa52-f7f2d6799abd)
