### PR TITLE
SEC-966: security: add --no-rc-file flag to disable loading .newmanrc from CWD

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -52,6 +52,8 @@ program
     .option('--timeout-script [n]', 'Specify a timeout for scripts (milliseconds)', util.cast.integer, 0)
     .option('--working-dir <path>', 'Specify the path to the working directory')
     .option('--no-insecure-file-read', 'Prevents reading the files situated outside of the working directory')
+    .option('--no-rc-file',
+        'Prevents Newman from loading the .newmanrc configuration file from the current working directory')
     .option('-k, --insecure', 'Disables SSL validations')
     .option('--ssl-client-cert-list <path>', 'Specify the path to a client certificates configurations (JSON)')
     .option('--ssl-client-cert <path>', 'Specify the path to a client certificate (PEM)')

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -380,7 +380,15 @@ module.exports = function (options, callback) {
     // allow insecure file read by default
     options.insecureFileRead = Boolean(_.get(options, 'insecureFileRead', true));
 
-    config.get(options, { loaders: configLoaders, command: 'run' }, function (err, result) {
+    config.get(options, {
+        loaders: configLoaders,
+        command: 'run',
+
+        // Allow opting out of loading the `.newmanrc` config file (via `--no-rc-file`, or `ignoreRcFile` when used as a
+        // library). The RC file is read from the current working directory and can inject reporter configuration, so a
+        // way to disable it is required for untrusted working directories (e.g. CI checkouts).
+        ignoreRcFile: options.rcFile === false || Boolean(options.ignoreRcFile)
+    }, function (err, result) {
         if (err) { return callback(err); }
 
         !_.isEmpty(options.globalVar) && _.forEach(options.globalVar, function (variable) {

--- a/test/fixtures/newmanrc-injection/.newmanrc
+++ b/test/fixtures/newmanrc-injection/.newmanrc
@@ -1,0 +1,3 @@
+{
+    "reporters": ["cli", "rc-injected-reporter"]
+}

--- a/test/unit/options.test.js
+++ b/test/unit/options.test.js
@@ -123,4 +123,33 @@ describe('options', function () {
             done();
         });
     });
+
+    describe('.newmanrc reporter loading', function () {
+        var cwd;
+
+        beforeEach(function () {
+            cwd = process.cwd();
+            process.chdir('./test/fixtures/newmanrc-injection');
+        });
+
+        afterEach(function () {
+            process.chdir(cwd);
+        });
+
+        it('should load reporters from .newmanrc in the working directory by default', function (done) {
+            options({}, function (err, result) {
+                expect(err).to.be.null;
+                expect(result.reporters).to.include('rc-injected-reporter');
+                done();
+            });
+        });
+
+        it('should not load .newmanrc reporters when rc file loading is disabled', function (done) {
+            options({ rcFile: false }, function (err, result) {
+                expect(err).to.be.null;
+                expect(result.reporters || []).to.not.include('rc-injected-reporter');
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Implemented the finding's recommended Option 1: added the `--no-rc-file` CLI flag (and programmatic `ignoreRcFile` passthrough) wiring newman's existing internal RC-ignore option, giving operators a way to prevent loading an untrusted `.newmanrc` from the working directory. Minimal, non-breaking, lint-clean, with a fails-red/passes-green regression test.

Linked Jira: SEC-966 — AppSec-authored remediation. The owning team owns the merge (AppSec never merges product repos).

## Vulnerability
Source: attacker-controllable `.newmanrc` present in the current working directory (e.g. a CI checkout or a smuggled file in a PR). It is loaded unconditionally, its `reporters` field survives the CLI/RC option merge, and a reporter name flows to a dynamic module require executed in newman's main Node process at startup. The finding's named sink is lib/run/index.js:371; the untrusted-ingestion chokepoint is the unconditional CWD RC push in lib/config/rc-file.js:37 (introduced by narayanspai2000@gmail.com). No opt-out control existed. Fix adds the missing opt-out; no payload reproduced here.

_(Safe-altitude description only — no payload/PoC in this PR. Full detail on the access-controlled Jira ticket.)_

## Fix
- Added a `--no-rc-file` option to the `newman run` command, mirroring the existing `--no-insecure-file-read` pattern and help style.
- Wired it in lib/run/options.js to the pre-existing internal `ignoreRcFile` config option (config.get already short-circuits rcfile.load when set), so RC loading is skipped when requested; also honors a programmatic `ignoreRcFile` for library callers.
- Default behavior is unchanged (non-breaking): RC file still loads unless the flag/option is passed — this supplies the opt-out control the finding flagged as entirely absent (H1 step 4).
- Added a regression test in test/unit/options.test.js plus a fixture `.newmanrc` proving the RC-injected reporter loads by default and is suppressed when rc loading is disabled.

— 4 file(s), scope: minimal

## Validation
local static/lint/syntax check: clean
regression test: red on parent → green on fix (see commit)

## Tracking
Jira SEC-966 · produced-by security-patch-generation · ready for review

## For the owning team
Merging this counts as your team's remediation of SEC-966. AppSec authored the fix; your team owns the merge and deploy.
