### PR TITLE
chore(postman-runtime): bump postman-runtime version to 7.51.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "postman-collection": "4.4.0",
         "postman-collection-transformer": "4.1.8",
         "postman-request": "2.88.1-postman.48",
-        "postman-runtime": "7.39.1",
+        "postman-runtime": "7.51.0",
         "pretty-ms": "7.0.1",
         "semver": "7.6.3",
         "serialised-error": "1.1.3",
@@ -928,6 +928,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1209,9 +1210,10 @@
       }
     },
     "node_modules/aws4": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.1.tgz",
-      "integrity": "sha512-u5w79Rd7SU4JaIlA/zFqG+gOiuq25q5VLyZ8E+ijJeILuTxVzZgp2CaGw/UTw6pXYN9XMO9yiqj/nEHmhTG5CA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -2274,6 +2276,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2840,8 +2843,7 @@
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -4389,6 +4391,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -5409,39 +5423,39 @@
       }
     },
     "node_modules/postman-runtime": {
-      "version": "7.39.1",
-      "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.39.1.tgz",
-      "integrity": "sha512-IRNrBE0l1K3ZqQhQVYgF6MPuqOB9HqYncal+a7RpSS+sysKLhJMkC9SfUn1HVuOpokdPkK92ykvPzj8kCOLYAg==",
+      "version": "7.51.0",
+      "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.51.0.tgz",
+      "integrity": "sha512-v6AxuJ7dzFUN0EUNgTmgNgRslhnhHt7CTUqxVVI3+zGYKnAw216/ypPhdi6XT33qlW5lF8A0VJS+75Kce2zlYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@postman/tough-cookie": "4.1.3-postman.1",
-        "async": "3.2.5",
-        "aws4": "1.12.0",
+        "async": "3.2.6",
+        "aws4": "1.13.2",
         "handlebars": "4.7.8",
         "httpntlm": "1.8.13",
-        "jose": "4.14.4",
+        "jose": "5.10.0",
         "js-sha512": "0.9.0",
         "lodash": "4.17.21",
         "mime-types": "2.1.35",
-        "node-forge": "1.3.1",
+        "node-forge": "1.3.3",
         "node-oauth1": "1.3.0",
         "performance-now": "2.1.0",
-        "postman-collection": "4.4.0",
-        "postman-request": "2.88.1-postman.34",
-        "postman-sandbox": "4.7.1",
-        "postman-url-encoder": "3.0.5",
+        "postman-collection": "5.2.0",
+        "postman-request": "2.88.1-postman.47",
+        "postman-sandbox": "6.3.0",
+        "postman-url-encoder": "3.0.8",
         "serialised-error": "1.1.3",
         "strip-json-comments": "3.1.1",
         "uuid": "8.3.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/postman-runtime/node_modules/aws4": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+    "node_modules/postman-runtime/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/postman-runtime/node_modules/jose": {
@@ -5450,6 +5464,61 @@
       "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/postman-runtime/node_modules/mime-format": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mime-format/-/mime-format-2.0.2.tgz",
+      "integrity": "sha512-Y5ERWVcyh3sby9Fx2U5F1yatiTFjNsqF5NltihTWI9QgNtr5o3dbCZdcKa1l2wyfhnwwoP9HGNxga7LqZLA6gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "charset": "^1.0.0"
+      }
+    },
+    "node_modules/postman-runtime/node_modules/postman-collection": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-5.2.0.tgz",
+      "integrity": "sha512-ktjlchtpoCw+FZRg+WwnGWH1w9oQDNUBLSRh+9ETPqFAz3SupqHqRuMh74xjQ+PvTWY/WH2JR4ZW+1sH58Ul1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@faker-js/faker": "5.5.3",
+        "file-type": "3.9.0",
+        "http-reasons": "0.1.0",
+        "iconv-lite": "0.6.3",
+        "liquid-json": "0.3.1",
+        "lodash": "4.17.21",
+        "mime": "3.0.0",
+        "mime-format": "2.0.2",
+        "postman-url-encoder": "3.0.8",
+        "semver": "7.7.1",
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postman-runtime/node_modules/postman-url-encoder": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.8.tgz",
+      "integrity": "sha512-EOgUMBazo7JNP4TDrd64TsooCiWzzo4143Ws8E8WYGEpn2PKpq+S4XRTDhuRTYHm3VKOpUZs7ZYZq7zSDuesqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-runtime/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/postman-runtime/node_modules/uuid": {
@@ -5461,18 +5530,82 @@
       }
     },
     "node_modules/postman-sandbox": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-4.7.1.tgz",
