### PR TITLE
Fix missing callback on early return in export-file.js

### DIFF
--- a/lib/run/export-file.js
+++ b/lib/run/export-file.js
@@ -83,7 +83,7 @@ module.exports = function (options, done) {
     }
     // final check that path is valid
     if (!(path && path.base)) {
-        return;
+        return done(new Error('Invalid export path: path must include filename'));
     }
 
     // now sore the unparsed result back for quick re-use during writing and a single place for unparsing


### PR DESCRIPTION
## Summary
- Fix missing `done()` callback on early return in `lib/run/export-file.js` when path validation fails
- Without the callback, `async.each` in the run module hangs indefinitely, causing Newman to silently freeze
- Now returns `done()` with a descriptive error, ensuring Newman always completes or reports a meaningful error

## Test plan
- Verified that normal export flows (`--export-environment`, `--export-globals`, etc.) are unaffected
- The guard at line 85 only triggers in edge cases (e.g., root path `/`, or third-party reporters pushing exports without a valid path or default)