### PR TITLE
feat: allow resolving Postman API resources against a self-hosted deployment

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,10 @@
+unreleased:
+  new features:
+    - >-
+      Added `--postman-api-base-url` (and the `postmanApiBaseUrl` run option /
+      `POSTMAN_API_BASE_URL` environment variable) so Postman API resources can be
+      resolved against a self-hosted Postman deployment
+
 6.2.2:
   date: 2026-01-16
   chores:

--- a/README.md
+++ b/README.md
@@ -615,6 +615,26 @@ $ newman run "https://api.getpostman.com/collections/$uid?apikey=$apiKey" \
     --environment "https://api.getpostman.com/environments/$uid?apikey=$apiKey"
 ```
 
+Alternatively, pass the resource `uid` directly and let Newman resolve it, sending the key
+as an `X-Api-Key` header rather than a query parameter:
+```console
+$ newman run $collectionUid --environment $environmentUid --postman-api-key $apiKey
+```
+
+### Self-hosted Postman deployments
+
+By default Newman resolves `uid`s against the public Postman API. To target a self-hosted
+deployment, set a base URL — via the `--postman-api-base-url` option or the
+`POSTMAN_API_BASE_URL` environment variable:
+
+```console
+$ newman run $collectionUid --postman-api-key $apiKey \
+    --postman-api-base-url https://api.postman.example.com
+```
+
+The API key is only ever sent to the public Postman API hosts or to the host configured
+this way — never to any other host named on the command line.
+
 [back to top](#table-of-contents)
 
 ## Using Newman in Docker

--- a/bin/newman.js
+++ b/bin/newman.js
@@ -38,6 +38,9 @@ program
     .option('--export-globals <path>', 'Exports the final globals to a file after completing the run')
     .option('--export-collection <path>', 'Exports the executed collection to a file after completing the run')
     .option('--postman-api-key <apiKey>', 'API Key used to load the resources from the Postman API')
+    .option('--postman-api-base-url <url>',
+        'Base URL of the Postman API, for self-hosted deployments. ' +
+        'Defaults to $POSTMAN_API_BASE_URL, then the public Postman API')
     .option('--bail [modifiers]',
         'Specify whether or not to gracefully stop a collection run on encountering an error' +
         ' and whether to end the run with an error based on the optional modifier', util.cast.csvParse)

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -22,7 +22,7 @@ module.exports.get = (overrides, options, callback) => {
     !callback && _.isFunction(options) && (callback = options, options = {});
 
     var loaders = options.loaders,
-        commonOptions = _.pick(overrides, ['postmanApiKey']);
+        commonOptions = _.pick(overrides, ['postmanApiKey', 'postmanApiBaseUrl']);
 
     async.waterfall([
         // Load RC Files.

--- a/lib/util.js
+++ b/lib/util.js
@@ -41,6 +41,52 @@ var fs = require('fs'),
     POSTMAN_API_URL = 'https://api.postman.com',
 
     /**
+     * Resolves the base URL of the Postman API.
+     *
+     * Honours an explicit override so that self-hosted Postman deployments can be
+     * targeted. Precedence: run option > `POSTMAN_API_BASE_URL` env var > public API.
+     * The environment variable name matches the one used by the Postman CLI.
+     *
+     * @param {Object=} options - Options passed to the current run.
+     * @param {String=} options.postmanApiBaseUrl - Explicit base URL of the Postman API.
+     * @returns {String} The base URL to resolve Postman API resources against, without a trailing slash.
+     */
+    resolveApiUrl = function (options) {
+        // eslint-disable-next-line no-process-env
+        var override = _.get(options, 'postmanApiBaseUrl') || process.env.POSTMAN_API_BASE_URL;
+
+        return override ? override.replace(/\/+$/, '') : POSTMAN_API_URL;
+    },
+
+    /**
+     * Determines whether the API key may be sent to the given host.
+     *
+     * True for the public Postman API hosts, and for the single host the user has
+     * explicitly configured. Deliberately not widened to arbitrary URLs: this check is
+     * what stops the API key being sent to a third-party host named on the command line.
+     *
+     * @param {String} host - Lower-cased host of the URL being fetched.
+     * @param {Object=} options - Options passed to the current run.
+     * @param {String=} options.postmanApiBaseUrl - Explicit base URL of the Postman API.
+     * @returns {Boolean} Whether the host is a trusted Postman API host.
+     */
+    isPostmanApiHost = function (host, options) {
+        if (POSTMAN_API_HOSTS[host]) { return true; }
+
+        // eslint-disable-next-line no-process-env
+        var override = _.get(options, 'postmanApiBaseUrl') || process.env.POSTMAN_API_BASE_URL;
+
+        if (!override) { return false; }
+
+        try {
+            return new Url(override).getHost().toLowerCase() === host;
+        }
+        catch (e) {
+            return false;
+        }
+    },
+
+    /**
      * Map of resource type and its equivalent API pathname.
      *
      * @type {Object}
@@ -148,6 +194,7 @@ util = {
      * @param {String} location - Can be an HTTP URL, a local file path or an UID.
      * @param {Object=} options - A set of options for JSON data loading.
      * @param {Object} options.postmanApiKey - API Key used to load the resources via UID from the Postman API.
+     * @param {String=} options.postmanApiBaseUrl - Base URL of the Postman API, for self-hosted deployments.
      * @param {Function} callback - The function whose invocation marks the end of the JSON fetch routine.
      * @returns {*}
      */
@@ -158,12 +205,12 @@ util = {
         const postmanApiKey = _.get(options, 'postmanApiKey'),
             headers = { 'User-Agent': USER_AGENT_VALUE },
             urlObj = new Url(location),
-            isPostmanHost = urlObj && POSTMAN_API_HOSTS[urlObj.getHost().toLowerCase()];
+            isPostmanHost = urlObj && isPostmanApiHost(urlObj.getHost().toLowerCase(), options);
 
         // build API URL if `location` is a valid UID and api key is provided.
         // Fetch from file in case a file with valid UID name is present.
         if (!fs.existsSync(location) && POSTMAN_API_PATH_MAP[type] && postmanApiKey && UID_REGEX.test(location)) {
-            location = `${POSTMAN_API_URL}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
+            location = `${resolveApiUrl(options)}/${POSTMAN_API_PATH_MAP[type]}/${location}`;
             headers[API_KEY_HEADER] = postmanApiKey;
         }
 

