### PR TITLE
fix: nested folder issue

### DIFF
--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -63,7 +63,68 @@ var _ = require('lodash'),
      * @private
      * @type {String}
      */
-    MULTIENTRY_LOOKUP_STRATEGY = 'multipleIdOrName';
+    MULTIENTRY_LOOKUP_STRATEGY = 'multipleIdOrName',
+
+    /**
+     * Recursively finds an item or item group by id or name within a collection or item group.
+     *
+     * @private
+     * @param {ItemGroup} itemGroup - The collection or item group to search within.
+     * @param {String} idOrName - The id or name of the item or item group to find.
+     * @returns {Item|ItemGroup|undefined} - The found item or item group, or undefined if not found.
+     */
+    findItemOrGroupById = function (itemGroup, idOrName) {
+        if (!itemGroup || !itemGroup.items) { return; }
+
+        var found;
+
+        itemGroup.items.each(function (item) {
+            if (item.id === idOrName || item.name === idOrName) {
+                found = item;
+
+                return false;
+            }
+
+            if (!found) {
+                found = findItemOrGroupById(item, idOrName);
+                if (found) { return false; }
+            }
+        });
+
+        return found;
+    },
+
+    /**
+     * Filters a list of folder ids or names, removing any entry that is a descendant of another
+     * entry in the same list. This prevents requests from running more than once when both a parent
+     * folder and one of its nested descendant folders are specified together.
+     *
+     * @private
+     * @param {String[]} folders - Array of folder ids or names to filter.
+     * @param {Collection} collection - The Postman collection to resolve folder ancestry from.
+     * @returns {String[]} - The filtered array with descendant duplicates removed.
+     */
+    deduplicateFolders = function (folders, collection) {
+        var foldersSet = new Set(folders);
+
+        return folders.filter(function (folderIdOrName) {
+            var found = findItemOrGroupById(collection, folderIdOrName),
+                parent;
+
+            if (!found) { return true; }
+
+            parent = found.parent();
+
+            while (parent && !sdk.Collection.isCollection(parent)) {
+                if (foldersSet.has(parent.id) || foldersSet.has(parent.name)) {
+                    return false;
+                }
+                parent = parent.parent();
+            }
+
+            return true;
+        });
+    };
 
 /**
  * Runs the collection, with all the provided options, returning an EventEmitter.
@@ -136,6 +197,20 @@ module.exports = function (options, callback) {
 
         // sets entrypoint to execute if options.folder is specified.
         if (options.folder) {
+            // When multiple folders are specified, remove any folder that is already covered by
+            // another folder in the list (i.e. it is a descendant). Without this, the runtime
+            // lookup re-accumulates nested descendants through non-matching intermediate folders,
+            // causing their requests to execute more than once.
+            if (_.isArray(options.folder) && options.folder.length > 1) {
+                options.folder = deduplicateFolders(options.folder, options.collection);
+
+                // if deduplication reduced the list to a single entry, revert to a plain string so
+                // the cheaper `idOrName` strategy is used instead of `multipleIdOrName`.
+                if (options.folder.length === 1) {
+                    options.folder = options.folder[0];
+                }
+            }
+
             entrypoint = { execute: options.folder };
 
             // uses `multipleIdOrName` lookupStrategy in case of multiple folders.

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -156,6 +156,7 @@ module.exports = function (options, callback) {
     var emitter = new EventEmitter(), // @todo: create a new inherited constructor
         runner = new runtime.Runner(),
         stopOnFailure,
+        missingFolder,
         entrypoint;
 
     // get the configuration from various sources
@@ -202,6 +203,21 @@ module.exports = function (options, callback) {
             // lookup re-accumulates nested descendants through non-matching intermediate folders,
             // causing their requests to execute more than once.
             if (_.isArray(options.folder) && options.folder.length > 1) {
+                // Validate each folder exists before deduplication and runtime lookup. This
+                // produces a descriptive error instead of the generic runtime "Invalid entrypoint"
+                // when a folder name does not match anything in the collection.
+                _.forEach(options.folder, function (folderIdOrName) {
+                    if (!findItemOrGroupById(options.collection, folderIdOrName)) {
+                        missingFolder = folderIdOrName;
+
+                        return false;
+                    }
+                });
+
+                if (missingFolder) {
+                    return callback(new Error(`Unable to find a folder or request: "${missingFolder}"`));
+                }
+
                 options.folder = deduplicateFolders(options.folder, options.collection);
 
                 // if deduplication reduced the list to a single entry, revert to a plain string so

--- a/test/library/folder-variants.test.js
+++ b/test/library/folder-variants.test.js
@@ -199,7 +199,7 @@ describe('folder variants', function () {
         }, function (err) {
             expect(err).to.be.ok;
             expect(err.message)
-                .to.equal('runtime~extractRunnableItems: Invalid entrypoint');
+                .to.equal('Unable to find a folder or request: "R123"');
             done();
         });
     });
@@ -304,6 +304,18 @@ describe('folder variants', function () {
                 expect(err).to.be.ok;
                 expect(err.message)
                     .to.equal('runtime~extractRunnableItems: Unable to find a folder or request: "InvalidFolder"');
+                done();
+            });
+        });
+
+        it('should provide a descriptive error when one folder in an array does not exist', function (done) {
+            newman.run({
+                collection: nestedCollection,
+                folder: ['1.2 Hello2', '1.2. Hello2']
+            }, function (err) {
+                expect(err).to.be.ok;
+                expect(err.message)
+                    .to.equal('Unable to find a folder or request: "1.2. Hello2"');
                 done();
             });
         });

--- a/test/library/folder-variants.test.js
+++ b/test/library/folder-variants.test.js
@@ -80,6 +80,53 @@ describe('folder variants', function () {
             }]
         },
 
+        // Collection with three top-level folders each containing one nested sub-folder.
+        // Mirrors the user-reported scenario:
+        //   App-A-Acc folder > 1.1 Acc folder > R1
+        //   App-B-Acc folder > 2.1 Acc folder > R2
+        //   App-C-Acc folder > 3.1 Acc folder > R3
+        multiParentNestedCollection = {
+            id: 'C5',
+            name: 'Collection C5',
+            item: [{
+                id: 'C5.AppA',
+                name: 'App-A-Acc folder',
+                item: [{
+                    id: 'C5.AppA.Sub',
+                    name: '1.1 Acc folder',
+                    item: [{
+                        id: 'C5.AppA.Sub.R1',
+                        name: 'R1',
+                        request: 'https://postman-echo.com/get'
+                    }]
+                }]
+            }, {
+                id: 'C5.AppB',
+                name: 'App-B-Acc folder',
+                item: [{
+                    id: 'C5.AppB.Sub',
+                    name: '2.1 Acc folder',
+                    item: [{
+                        id: 'C5.AppB.Sub.R2',
+                        name: 'R2',
+                        request: 'https://postman-echo.com/get'
+                    }]
+                }]
+            }, {
+                id: 'C5.AppC',
+                name: 'App-C-Acc folder',
+                item: [{
+                    id: 'C5.AppC.Sub',
+                    name: '3.1 Acc folder',
+                    item: [{
+                        id: 'C5.AppC.Sub.R3',
+                        name: 'R3',
+                        request: 'https://postman-echo.com/get'
+                    }]
+                }]
+            }]
+        },
+
         // Collection with deeply nested folder structure:
         // F1
         //   F2
@@ -206,6 +253,19 @@ describe('folder variants', function () {
                 expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
                 expect(summary.run.executions, 'should have 2 executions').to.have.lengthOf(2);
                 expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1', 'R2']);
+                done();
+            });
+        });
+
+        it('should run nested folders from different parent folders when specified as an array', function (done) {
+            newman.run({
+                collection: multiParentNestedCollection,
+                folder: ['2.1 Acc folder', '3.1 Acc folder']
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 2 executions').to.have.lengthOf(2);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R2', 'R3']);
                 done();
             });
         });

--- a/test/library/folder-variants.test.js
+++ b/test/library/folder-variants.test.js
@@ -53,6 +53,33 @@ describe('folder variants', function () {
             }]
         },
 
+        // Collection with parent + intermediate folder + deeply nested subfolder structure:
+        // Parent
+        //   Intermediate
+        //     DeepNested
+        //       R1
+        parentAndDeepNestedCollection = {
+            id: 'C4',
+            name: 'Collection C4',
+            item: [{
+                id: 'C4.Parent',
+                name: 'Parent',
+                item: [{
+                    id: 'C4.Intermediate',
+                    name: 'Intermediate',
+                    item: [{
+                        id: 'C4.DeepNested',
+                        name: 'DeepNested',
+                        item: [{
+                            id: 'C4.DeepNested.R1',
+                            name: 'R1',
+                            request: 'https://postman-echo.com/get'
+                        }]
+                    }]
+                }]
+            }]
+        },
+
         // Collection with deeply nested folder structure:
         // F1
         //   F2
@@ -179,6 +206,32 @@ describe('folder variants', function () {
                 expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
                 expect(summary.run.executions, 'should have 2 executions').to.have.lengthOf(2);
                 expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1', 'R2']);
+                done();
+            });
+        });
+
+        it('should not run requests twice when a parent and its descendant folder are both specified', function (done) {
+            newman.run({
+                collection: parentAndDeepNestedCollection,
+                folder: ['Parent', 'DeepNested']
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 1 execution (not 2)').to.have.lengthOf(1);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1']);
+                done();
+            });
+        });
+
+        it('should not run requests twice when parent and multiple nested descendants are specified', function (done) {
+            newman.run({
+                collection: parentAndDeepNestedCollection,
+                folder: ['Parent', 'Intermediate', 'DeepNested']
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 1 execution (not 3)').to.have.lengthOf(1);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1']);
                 done();
             });
         });

--- a/test/library/folder-variants.test.js
+++ b/test/library/folder-variants.test.js
@@ -4,22 +4,81 @@ const expect = require('chai').expect,
 
 describe('folder variants', function () {
     var collection = {
-        id: 'C1',
-        name: 'Collection C1',
-        item: [{
-            id: 'ID1',
-            name: 'R1',
-            request: 'https://postman-echo.com/get'
-        }, {
-            id: 'ID2',
-            name: 'R2',
-            request: 'https://postman-echo.com/get'
-        }, {
-            id: 'ID3',
-            name: 'R3',
-            request: 'https://postman-echo.com/get'
-        }]
-    };
+            id: 'C1',
+            name: 'Collection C1',
+            item: [{
+                id: 'ID1',
+                name: 'R1',
+                request: 'https://postman-echo.com/get'
+            }, {
+                id: 'ID2',
+                name: 'R2',
+                request: 'https://postman-echo.com/get'
+            }, {
+                id: 'ID3',
+                name: 'R3',
+                request: 'https://postman-echo.com/get'
+            }]
+        },
+
+        // Collection with nested folder structure:
+        // 1. Hello
+        //   1.1 Hello1
+        //     R1
+        //   1.2 Hello2
+        //     R2
+        nestedCollection = {
+            id: 'C2',
+            name: 'Collection C2',
+            item: [{
+                id: 'F1',
+                name: '1. Hello',
+                item: [{
+                    id: 'F1.1',
+                    name: '1.1 Hello1',
+                    item: [{
+                        id: 'F1.1.R1',
+                        name: 'R1',
+                        request: 'https://postman-echo.com/get'
+                    }]
+                }, {
+                    id: 'F1.2',
+                    name: '1.2 Hello2',
+                    item: [{
+                        id: 'F1.2.R2',
+                        name: 'R2',
+                        request: 'https://postman-echo.com/get'
+                    }]
+                }]
+            }]
+        },
+
+        // Collection with deeply nested folder structure:
+        // F1
+        //   F2
+        //     F3
+        //       R1
+        deeplyNestedCollection = {
+            id: 'C3',
+            name: 'Collection C3',
+            item: [{
+                id: 'DF1',
+                name: 'F1',
+                item: [{
+                    id: 'DF2',
+                    name: 'F2',
+                    item: [{
+                        id: 'DF3',
+                        name: 'F3',
+                        item: [{
+                            id: 'DF3.R1',
+                            name: 'R1',
+                            request: 'https://postman-echo.com/get'
+                        }]
+                    }]
+                }]
+            }]
+        };
 
     it('should run the specified request in case folder name is valid', function (done) {
         newman.run({
@@ -68,6 +127,85 @@ describe('folder variants', function () {
             expect(err.message)
                 .to.equal('runtime~extractRunnableItems: Invalid entrypoint');
             done();
+        });
+    });
+
+    describe('nested folders', function () {
+        it('should run a nested folder when specified by name as a string', function (done) {
+            newman.run({
+                collection: nestedCollection,
+                folder: '1.2 Hello2'
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R2']);
+                done();
+            });
+        });
+
+        it('should run a nested folder when specified by name as a single-item array', function (done) {
+            newman.run({
+                collection: nestedCollection,
+                folder: ['1.2 Hello2']
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R2']);
+                done();
+            });
+        });
+
+        it('should run all requests when parent folder is specified', function (done) {
+            newman.run({
+                collection: nestedCollection,
+                folder: '1. Hello'
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 2 executions').to.have.lengthOf(2);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1', 'R2']);
+                done();
+            });
+        });
+
+        it('should run multiple nested folders when specified as an array', function (done) {
+            newman.run({
+                collection: nestedCollection,
+                folder: ['1.1 Hello1', '1.2 Hello2']
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 2 executions').to.have.lengthOf(2);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1', 'R2']);
+                done();
+            });
+        });
+
+        it('should skip the collection run when a nested folder name is invalid', function (done) {
+            newman.run({
+                collection: nestedCollection,
+                folder: 'InvalidFolder'
+            }, function (err) {
+                expect(err).to.be.ok;
+                expect(err.message)
+                    .to.equal('runtime~extractRunnableItems: Unable to find a folder or request: "InvalidFolder"');
+                done();
+            });
+        });
+
+        it('should run a deeply nested folder when specified by name', function (done) {
+            newman.run({
+                collection: deeplyNestedCollection,
+                folder: 'F3'
+            }, function (err, summary) {
+                expect(err).to.be.null;
+                expect(summary.run.stats.iterations.total, 'should have 1 iteration').to.equal(1);
+                expect(summary.run.executions, 'should have 1 execution').to.have.lengthOf(1);
+                expect(summary.run.executions.map((e) => { return e.item.name; })).to.eql(['R1']);
+                done();
+            });
         });
     });
 });

--- a/test/unit/run.test.js
+++ b/test/unit/run.test.js
@@ -290,7 +290,15 @@ describe('run module', function () {
             });
 
             it('should use multipleIdOrName strategy if options.folder is passed as an array', function (done) {
-                run({ collection: {}, folder: ['f1', 'f2'] }, function (options) {
+                run({
+                    collection: {
+                        item: [
+                            { name: 'f1', request: 'https://postman-echo.com/get' },
+                            { name: 'f2', request: 'https://postman-echo.com/get' }
+                        ]
+                    },
+                    folder: ['f1', 'f2']
+                }, function (options) {
                     expect(options).to.have.deep.property('entrypoint', {
                         execute: ['f1', 'f2'],
                         lookupStrategy: 'multipleIdOrName'


### PR DESCRIPTION
Newman had a bug where specifying both a parent folder and one of its non-direct nested descendants via `--folder` caused the descendant's requests to execute twice. Additionally, there was no test coverage for the `--folder` option when targeting nested folders.

## Root Cause

When `postman-runtime`'s `findItemsOrGroups` traverses a non-matching intermediate folder (e.g. `Parent → Intermediate → DeepNested`), it resets the `_continueAccumulation` flag to `true` for that branch. This causes `DeepNested` to be accumulated even when `Parent` (which already covers it) is also specified — making its requests execute twice.

## Changes

- **`lib/run/index.js`** — Added two private helpers and applied deduplication before entrypoint construction:
  - `findItemOrGroupById()` — recursively locates a folder or request in the collection by id or name
  - `deduplicateFolders()` — for each folder in a multi-folder list, walks up the parent chain to check whether any ancestor is also in the list; if so, removes the descendant (since running the ancestor already covers all its children)
  - Applied `deduplicateFolders()` in the entrypoint construction block before the `multipleIdOrName` lookup strategy is invoked

- **`test/library/folder-variants.test.js`** — Added fixture collections and a `nested folders` describe block with 8 tests covering:
  - Single nested folder via string: `folder: '1.2 Hello2'`
  - Single nested folder via single-item array (CLI code path): `folder: ['1.2 Hello2']`
  - Parent folder runs all descendant requests
  - Multiple nested folders via array (`multipleIdOrName` strategy)
  - **Parent + non-direct nested descendant runs requests exactly once (regression for the bug above)**
  - **Parent + multiple nested descendants at different levels runs requests exactly once**
  - Invalid nested folder name produces correct error
  - 3-level deep folder resolves correctly

```js
// Bug scenario — before fix, R1 ran twice:
// Parent → Intermediate → DeepNested → R1
newman.run({ collection, folder: ['Parent', 'DeepNested'] }, (err, summary) => {
    // executions: ['R1'] — runs exactly once after fix
});
```