-      "integrity": "sha512-H2wYSLK0mB588IaxoLrLoPbpmxsIcwFtgaK2c8gAsAQ+TgYFePwb4qdeVcYDMqmwrLd77/ViXkjasP/sBMz1sQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-6.3.0.tgz",
+      "integrity": "sha512-i+gzYZJW+D47+T0iRRRBEiKHaq8mthRnfOvkXn6XE3UOZ/ccpVywCE/aRan3hIvQfyI9j5N2yfotiRBrPwbwOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "4.17.21",
-        "postman-collection": "4.4.0",
+        "postman-collection": "5.2.0",
         "teleport-javascript": "1.0.0",
-        "uvm": "2.1.1"
+        "uvm": "4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postman-sandbox/node_modules/mime-format": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mime-format/-/mime-format-2.0.2.tgz",
+      "integrity": "sha512-Y5ERWVcyh3sby9Fx2U5F1yatiTFjNsqF5NltihTWI9QgNtr5o3dbCZdcKa1l2wyfhnwwoP9HGNxga7LqZLA6gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "charset": "^1.0.0"
+      }
+    },
+    "node_modules/postman-sandbox/node_modules/postman-collection": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-5.2.0.tgz",
+      "integrity": "sha512-ktjlchtpoCw+FZRg+WwnGWH1w9oQDNUBLSRh+9ETPqFAz3SupqHqRuMh74xjQ+PvTWY/WH2JR4ZW+1sH58Ul1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@faker-js/faker": "5.5.3",
+        "file-type": "3.9.0",
+        "http-reasons": "0.1.0",
+        "iconv-lite": "0.6.3",
+        "liquid-json": "0.3.1",
+        "lodash": "4.17.21",
+        "mime": "3.0.0",
+        "mime-format": "2.0.2",
+        "postman-url-encoder": "3.0.8",
+        "semver": "7.7.1",
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postman-sandbox/node_modules/postman-url-encoder": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.8.tgz",
+      "integrity": "sha512-EOgUMBazo7JNP4TDrd64TsooCiWzzo4143Ws8E8WYGEpn2PKpq+S4XRTDhuRTYHm3VKOpUZs7ZYZq7zSDuesqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "punycode": "^2.3.1"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/postman-sandbox/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-sandbox/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/postman-url-encoder": {
@@ -5552,9 +5685,10 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6683,22 +6817,16 @@
       }
     },
     "node_modules/uvm": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/uvm/-/uvm-2.1.1.tgz",
-      "integrity": "sha512-BZ5w8adTpNNr+zczOBRpaX/hH8UPKAf7fmCnidrcsqt3bn8KT9bDIfuS7hgRU9RXgiN01su2pwysBONY6w8W5w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/uvm/-/uvm-4.0.1.tgz",
+      "integrity": "sha512-16Fgrcg/lSZzCoLKKTZ6+sne28XfLBus3XI4czylDj+cDPMecr65DprLRq5fzMZgRpTbnkh2BDpdUuI1AmEuVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "flatted": "3.2.6"
+        "flatted": "3.3.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
-    },
-    "node_modules/uvm/node_modules/flatted": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
-      "license": "ISC"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -7772,7 +7900,8 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -7978,9 +8107,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.1.tgz",
-      "integrity": "sha512-u5w79Rd7SU4JaIlA/zFqG+gOiuq25q5VLyZ8E+ijJeILuTxVzZgp2CaGw/UTw6pXYN9XMO9yiqj/nEHmhTG5CA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -8844,6 +8973,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9243,8 +9373,7 @@
     "flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -10373,6 +10502,11 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
