### PR TITLE
fix: accept Node.js prerelease versions

### DIFF
--- a/lib/node-version-check/index.js
+++ b/lib/node-version-check/index.js
@@ -24,7 +24,7 @@ if (!(requiredNodeVersion && currentNodeVersion)) {
 }
 
 // we check semver satisfaction and throw error on mismatch
-if (!semver.satisfies(currentNodeVersion, requiredNodeVersion)) {
+if (!semver.satisfies(currentNodeVersion, requiredNodeVersion, { includePrerelease: true })) {
     console.error([colors.red('newman:'), 'required node version', requiredNodeVersion].join(' '));
     process.exit(1);
 }

--- a/test/unit/node-version-check.test.js
+++ b/test/unit/node-version-check.test.js
@@ -1,0 +1,31 @@
+const childProcess = require('child_process'),
+    expect = require('chai').expect,
+    path = require('path'),
+
+    versionCheckPath = path.join(__dirname, '..', '..', 'lib', 'node-version-check');
+
+describe('node version check', function () {
+    const checkVersion = (version) => {
+        return childProcess.spawnSync(process.execPath, [
+            '-e',
+            'Object.defineProperty(process, "version", { value: process.argv[1] }); require(process.argv[2]);',
+            version,
+            versionCheckPath
+        ], { encoding: 'utf8' });
+    };
+
+    it('should accept a supported prerelease version', function () {
+        const result = checkVersion('v26.8.0-alpha.0.0.0');
+
+        expect(result.status).to.equal(0);
+        expect(result.stderr).to.be.empty;
+    });
+
+    it('should reject an unsupported prerelease version', function () {
+        const result = checkVersion('v15.99.0-alpha.1');
+
+        expect(result.status).to.equal(1);
+        expect(result.stderr).to.include('newman:');
+        expect(result.stderr).to.include('required node version >=16');
+    });
+});


### PR DESCRIPTION
## What

  Allow Newman to run on supported Node.js prerelease versions.

  ## Why

  Newman currently rejects prerelease versions such as
  `v26.8.0-alpha.0.0.0`, even though they satisfy its Node.js `>=16`
  runtime requirement.

  ## Root cause

  `semver.satisfies` excludes prerelease versions from ordinary range
  matching by default.

  ## Fix

  Enable the `includePrerelease` option when evaluating the configured
  Node.js engine range.

  Add regression tests confirming that:

  - A supported prerelease is accepted.
  - A prerelease below the minimum supported version is rejected.

  Stable version handling remains unchanged.

  ## Testing

  - `npx mocha test/unit/node-version-check.test.js`
  - `npm run test-unit`
  - `npm run test-lint`
  - `npm --cache /private/tmp/newman-deep-review-cache test`
  - `git diff --check origin/develop...HEAD`

  The complete test suite passed, including system, unit, integration,
  CLI, and library tests.

  ## Related issue

  Fixes #3379