### PR TITLE
fix(ssl): expand tilde in client certificate file paths

### DIFF
--- a/docker/images/alpine/README.md
+++ b/docker/images/alpine/README.md
@@ -23,7 +23,7 @@ For newman-docker to be able to use collections and environment files saved on t
   - You can pass the full path to your collection and environment files to newman. For instance, if you mount to `/etc/newman`,
 
 ```terminal
-docker --volume="/home/postman/collection:/etc/newman" -t postman/newman:alpine run JSONBlobCoreAPI.json.postman_collection" -r json --reporter-json-export newman-report.json
+docker --volume="/home/postman/collection:/etc/newman" -t postman/newman:alpine run JSONBlobCoreAPI.json.postman_collection -r json --reporter-json-export newman-report.json
 ```
   - You can change the working directory while running the image to the location you mounted to, using the `-w` or `--workdir` flag.
 

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -1,4 +1,6 @@
 var _ = require('lodash'),
+    os = require('os'),
+    path = require('path'),
     EventEmitter = require('events'),
     asyncEach = require('async/each'),
     sdk = require('postman-collection'),
@@ -112,7 +114,36 @@ module.exports = function (options, callback) {
         // different URLs
         var sslClientCertList = options.sslClientCertList || [],
             // allow providing custom cookieJar
-            cookieJar = options.cookieJar || request.jar();
+            cookieJar = options.cookieJar || request.jar(),
+
+            /**
+             * Expands a leading tilde in a certificate file path to the
+             * user's home directory. Paths such as `~/.certs/client.crt`
+             * are otherwise left unresolved by the underlying file resolver,
+             * which causes certificate load errors (refer postmanlabs/newman#3003).
+             *
+             * @param {String} src - The certificate source path, which may begin with `~`.
+             * @returns {String} - The path with any leading tilde expanded to the home directory.
+             */
+            expandHomeDir = function (src) {
+                if (typeof src !== 'string' || src !== '~' && !src.startsWith('~/') &&
+                    !(os.platform() === 'win32' && src.startsWith('~\\'))) {
+                    return src;
+                }
+
+                return path.join(os.homedir(), src.slice(1));
+            },
+
+            // expand `~` in all certificate paths before handing the list to the runtime
+            resolveCertPaths = function (list) {
+                _.forEach(list, function (cert) {
+                    cert = cert || {};
+                    _.isObject(cert.key) && (cert.key.src = expandHomeDir(cert.key.src));
+                    _.isObject(cert.cert) && (cert.cert.src = expandHomeDir(cert.cert.src));
+                });
+
+                return list;
+            };
 
         // if sslClientCert option is set, put it at the end of the list to
         // match all URLs that didn't match in the list
@@ -120,8 +151,8 @@ module.exports = function (options, callback) {
             sslClientCertList.push({
                 name: 'client-cert',
                 matches: [sdk.UrlMatchPattern.MATCH_ALL_URLS],
-                key: { src: options.sslClientKey },
-                cert: { src: options.sslClientCert },
+                key: { src: expandHomeDir(options.sslClientKey) },
+                cert: { src: expandHomeDir(options.sslClientCert) },
                 passphrase: options.sslClientPassphrase
             });
         }
@@ -186,7 +217,8 @@ module.exports = function (options, callback) {
                 extendedRootCA: options.sslExtraCaCerts,
                 agents: _.isObject(options.requestAgents) ? options.requestAgents : undefined
             },
-            certificates: sslClientCertList.length && new sdk.CertificateList({}, sslClientCertList)
+            certificates: sslClientCertList.length && new sdk.CertificateList({},
+                resolveCertPaths(sslClientCertList))
         }, function (err, run) {
             if (err) { return callback(err); }
 

--- a/test/.fs-extra-shim.js
+++ b/test/.fs-extra-shim.js
@@ -1,0 +1,21 @@
+// Minimal fs-extra helpers used by the SSL client cert tests, without adding a dependency.
+module.exports = function () {
+    var fs = require('fs'),
+        path = require('path');
+
+    return {
+        ensureDirSync: function (dir) {
+            fs.mkdirSync(dir, { recursive: true });
+        },
+        copySync: function (src, dest) {
+            fs.copyFileSync(src, dest);
+        },
+        writeJsonSync: function (file, data) {
+            fs.mkdirSync(path.dirname(file), { recursive: true });
+            fs.writeFileSync(file, JSON.stringify(data));
+        },
+        removeSync: function (dir) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    };
+};

--- a/test/library/ssl-client-cert.test.js
+++ b/test/library/ssl-client-cert.test.js
@@ -171,6 +171,40 @@ describe('SSL Client certificates', function () {
         }, done);
     });
 