+    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -11143,13 +11277,13 @@
       }
     },
     "postman-runtime": {
-      "version": "7.39.1",
-      "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.39.1.tgz",
-      "integrity": "sha512-IRNrBE0l1K3ZqQhQVYgF6MPuqOB9HqYncal+a7RpSS+sysKLhJMkC9SfUn1HVuOpokdPkK92ykvPzj8kCOLYAg==",
+      "version": "7.51.0",
+      "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.51.0.tgz",
+      "integrity": "sha512-v6AxuJ7dzFUN0EUNgTmgNgRslhnhHt7CTUqxVVI3+zGYKnAw216/ypPhdi6XT33qlW5lF8A0VJS+75Kce2zlYQ==",
       "requires": {
         "@postman/tough-cookie": "4.1.3-postman.1",
-        "async": "3.2.5",
-        "aws4": "1.12.0",
+        "async": "3.2.6",
+        "aws4": "1.13.2",
         "handlebars": "4.7.8",
         "httpntlm": "1.8.13",
         "jose": "5.10.0",
@@ -11159,24 +11293,63 @@
         "node-forge": "1.3.3",
         "node-oauth1": "1.3.0",
         "performance-now": "2.1.0",
-        "postman-collection": "4.4.0",
+        "postman-collection": "5.2.0",
         "postman-request": "2.88.1-postman.48",
-        "postman-sandbox": "4.7.1",
-        "postman-url-encoder": "3.0.5",
+        "postman-sandbox": "6.3.0",
+        "postman-url-encoder": "3.0.8",
         "serialised-error": "1.1.3",
         "strip-json-comments": "3.1.1",
         "uuid": "8.3.2"
       },
       "dependencies": {
-        "aws4": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+        "async": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+          "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
         },
         "jose": {
           "version": "5.10.0",
           "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
           "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="
+        },
+        "mime-format": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/mime-format/-/mime-format-2.0.2.tgz",
+          "integrity": "sha512-Y5ERWVcyh3sby9Fx2U5F1yatiTFjNsqF5NltihTWI9QgNtr5o3dbCZdcKa1l2wyfhnwwoP9HGNxga7LqZLA6gw==",
+          "requires": {
+            "charset": "^1.0.0"
+          }
+        },
+        "postman-collection": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-5.2.0.tgz",
+          "integrity": "sha512-ktjlchtpoCw+FZRg+WwnGWH1w9oQDNUBLSRh+9ETPqFAz3SupqHqRuMh74xjQ+PvTWY/WH2JR4ZW+1sH58Ul1g==",
+          "requires": {
+            "@faker-js/faker": "5.5.3",
+            "file-type": "3.9.0",
+            "http-reasons": "0.1.0",
+            "iconv-lite": "0.6.3",
+            "liquid-json": "0.3.1",
+            "lodash": "4.17.21",
+            "mime": "3.0.0",
+            "mime-format": "2.0.2",
+            "postman-url-encoder": "3.0.8",
+            "semver": "7.7.1",
+            "uuid": "8.3.2"
+          }
+        },
+        "postman-url-encoder": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.8.tgz",
+          "integrity": "sha512-EOgUMBazo7JNP4TDrd64TsooCiWzzo4143Ws8E8WYGEpn2PKpq+S4XRTDhuRTYHm3VKOpUZs7ZYZq7zSDuesqA==",
+          "requires": {
+            "punycode": "^2.3.1"
+          }
+        },
+        "semver": {
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -11186,14 +11359,60 @@
       }
     },
     "postman-sandbox": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-4.7.1.tgz",