--- a/test/library/postman-api-key.test.js
+++ b/test/library/postman-api-key.test.js
@@ -50,6 +50,21 @@ describe('newman.run postmanApiKey', function () {
             .persist()
             .get('/collection.json?apikey=12345678')
             .reply(200, COLLECTION);
+
+        nock('https://api.self-hosted.example.com')
+            .persist()
+            .get(/^\/collections/)
+            .reply(200, COLLECTION);
+
+        nock('https://api.self-hosted.example.com')
+            .persist()
+            .get(/^\/environments/)
+            .reply(200, VARIABLE);
+
+        nock('https://untrusted.example.com')
+            .persist()
+            .get(/^\/collections/)
+            .reply(200, COLLECTION);
     });
 
     after(function () {
@@ -261,6 +276,187 @@ describe('newman.run postmanApiKey', function () {
 
                 done();
             });
+        });
+    });
+});
+
+describe('newman.run postmanApiBaseUrl', function () {
+    const SELF_HOSTED = 'https://api.self-hosted.example.com';
+
+    before(function () {
+        // the preceding suite calls nock.restore(), which detaches the http interceptor
+        !nock.isActive() && nock.activate();
+
+        nock('https://api.postman.com')
+            .persist()
+            .get(/^\/collections/)
+            .reply(200, COLLECTION);
+
+        nock(SELF_HOSTED)
+            .persist()
+            .get(/^\/collections/)
+            .reply(200, COLLECTION);
+
+        nock(SELF_HOSTED)
+            .persist()
+            .get(/^\/environments/)
+            .reply(200, VARIABLE);
+
+        nock('https://untrusted.example.com')
+            .persist()
+            .get(/^\/collections/)
+            .reply(200, COLLECTION);
+    });
+
+    after(function () {
+        nock.restore();
+        // eslint-disable-next-line no-process-env
+        delete process.env.POSTMAN_API_BASE_URL;
+    });
+
+    beforeEach(function () {
+        sinon.spy(request, 'get');
+        // eslint-disable-next-line no-process-env
+        delete process.env.POSTMAN_API_BASE_URL;
+    });
+
+    afterEach(function () {
+        request.get.restore();
+        // eslint-disable-next-line no-process-env
+        delete process.env.POSTMAN_API_BASE_URL;
+    });
+
+    it('should resolve a collection UID against the configured base URL', function (done) {
+        newman.run({
+            collection: '1234-588025f9-2497-46f7-b849-47f58b865807',
+            postmanApiKey: '12345678',
+            postmanApiBaseUrl: SELF_HOSTED
+        }, function (err) {
+            expect(err).to.be.null;
+
+            const requestArg = request.get.firstCall.args[0];
+
+            expect(requestArg.url)
+                .to.equal(SELF_HOSTED + '/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+            expect(requestArg.headers).to.have.property('X-Api-Key', '12345678');
+
+            done();
+        });
+    });
+
+    it('should resolve an environment UID against the configured base URL', function (done) {
+        newman.run({
+            collection: 'test/fixtures/run/single-get-request.json',
+            environment: '1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f',
+            postmanApiKey: '12345678',
+            postmanApiBaseUrl: SELF_HOSTED
+        }, function (err) {
+            expect(err).to.be.null;
+
+            const requestArg = request.get.firstCall.args[0];
+
+            expect(requestArg.url)
+                .to.equal(SELF_HOSTED + '/environments/1234-931c1484-fd1e-4ceb-81d0-2aa102ca8b5f');
+            expect(requestArg.headers).to.have.property('X-Api-Key', '12345678');
+
+            done();
+        });
+    });
+
+    it('should honour the POSTMAN_API_BASE_URL environment variable', function (done) {
+        // eslint-disable-next-line no-process-env
+        process.env.POSTMAN_API_BASE_URL = SELF_HOSTED;
+
+        newman.run({
+            collection: '1234-588025f9-2497-46f7-b849-47f58b865807',
+            postmanApiKey: '12345678'
+        }, function (err) {
+            expect(err).to.be.null;
+
+            const requestArg = request.get.firstCall.args[0];
+
+            expect(requestArg.url)
+                .to.equal(SELF_HOSTED + '/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+            expect(requestArg.headers).to.have.property('X-Api-Key', '12345678');
+
+            done();
+        });
+    });
+
+    it('should let the run option take precedence over the environment variable', function (done) {
+        // eslint-disable-next-line no-process-env
+        process.env.POSTMAN_API_BASE_URL = 'https://api.postman.com';
+
+        newman.run({
+            collection: '1234-588025f9-2497-46f7-b849-47f58b865807',
+            postmanApiKey: '12345678',
+            postmanApiBaseUrl: SELF_HOSTED
+        }, function (err) {
+            expect(err).to.be.null;
+
+            expect(request.get.firstCall.args[0].url)
+                .to.equal(SELF_HOSTED + '/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+
+            done();
+        });
+    });
+
+    it('should tolerate a trailing slash on the configured base URL', function (done) {
+        newman.run({
+            collection: '1234-588025f9-2497-46f7-b849-47f58b865807',
+            postmanApiKey: '12345678',
+            postmanApiBaseUrl: SELF_HOSTED + '/'
+        }, function (err) {
+            expect(err).to.be.null;
+
+            expect(request.get.firstCall.args[0].url)
+                .to.equal(SELF_HOSTED + '/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+
+            done();
+        });
+    });
+
+    it('should send the API key when fetching a full URL on the configured host', function (done) {
+        newman.run({
+            collection: SELF_HOSTED + '/collections/C1',
+            postmanApiKey: '12345678',
+            postmanApiBaseUrl: SELF_HOSTED
+        }, function (err) {
+            expect(err).to.be.null;
+
+            expect(request.get.firstCall.args[0].headers)
+                .to.have.property('X-Api-Key', '12345678');
+
+            done();
+        });
+    });
+
+    it('should NOT send the API key to a host that is not configured', function (done) {
+        newman.run({
+            collection: 'https://untrusted.example.com/collections/C1',
+            postmanApiKey: '12345678',
+            postmanApiBaseUrl: SELF_HOSTED
+        }, function (err) {
+            expect(err).to.be.null;
+
+            expect(request.get.firstCall.args[0].headers)
+                .to.not.have.property('X-Api-Key');
+
+            done();
+        });
+    });
+
+    it('should default to the public API when no override is set', function (done) {
+        newman.run({
+            collection: '1234-588025f9-2497-46f7-b849-47f58b865807',
+            postmanApiKey: '12345678'
+        }, function (err) {
+            expect(err).to.be.null;
+
+            expect(request.get.firstCall.args[0].url)
+                .to.equal('https://api.postman.com/collections/1234-588025f9-2497-46f7-b849-47f58b865807');
+
+            done();
         });
     });
 });


### PR DESCRIPTION
## Problem

Newman hardcodes the Postman API host in `lib/util.js`, in two separate places:

```js
POSTMAN_API_HOSTS = { 'api.postman.com': true, 'api.getpostman.com': true },
POSTMAN_API_URL   = 'https://api.postman.com',
```

This makes `--postman-api-key` unusable against a self-hosted (Postman Private Cloud) deployment, in two different ways:

| invocation | today |
|---|---|
| `newman run <uid> --postman-api-key <key>` | uid is expanded to `https://api.postman.com/...` — silently targets public SaaS |
| `newman run https://api.self-hosted…/collections/<uid> --postman-api-key <key>` | host is not on the allowlist, so `X-Api-Key` is never attached |

Both surface the same `Invalid API Key` error, and nothing indicates the flag was ignored.

The only method that works today is embedding `?apikey=` in the URL — which places the credential in argv, shell history, and every access log between the client and the server. For CI that is materially worse than a header.

## Change

A configurable base URL, resolved as:

**`postmanApiBaseUrl` run option → `POSTMAN_API_BASE_URL` env var → the public Postman API**

The environment variable name matches the one the Postman CLI already uses, so a self-hosted user configures one variable for both tools.

- `bin/newman.js` — new `--postman-api-base-url <url>` option
- `lib/util.js` — `resolveApiUrl()` and `isPostmanApiHost()` helpers; `fetchJson` uses them
- `lib/config/index.js` — thread the new key through the common-options pick
- Covers both `collections` and `environments` uid resolution (`POSTMAN_API_PATH_MAP`)

Default behaviour is unchanged when no override is set.

## Security note

The host allowlist exists to stop the API key being sent to an arbitrary host named on the command line. That property is preserved: the allowlist is widened **only** to the single host the user explicitly configured, never to any URL passed in. There is an explicit test for this:

> `should NOT send the API key to a host that is not configured`

## Usage

```console
$ newman run $collectionUid --environment $environmentUid \
    --postman-api-key $apiKey \
    --postman-api-base-url https://api.postman.example.com
```

or

```console
$ export POSTMAN_API_BASE_URL=https://api.postman.example.com
$ newman run $collectionUid --postman-api-key $apiKey
```

## Tests

8 new cases in `test/library/postman-api-key.test.js`, following the existing nock/sinon pattern: uid resolution for collections and environments, env-var support, option-over-env precedence, trailing-slash tolerance, header attached for the configured host, header **not** attached for an unrelated host, and unchanged default behaviour.

```
16 passing   (8 existing + 8 new)
```

`test-lint` clean. `test-unit` 128 passing, `test-library` 77 passing. `test-system` has one pre-existing failure (`npm publish > should not publish unnecessary files`) that also fails on a clean `develop` checkout and is unrelated to this change.

Also verified end to end against a real self-hosted deployment — bare uid via env var, bare uid via flag, and a full self-hosted URL with `--postman-api-key` all fetch and execute; with no override set the run still goes to the public API and fails as before.

## Docs

README gains a *Self-hosted Postman deployments* subsection, plus a note that the uid form sends the key as a header rather than a query parameter.