### PR TITLE
ci: onboard to incremental (patch) coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,40 @@ jobs:
               run: |
                   npm run test-library
                   bash <(curl -s https://codecov.io/bash) -c -Z -f .coverage/coverage-final.json -F library -t ${{ secrets.CODECOV_TOKEN }}
+
+    # Dedicated job for the incremental (patch) coverage gate.
+    # The check name is literally `unit-test` (no `name:` override) so the
+    # coverage PR-comment action can match it via `jobName: unit-test`.
+    # It has no `needs` on slow jobs and runs a single fast test suite so the
+    # matching check appears on the PR head SHA well within the action's poll window.
+    unit-test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Use Node.js 18
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+                  cache: "npm"
+
+            - name: Install
+              run: npm ci
+
+            # `tee` captures the nyc text report into coverage.txt while preserving
+            # the suite's exit code so a genuine test failure still fails the job.
+            - name: Run unit tests
+              run: npm run test-unit | tee coverage.txt && exit ${PIPESTATUS[0]}
+
+            - name: Upload unit coverage summary artifact
+              if: ${{ always() }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: coverage-summary-unit
+                  path: |
+                      .coverage/coverage-summary.json
+                      .coverage/lcov.info
+                      coverage.txt
+                  if-no-files-found: error

--- a/.nycrc.js
+++ b/.nycrc.js
@@ -45,6 +45,6 @@ module.exports = {
     'report-dir': '.coverage',
     'temp-dir': '.nyc_output',
     include: ['lib/**/*.js', 'bin/**/*.js'],
-    reporter: ['lcov', 'json', 'text', 'text-summary'],
+    reporter: ['lcov', 'json', 'json-summary', 'text', 'text-summary'],
     ...configOverrides(TEST_TYPE),
 };


### PR DESCRIPTION
## What & why

Onboards this repo to Postman's incremental (patch) code-coverage tooling by producing the coverage artifacts the QE tooling consumes. The gate is intentionally left **advisory (non-blocking)** — `coverage-thresholds.json` is not touched.

### Changes
- **`.nycrc.js`**: add `json-summary` to the `reporter` array so `.coverage/coverage-summary.json` is emitted. `lcov` (→ `.coverage/lcov.info`) and `json` (→ `.coverage/coverage-final.json`) are kept so line-level / patch coverage remains available.
- **`.github/workflows/ci.yml`**: add a dedicated `unit-test` job:
  - Check name is literally `unit-test` (no `name:` override) so a future PR-comment action can match it via `jobName: unit-test`.
  - No `needs` on slow jobs; runs a single fast suite so the check appears on the PR head SHA quickly.
  - Runs `npm run test-unit | tee coverage.txt` (preserving the suite exit code via `${PIPESTATUS[0]}`) and uploads artifact **`coverage-summary-unit`** containing `.coverage/coverage-summary.json`, `.coverage/lcov.info`, and `coverage.txt`.
  - Existing `tests` matrix job and the `coverage` job (codecov upload) are unchanged.

## ⚠️ Public-repo / cross-org viability caveat (read this)

The coverage **PR-comment action is NOT wired up in this PR**, and by design cannot run here as-is. Evidence:

1. **Private/internal action, different org.** The action `postman-eng/test-infra-scripts/.github/actions/coverage-pr-comment-action@main` lives in `postman-eng/test-infra-scripts`, whose visibility is **`internal`**. This repo (`postmanlabs/newman`) is **`public`** and in a **different org** (`postmanlabs` ≠ `postman-eng`). A public repo cannot resolve an internal action owned by a different org via `uses:` — the runner would fail at action checkout.
2. **Cross-org org secrets are unavailable.** The action requires `QE_HEVO_WEBHOOK_URL`, `QE_HEVO_ACCESS_KEY`, `QE_HEVO_SECRET_KEY`, `POSTMAN_NPM_TOKEN`. These are **`postman-eng` org secrets**; they are not inherited by a `postmanlabs` repo. (Secret **names** could not even be listed here — the API returns `HTTP 403` for both the repo and the `postmanlabs` org, confirming this account/token has no access to secrets in this org.)

Because of the above, `.github/workflows/gh-PR-comment.yml` is **intentionally omitted** per the onboarding runbook ("add it only if the action is viable, otherwise omit and document").

### Recommended next steps to fully enable the gate here
- **Make the action public** (or publish a public mirror), so a public repo can consume it; and
- **Add repo-level secrets** on `postmanlabs/newman` (`QE_HEVO_WEBHOOK_URL`, `QE_HEVO_ACCESS_KEY`, `QE_HEVO_SECRET_KEY`, `POSTMAN_NPM_TOKEN`) or run the comment workflow from a repo/org that already has them.
- Then add `.github/workflows/gh-PR-comment.yml` (`on: pull_request`) with a `track-unit-test-coverage` job pointing `jobName: unit-test`, `artifactSource: coverage-summary-unit`, `coverageType: unit`, `squad: automation-testing`.
- Note: `pull_request` runs from forks receive a read-only token and no secrets — this comment flow only works for same-repo (non-fork) PRs even after secrets exist.

## Verification
The `coverage-summary-unit` artifact (lcov.info + coverage-summary.json + coverage.txt) is verified via the `unit-test` job in CI. The comment action is not verified because it is not viable in this public/cross-org context (see above).
