### PR TITLE
Fix operator precedence bug dropping header size from total data received

### DIFF
--- a/lib/run/summary.js
+++ b/lib/run/summary.js
@@ -312,7 +312,7 @@ _.assign(RunSummary, {
                 timingPhases;
 
             // compute the response size total
-            size && (summary.run.transfers.responseTotal += (size.body || 0 + size.headers || 0));
+            size && (summary.run.transfers.responseTotal += ((size.body || 0) + (size.headers || 0)));
 
             // if there are redirects, get timings for the last request sent
             timings = _.last(_.get(o, 'history.execution.data'));

--- a/test/unit/run-summary.test.js
+++ b/test/unit/run-summary.test.js
@@ -269,5 +269,54 @@ describe('run summary', function () {
                 });
             });
         });
+
+        describe('transfer size tracking', function () {
+            var emitter,
+                collection,
+                summary;
+
+            beforeEach(function () {
+                collection = new sdk.Collection({
+                    item: [{ id: 'i1', request: 'http://localhost/1' }]
+                });
+                emitter = new EventEmitter();
+                summary = new Summary(emitter, { collection });
+            });
+
+            afterEach(function () {
+                collection = null;
+                emitter = null;
+                summary = null;
+            });
+
+            it('should sum both body and header sizes into responseTotal', function () {
+                var item = collection.items.one('i1');
+
+                emitter.emit('request', null, {
+                    item: item,
+                    response: { size () { return { body: 270, headers: 793 }; } },
+                    cursor: { ref: '1', iteration: 0 }
+                });
+
+                expect(summary.run.transfers.responseTotal).to.equal(1063);
+            });
+
+            it('should accumulate responseTotal across multiple requests', function () {
+                var item = collection.items.one('i1');
+
+                emitter.emit('request', null, {
+                    item: item,
+                    response: { size () { return { body: 100, headers: 50 }; } },
+                    cursor: { ref: '1', iteration: 0 }
+                });
+                emitter.emit('request', null, {
+                    item: item,
+                    response: { size () { return { body: 200, headers: 25 }; } },
+                    cursor: { ref: '2', iteration: 1 }
+                });
+
+                expect(summary.run.transfers.responseTotal).to.equal(375);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Summary

- `lib/run/summary.js`'s `attachRequestTracker` computed `run.transfers.responseTotal` with `size.body || 0 + size.headers || 0`. Since `+` binds tighter than `||` in JS, this evaluates as `size.body || (0 + size.headers) || 0`, so `size.headers` is silently dropped whenever `size.body` is truthy (i.e. almost always). The CLI's "total data received" summary line has therefore been undercounting by the size of every response's headers.
- Wrapped both terms in explicit parens: `(size.body || 0) + (size.headers || 0)`.
- Added regression tests covering single- and multi-request accumulation of `responseTotal`, closing the gap noted by the pre-existing `// @todo add test for computation of timings, transfer sizes and average response time` comment in `test/unit/run-summary.test.js`.

Fixes #3367

## Test plan

- [x] `node_modules/.bin/mocha test/unit/run-summary.test.js` — 70 passing, including 2 new tests
- [x] Confirmed the new tests fail against the old code (`270`/`300` instead of `1063`/`375`) and pass against the fix
- [x] `node_modules/.bin/eslint lib/run/summary.js test/unit/run-summary.test.js` — clean
- [x] `node_modules/.bin/mocha test/unit` — 130 passing, 11 pending (pre-existing, unrelated)