+    it('should expand tilde in client cert and key paths inside cert list', function (done) {
+        // copy the fixture certificates into a directory under the user home,
+        // so that a `~/...` path resolves to real files
+        var osHomeDir = require('os').homedir(),
+            path = require('path'),
+            fsExtra = require('../../test/.fs-extra-shim')(),
+            fixtureCertsDir = path.join(osHomeDir, '.newman-test-ssl-certs'),
+            certListPath;
+
+        fsExtra.ensureDirSync(fixtureCertsDir);
+        ['client2.key', 'client2.crt'].forEach(function (file) {
+            fsExtra.copySync(path.join('test/fixtures/ssl', file),
+                path.join(fixtureCertsDir, file));
+        });
+
+        certListPath = path.join(fixtureCertsDir, 'cert-list.json');
+        fsExtra.writeJsonSync(certListPath, [{
+            name: 'tilde-client',
+            matches: ['https://localhost:3001', 'https://localhost:3001/*'],
+            key: { src: `~/.newman-test-ssl-certs/client2.key` },
+            cert: { src: `~/.newman-test-ssl-certs/client2.crt` },
+            passphrase: 'password'
+        }]);
+
+        newman.run({
+            collection: 'test/fixtures/run/ssl-client-cert-list.json',
+            sslClientCertList: certListPath,
+            insecure: true
+        }, function (err) {
+            fsExtra.removeSync(fixtureCertsDir);
+            done(err);
+        });
+    });
+
     it('should bail if client certificate list file path is invalid', function (done) {
         newman.run({
             collection: 'test/fixtures/run/ssl-client-cert-list.json',

--- a/test/library/ssl-client-cert.test.js
+++ b/test/library/ssl-client-cert.test.js
@@ -190,8 +190,8 @@ describe('SSL Client certificates', function () {
         fsExtra.writeJsonSync(certListPath, [{
             name: 'tilde-client',
             matches: ['https://localhost:3001', 'https://localhost:3001/*'],
-            key: { src: `~/.newman-test-ssl-certs/client2.key` },
-            cert: { src: `~/.newman-test-ssl-certs/client2.crt` },
+            key: { src: '~/.newman-test-ssl-certs/client2.key' },
+            cert: { src: '~/.newman-test-ssl-certs/client2.crt' },
             passphrase: 'password'
         }]);
 


### PR DESCRIPTION
Fixes #3003

## Problem
When the SSL client certificate list file contains paths relative to the user's home directory (e.g. `~/.certs/myservice.client.crt`), Newman fails at request time with:

```
certificate "cert" load error:  ENOENT: no such file or directory, open '~/.certs/myservice.client.crt'
```

The cert `src` paths from the list (and the standalone `--ssl-client-cert` / `--ssl-client-key` options) are handed to the runtime's file resolver verbatim, which never expands a leading tilde. Only absolute or CWD-relative paths work today.

## Root cause
`lib/run/index.js` builds the `CertificateList` passed to the runtime directly from the parsed options; no path normalization happens for `key.src` / `cert.src`, and neither Node nor SecureFS expands `~`.

## Fix
Expand a leading tilde (`~/...`, `~\...` on Windows, or bare `~`) to `os.homedir()` for every certificate entry in the client cert list, as well as for the standalone `sslClientCert`/`sslClientKey` options, before constructing the runtime `CertificateList`. Absolute and relative paths are untouched.

## Testing
- Added a failing-first regression test in `test/library/ssl-client-cert.test.js`: it copies fixture certificates into a directory under `os.homedir()`, references them via `~/...` inside a cert-list file, and asserts an authenticated (200) run. Before the fix the run reports a test failure (401); after the fix it passes.
- Full library SSL suite passes locally (`test/library/ssl-client-cert.test.js`: 10 passing).