### PR TITLE
fix(secure-fs): skip deprecated fs.F_OK/R_OK/W_OK/X_OK on Node 24

### DIFF
--- a/lib/run/secure-fs.js
+++ b/lib/run/secure-fs.js
@@ -8,6 +8,7 @@ const fs = require('fs'),
     FUNCTION = 'function',
     DEPRECATED_SYNC_WRITE_STREAM = 'SyncWriteStream',
     EXPERIMENTAL_PROMISE = 'promises',
+    DEPRECATED_ACCESS_CONSTANTS = ['F_OK', 'R_OK', 'W_OK', 'X_OK'],
 
     // Use simple character check instead of regex to prevent regex attack
     /*
@@ -143,7 +144,10 @@ SecureFS.prototype.resolvePathSync = function (relOrAbsPath, whiteList) {
 // Attach all functions in fs to postman-fs
 Object.getOwnPropertyNames(fs).map((prop) => {
     // Bail-out early to prevent fs module from logging warning for deprecated and experimental methods
-    if (prop === DEPRECATED_SYNC_WRITE_STREAM || prop === EXPERIMENTAL_PROMISE || typeof fs[prop] !== FUNCTION) {
+    if (prop === DEPRECATED_SYNC_WRITE_STREAM ||
+        prop === EXPERIMENTAL_PROMISE ||
+        DEPRECATED_ACCESS_CONSTANTS.indexOf(prop) !== -1 ||
+        typeof fs[prop] !== FUNCTION) {
         return;
     }
 


### PR DESCRIPTION
Fixes #3324.

`Object.getOwnPropertyNames(fs)` includes the deprecated access-mode constants `F_OK`, `R_OK`, `W_OK`, `X_OK` on Node 24+, exposed via deprecation getters. The current skip-list only names `SyncWriteStream` and `promises`, so reading `fs[prop]` for the access constants — even just to do `typeof fs[prop] !== FUNCTION` — triggers `DEP0176` for each one.

Add the four names to the bail-out so they are filtered by name *before* `fs[prop]` is read. No runtime behavior change on older Node versions: those names were never functions, so the existing `typeof !== 'function'` check already excluded them from the prototype copy — this just stops them from being read at all.

Reference: [DEP0176](https://nodejs.org/api/deprecations.html#dep0176-fsf_ok-fsr_ok-fsw_ok-fsx_ok).

I'm on Node 22 locally so I couldn't reproduce the warning directly — happy to add a test if there's a clean spot for one.