-      "integrity": "sha512-H2wYSLK0mB588IaxoLrLoPbpmxsIcwFtgaK2c8gAsAQ+TgYFePwb4qdeVcYDMqmwrLd77/ViXkjasP/sBMz1sQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-6.3.0.tgz",
+      "integrity": "sha512-i+gzYZJW+D47+T0iRRRBEiKHaq8mthRnfOvkXn6XE3UOZ/ccpVywCE/aRan3hIvQfyI9j5N2yfotiRBrPwbwOw==",
       "requires": {
         "lodash": "4.17.21",
-        "postman-collection": "4.4.0",
+        "postman-collection": "5.2.0",
         "teleport-javascript": "1.0.0",
-        "uvm": "2.1.1"
+        "uvm": "4.0.1"
+      },
+      "dependencies": {
+        "mime-format": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/mime-format/-/mime-format-2.0.2.tgz",
+          "integrity": "sha512-Y5ERWVcyh3sby9Fx2U5F1yatiTFjNsqF5NltihTWI9QgNtr5o3dbCZdcKa1l2wyfhnwwoP9HGNxga7LqZLA6gw==",
+          "requires": {
+            "charset": "^1.0.0"
+          }
+        },
+        "postman-collection": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-5.2.0.tgz",
+          "integrity": "sha512-ktjlchtpoCw+FZRg+WwnGWH1w9oQDNUBLSRh+9ETPqFAz3SupqHqRuMh74xjQ+PvTWY/WH2JR4ZW+1sH58Ul1g==",
+          "requires": {
+            "@faker-js/faker": "5.5.3",
+            "file-type": "3.9.0",
+            "http-reasons": "0.1.0",
+            "iconv-lite": "0.6.3",
+            "liquid-json": "0.3.1",
+            "lodash": "4.17.21",
+            "mime": "3.0.0",
+            "mime-format": "2.0.2",
+            "postman-url-encoder": "3.0.8",
+            "semver": "7.7.1",
+            "uuid": "8.3.2"
+          }
+        },
+        "postman-url-encoder": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.8.tgz",
+          "integrity": "sha512-EOgUMBazo7JNP4TDrd64TsooCiWzzo4143Ws8E8WYGEpn2PKpq+S4XRTDhuRTYHm3VKOpUZs7ZYZq7zSDuesqA==",
+          "requires": {
+            "punycode": "^2.3.1"
+          }
+        },
+        "semver": {
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "postman-url-encoder": {
@@ -11255,9 +11474,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "qs": {
       "version": "6.14.1",
@@ -12121,18 +12340,11 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "uvm": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/uvm/-/uvm-2.1.1.tgz",
-      "integrity": "sha512-BZ5w8adTpNNr+zczOBRpaX/hH8UPKAf7fmCnidrcsqt3bn8KT9bDIfuS7hgRU9RXgiN01su2pwysBONY6w8W5w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/uvm/-/uvm-4.0.1.tgz",
+      "integrity": "sha512-16Fgrcg/lSZzCoLKKTZ6+sne28XfLBus3XI4czylDj+cDPMecr65DprLRq5fzMZgRpTbnkh2BDpdUuI1AmEuVQ==",
       "requires": {
-        "flatted": "3.2.6"
-      },
-      "dependencies": {
-        "flatted": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-          "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ=="
-        }
+        "flatted": "3.3.1"
       }
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "postman-collection": "4.4.0",
     "postman-collection-transformer": "4.1.8",
     "postman-request": "2.88.1-postman.48",
-    "postman-runtime": "7.39.1",
+    "postman-runtime": "7.51.0",
     "pretty-ms": "7.0.1",
     "semver": "7.6.3",
     "serialised-error": "1.1.3",


### PR DESCRIPTION
Update dependency to postman-runtime v7.51.0 and refresh lockfile
Align newman execution path with the latest runtime fixes/perf updates
No functional changes expected beyond dependency update
Tests:
 npm test
 Smoke run newman.js run <collection> to confirm CLI path still works
g