### PR TITLE
docs(docker): remove stray double quote in alpine README example command

### DIFF
--- a/docker/images/alpine/README.md
+++ b/docker/images/alpine/README.md
@@ -23,7 +23,7 @@ For newman-docker to be able to use collections and environment files saved on t
   - You can pass the full path to your collection and environment files to newman. For instance, if you mount to `/etc/newman`,
 
 ```terminal
-docker --volume="/home/postman/collection:/etc/newman" -t postman/newman:alpine run JSONBlobCoreAPI.json.postman_collection" -r json --reporter-json-export newman-report.json
+docker --volume="/home/postman/collection:/etc/newman" -t postman/newman:alpine run JSONBlobCoreAPI.json.postman_collection -r json --reporter-json-export newman-report.json
 ```
   - You can change the working directory while running the image to the location you mounted to, using the `-w` or `--workdir` flag.
 


### PR DESCRIPTION
## What

Removes a stray double quote from the example `docker run` command in `docker/images/alpine/README.md`:

```
- ... run JSONBlobCoreAPI.json.postman_collection" -r json ...
+ ... run JSONBlobCoreAPI.json.postman_collection -r json ...
```

## Why

The command as written is invalid — the collection filename ends with an unmatched `"`, so copy-pasting it produces a shell error. The equivalent Ubuntu image README (`docker/images/ubuntu/README.md`) has the same example without the stray quote, confirming this is a typo.

## Verification

- Confirmed the typo exists on the current `develop` branch (line 26 of `docker/images/alpine/README.md`).
- Diffed against the parallel ubuntu README example, which is correctly quoted.
- Docs-only change; no code paths affected.